### PR TITLE
Support single backtest upload

### DIFF
--- a/app/data/models.py
+++ b/app/data/models.py
@@ -25,7 +25,7 @@ class Trade(BaseModel):
     closing_commissions_fees: float
     opening_short_long_ratio: float
     closing_short_long_ratio: Optional[float] = None
-    opening_vix: float
+    opening_vix: Optional[float] = None
     closing_vix: Optional[float] = None
     gap: Optional[float] = None
     movement: Optional[float] = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,15 @@ def sample_csv_content():
 2025-09-17,10:01:00,6631.83,"11 Sep 18 6635 C BTO 10.45 | 11 Sep 18 6675 C STO 0.70",-985,6631.96,2025-09-18,16:00:00,0,Expired,-10874.16,11,1586111.24,22660,Test Strategy 2,39.16,0,0.07,0.5,15.24,15.77,26.5,4.98,126.4,-100"""
     return csv_content
 
+@pytest.fixture
+def sample_single_backtest_csv_content():
+    """Sample CSV content for testing file upload"""
+    csv_content = """"Date Opened","Time Opened","Opening Price","Legs","Premium","Closing Price","Date Closed","Time Closed","Avg. Closing Cost","Reason For Close","P/L","No. of Contracts","Funds at Close","Margin Req.","Strategy","Opening Commissions + Fees","Closing Commissions + Fees","Opening Short/Long Ratio","Closing Short/Long Ratio","Gap","Movement","Max Profit","Max Loss"
+"2025-08-22","15:02:00",6469.83,"208 Aug 27 6410 P STO 8.70 | 208 Aug 27 6520 C STO 5.80 | 208 Aug 29 6410 P BTO 18.45 | 208 Aug 29 6520 C BTO 17.70",-2175,6462.47,"2025-08-22","15:59:00",-2095,"Backtest Completed",-19136,208,3004512,452400,"",1248,1248,0.4,0.381,14.42,85.24,1.84,-3.68
+"2025-08-15","15:02:00",6456.59,"252 Aug 20 6395 P STO 8.85 | 252 Aug 20 6505 C STO 6.80 | 252 Aug 22 6395 P BTO 17.25 | 252 Aug 22 6505 C BTO 16.30",-1800,6443.11,"2025-08-19","09:38:00",-1795,"Below Short/Long Ratio",-4284,252,3023648,453600,"",1512,1512,0.47,0.172,8.84,-20.79,14.44,-1.11
+"""
+    return csv_content
+
 
 @pytest.fixture
 def sample_portfolio(sample_csv_content):

--- a/tests/unit/test_processor.py
+++ b/tests/unit/test_processor.py
@@ -1,5 +1,6 @@
 from datetime import date, time
 
+import pandas as pd
 import pytest
 
 from app.data.models import Portfolio, Trade
@@ -25,6 +26,17 @@ def test_trade_conversion(portfolio_processor, sample_csv_content):
     assert trade.time_opened == time(10, 31, 0)
     assert trade.pl == -6850.6
     assert trade.strategy == "Test Strategy 1"
+
+
+def test_trade_conversion_single_backtest(portfolio_processor, sample_single_backtest_csv_content):
+    """Test conversion of CSV data to Trade objects"""
+    portfolio = portfolio_processor.parse_csv(sample_single_backtest_csv_content, "test.csv")
+
+    trade = portfolio.trades[0]
+    assert isinstance(trade, Trade)
+    assert trade.strategy == ""
+    assert pd.isna(trade.opening_vix) is True
+    assert pd.isna(trade.closing_vix) is True
 
 
 def test_portfolio_stats_calculation(portfolio_processor, sample_portfolio):


### PR DESCRIPTION
# TradeBlocks Pull Request

## 🧱 What's Changed

<!-- Describe your changes here -->

Main change is to support single backtest upload instead of only portfolios, so it can still leverage MC/performance metrics.

- One breaking change I did is to fail the whole upload instead of skipping individual rows, as IMO, it'll be better to have users fix those rows and try upload again instead of skipping/failing silently. WDYT?

## ✅ Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)

## 🧪 Testing

- [ ] I have tested these changes locally
- [ ] The app starts without errors
- [ ] All existing functionality still works
- [ ] New features work as expected

## 📋 Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated documentation if needed

## 🚀 Deployment Notes

<!-- Any special deployment considerations? -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

---

**Ready to build! 🧱** This PR will automatically deploy a preview on Vercel.