### PR TITLE
feat: add view mode toggle for performance charts (dollars/percent)

### DIFF
--- a/lib/services/performance-snapshot.ts
+++ b/lib/services/performance-snapshot.ts
@@ -39,7 +39,7 @@ interface SnapshotOptions {
 export interface SnapshotChartData {
   equityCurve: Array<{ date: string; equity: number; highWaterMark: number; tradeNumber: number }>
   drawdownData: Array<{ date: string; drawdownPct: number }>
-  dayOfWeekData: Array<{ day: string; count: number; avgPl: number }>
+  dayOfWeekData: Array<{ day: string; count: number; avgPl: number; avgPlPercent: number }>
   returnDistribution: number[]
   streakData: {
     winDistribution: Record<number, number>
@@ -52,7 +52,8 @@ export interface SnapshotChartData {
     }
   }
   monthlyReturns: Record<number, Record<number, number>>
-  tradeSequence: Array<{ tradeNumber: number; pl: number; date: string }>
+  monthlyReturnsPercent: Record<number, Record<number, number>>
+  tradeSequence: Array<{ tradeNumber: number; pl: number; rom: number; date: string }>
   romTimeline: Array<{ date: string; rom: number }>
   rollingMetrics: Array<{ date: string; winRate: number; sharpeRatio: number; profitFactor: number; volatility: number }>
   volatilityRegimes: Array<{ date: string; openingVix?: number; closingVix?: number; pl: number; rom?: number }>
@@ -160,10 +161,12 @@ export async function processChartData(
   const streakData = calculateStreakData(trades)
 
   const monthlyReturns = calculateMonthlyReturns(trades)
+  const monthlyReturnsPercent = calculateMonthlyReturnsPercent(trades, dailyLogs)
 
   const tradeSequence = trades.map((trade, index) => ({
     tradeNumber: index + 1,
     pl: trade.pl,
+    rom: trade.marginReq && trade.marginReq > 0 ? (trade.pl / trade.marginReq) * 100 : 0,
     date: new Date(trade.dateOpened).toISOString()
   }))
 
@@ -194,6 +197,7 @@ export async function processChartData(
     returnDistribution,
     streakData,
     monthlyReturns,
+    monthlyReturnsPercent,
     tradeSequence,
     romTimeline,
     rollingMetrics,
@@ -413,7 +417,12 @@ function calculateEquityCurveFromTrades(trades: Trade[]) {
 
 function calculateDayOfWeekData(trades: Trade[]) {
   const dayNames = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
-  const dayData: Record<string, { count: number; totalPl: number }> = {}
+  const dayData: Record<string, {
+    count: number
+    totalPl: number
+    totalPlPercent: number
+    percentSampleCount: number
+  }> = {}
 
   trades.forEach(trade => {
     const tradeDate = trade.dateOpened instanceof Date ? trade.dateOpened : new Date(trade.dateOpened)
@@ -423,16 +432,23 @@ function calculateDayOfWeekData(trades: Trade[]) {
     const day = dayNames[pythonWeekday]
 
     if (!dayData[day]) {
-      dayData[day] = { count: 0, totalPl: 0 }
+      dayData[day] = { count: 0, totalPl: 0, totalPlPercent: 0, percentSampleCount: 0 }
     }
     dayData[day].count++
     dayData[day].totalPl += trade.pl
+
+    // Calculate percentage return (ROM) if margin is available
+    if (trade.marginReq && trade.marginReq > 0) {
+      dayData[day].totalPlPercent += (trade.pl / trade.marginReq) * 100
+      dayData[day].percentSampleCount++
+    }
   })
 
   return Object.entries(dayData).map(([day, data]) => ({
     day,
     count: data.count,
-    avgPl: data.count > 0 ? data.totalPl / data.count : 0
+    avgPl: data.count > 0 ? data.totalPl / data.count : 0,
+    avgPlPercent: data.percentSampleCount > 0 ? data.totalPlPercent / data.percentSampleCount : 0
   }))
 }
 
@@ -524,6 +540,192 @@ function calculateMonthlyReturns(trades: Trade[]) {
   })
 
   return monthlyReturns
+}
+
+function calculateMonthlyReturnsPercent(
+  trades: Trade[],
+  dailyLogs?: DailyLogEntry[]
+): Record<number, Record<number, number>> {
+  // If daily logs are available, use them for accurate balance tracking
+  if (dailyLogs && dailyLogs.length > 0) {
+    return calculateMonthlyReturnsPercentFromDailyLogs(trades, dailyLogs)
+  }
+
+  // Fallback to trade-based calculation
+  return calculateMonthlyReturnsPercentFromTrades(trades)
+}
+
+function calculateMonthlyReturnsPercentFromDailyLogs(
+  trades: Trade[],
+  dailyLogs: DailyLogEntry[]
+): Record<number, Record<number, number>> {
+  const sortedLogs = [...dailyLogs].sort((a, b) =>
+    new Date(a.date).getTime() - new Date(b.date).getTime()
+  )
+
+  if (sortedLogs.length === 0) {
+    return {}
+  }
+
+  // Pre-compute trade-based percents for fallback months without balance data
+  const tradeBasedPercents = calculateMonthlyReturnsPercentFromTrades(trades)
+
+  // Group trades by month to get P&L per month
+  const monthlyPL: Record<string, number> = {}
+  trades.forEach(trade => {
+    const date = new Date(trade.dateOpened)
+    const year = date.getUTCFullYear()
+    const month = date.getUTCMonth() + 1
+    const monthKey = `${year}-${String(month).padStart(2, '0')}`
+    monthlyPL[monthKey] = (monthlyPL[monthKey] || 0) + trade.pl
+  })
+
+  // Get starting balance for each month from daily logs
+  const monthlyBalances: Record<string, { startBalance: number; endBalance: number }> = {}
+
+  sortedLogs.forEach((log, index) => {
+    const date = new Date(log.date)
+    const year = date.getUTCFullYear()
+    const month = date.getUTCMonth() + 1
+    const monthKey = `${year}-${String(month).padStart(2, '0')}`
+
+    const balance = getEquityValueFromDailyLog(log)
+
+    if (!monthlyBalances[monthKey]) {
+      monthlyBalances[monthKey] = { startBalance: balance, endBalance: balance }
+    } else {
+      monthlyBalances[monthKey].endBalance = balance
+    }
+  })
+
+  // Calculate percentage returns
+  const monthlyReturnsPercent: Record<number, Record<number, number>> = {}
+  const years = new Set<number>()
+
+  Object.keys(monthlyPL).forEach(monthKey => {
+    const [yearStr, monthStr] = monthKey.split('-')
+    const year = parseInt(yearStr, 10)
+    const month = parseInt(monthStr, 10)
+    years.add(year)
+
+    if (!monthlyReturnsPercent[year]) {
+      monthlyReturnsPercent[year] = {}
+    }
+
+    const pl = monthlyPL[monthKey] || 0
+    const balanceData = monthlyBalances[monthKey]
+
+    if (balanceData && balanceData.startBalance > 0) {
+      // Calculate percentage: (monthPL / startingBalance) * 100
+      monthlyReturnsPercent[year][month] = (pl / balanceData.startBalance) * 100
+    } else {
+      const fallbackPercent = tradeBasedPercents[year]?.[month]
+      monthlyReturnsPercent[year][month] = typeof fallbackPercent === 'number' ? fallbackPercent : 0
+    }
+  })
+
+  // Fill in zeros for months without data
+  Array.from(years).sort().forEach(year => {
+    if (!monthlyReturnsPercent[year]) {
+      monthlyReturnsPercent[year] = {}
+    }
+    for (let month = 1; month <= 12; month++) {
+      if (monthlyReturnsPercent[year][month] === undefined) {
+        monthlyReturnsPercent[year][month] = 0
+      }
+    }
+  })
+
+  return monthlyReturnsPercent
+}
+
+function calculateMonthlyReturnsPercentFromTrades(
+  trades: Trade[]
+): Record<number, Record<number, number>> {
+  if (trades.length === 0) {
+    return {}
+  }
+
+  // Sort trades by date
+  const sortedTrades = [...trades].sort((a, b) =>
+    new Date(a.dateOpened).getTime() - new Date(b.dateOpened).getTime()
+  )
+
+  // Calculate initial capital
+  let runningCapital = PortfolioStatsCalculator.calculateInitialCapital(sortedTrades)
+  if (!isFinite(runningCapital) || runningCapital <= 0) {
+    runningCapital = 100000
+  }
+
+  // Group trades by month
+  const monthlyData: Record<string, { pl: number; startingCapital: number }> = {}
+  const years = new Set<number>()
+
+  sortedTrades.forEach(trade => {
+    const date = new Date(trade.dateOpened)
+    const year = date.getUTCFullYear()
+    const month = date.getUTCMonth() + 1
+    const monthKey = `${year}-${String(month).padStart(2, '0')}`
+
+    years.add(year)
+
+    if (!monthlyData[monthKey]) {
+      monthlyData[monthKey] = {
+        pl: 0,
+        startingCapital: runningCapital
+      }
+    }
+
+    monthlyData[monthKey].pl += trade.pl
+  })
+
+  // Calculate percentage returns and update running capital
+  const monthlyReturnsPercent: Record<number, Record<number, number>> = {}
+  const sortedMonthKeys = Object.keys(monthlyData).sort()
+
+  sortedMonthKeys.forEach(monthKey => {
+    const [yearStr, monthStr] = monthKey.split('-')
+    const year = parseInt(yearStr, 10)
+    const month = parseInt(monthStr, 10)
+
+    if (!monthlyReturnsPercent[year]) {
+      monthlyReturnsPercent[year] = {}
+    }
+
+    const { pl, startingCapital } = monthlyData[monthKey]
+
+    if (startingCapital > 0) {
+      monthlyReturnsPercent[year][month] = (pl / startingCapital) * 100
+    } else {
+      monthlyReturnsPercent[year][month] = 0
+    }
+
+    // Update capital for next month (compounding)
+    runningCapital = startingCapital + pl
+
+    // Update startingCapital for any remaining trades in future months
+    const currentMonthIndex = sortedMonthKeys.indexOf(monthKey)
+    if (currentMonthIndex < sortedMonthKeys.length - 1) {
+      const nextMonthKey = sortedMonthKeys[currentMonthIndex + 1]
+      if (monthlyData[nextMonthKey]) {
+        monthlyData[nextMonthKey].startingCapital = runningCapital
+      }
+    }
+  })
+
+  // Fill in zeros for months without data
+  Array.from(years).sort().forEach(year => {
+    if (!monthlyReturnsPercent[year]) {
+      monthlyReturnsPercent[year] = {}
+    }
+    for (let month = 1; month <= 12; month++) {
+      if (monthlyReturnsPercent[year][month] === undefined) {
+        monthlyReturnsPercent[year][month] = 0
+      }
+    }
+  })
+
+  return monthlyReturnsPercent
 }
 
 function calculateRollingMetrics(trades: Trade[]) {

--- a/tests/unit/day-of-week-data.test.ts
+++ b/tests/unit/day-of-week-data.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from '@jest/globals'
+import { processChartData } from '@/lib/services/performance-snapshot'
+import { Trade } from '@/lib/models/trade'
+
+describe('Day of Week data', () => {
+  it('averages percent returns using only trades with margin', async () => {
+    const trades: Trade[] = [
+      {
+        dateOpened: new Date('2024-07-01T09:30:00Z'), // Monday
+        timeOpened: '09:30:00',
+        openingPrice: 100,
+        legs: 'Call',
+        premium: 1,
+        pl: 500,
+        numContracts: 1,
+        fundsAtClose: 100500,
+        marginReq: 5000,
+        strategy: 'Test',
+        openingCommissionsFees: 5,
+        closingCommissionsFees: 5,
+        openingShortLongRatio: 1,
+        dateClosed: new Date('2024-07-02T09:30:00Z')
+      },
+      {
+        dateOpened: new Date('2024-07-08T09:30:00Z'), // Monday
+        timeOpened: '09:30:00',
+        openingPrice: 100,
+        legs: 'Put',
+        premium: 1,
+        pl: -200,
+        numContracts: 1,
+        fundsAtClose: 99800,
+        marginReq: 0, // No margin -> should not influence percent avg
+        strategy: 'Test',
+        openingCommissionsFees: 5,
+        closingCommissionsFees: 5,
+        openingShortLongRatio: 1,
+        dateClosed: new Date('2024-07-09T09:30:00Z')
+      }
+    ]
+
+    const snapshot = await processChartData(trades)
+    const monday = snapshot.dayOfWeekData.find(day => day.day === 'Monday')
+
+    expect(monday).toBeDefined()
+    expect(monday?.count).toBe(2)
+    expect(monday?.avgPl).toBeCloseTo((500 - 200) / 2, 5)
+    expect(monday?.avgPlPercent).toBeCloseTo(10, 5)
+  })
+})

--- a/tests/unit/monthly-returns-percent.test.ts
+++ b/tests/unit/monthly-returns-percent.test.ts
@@ -1,0 +1,392 @@
+import { describe, it, expect } from '@jest/globals'
+import { processChartData } from '@/lib/services/performance-snapshot'
+import { Trade } from '@/lib/models/trade'
+import { DailyLogEntry } from '@/lib/models/daily-log'
+
+describe('Monthly Returns Percentage Calculation', () => {
+  it('calculates monthly returns percentage from trades with compounding', async () => {
+    // Create trades across multiple months
+    const trades: Trade[] = [
+      {
+        dateOpened: new Date('2024-01-15'),
+        timeOpened: '09:30:00',
+        openingPrice: 100,
+        legs: 'Trade 1',
+        pl: 5000, // +5% on 100k
+        numContracts: 1,
+        fundsAtClose: 105000,
+        marginReq: 20000,
+        strategy: 'Test',
+        openingCommissionsFees: 10,
+        closingCommissionsFees: 10,
+        openingShortLongRatio: 0.5,
+        dateClosed: new Date('2024-01-20')
+      },
+      {
+        dateOpened: new Date('2024-02-15'),
+        timeOpened: '09:30:00',
+        openingPrice: 100,
+        legs: 'Trade 2',
+        pl: 10500, // +10% on 105k
+        numContracts: 1,
+        fundsAtClose: 115500,
+        marginReq: 20000,
+        strategy: 'Test',
+        openingCommissionsFees: 10,
+        closingCommissionsFees: 10,
+        openingShortLongRatio: 0.5,
+        dateClosed: new Date('2024-02-20')
+      },
+      {
+        dateOpened: new Date('2024-03-15'),
+        timeOpened: '09:30:00',
+        openingPrice: 100,
+        legs: 'Trade 3',
+        pl: -5775, // -5% on 115.5k
+        numContracts: 1,
+        fundsAtClose: 109725,
+        marginReq: 20000,
+        strategy: 'Test',
+        openingCommissionsFees: 10,
+        closingCommissionsFees: 10,
+        openingShortLongRatio: 0.5,
+        dateClosed: new Date('2024-03-20')
+      }
+    ]
+
+    const result = await processChartData(trades)
+
+    expect(result.monthlyReturnsPercent).toBeDefined()
+    expect(result.monthlyReturnsPercent[2024]).toBeDefined()
+
+    // January: +5000 / 100000 = +5%
+    expect(result.monthlyReturnsPercent[2024][1]).toBeCloseTo(5.0, 1)
+
+    // February: +10500 / 105000 = +10%
+    expect(result.monthlyReturnsPercent[2024][2]).toBeCloseTo(10.0, 1)
+
+    // March: -5775 / 115500 = -5%
+    expect(result.monthlyReturnsPercent[2024][3]).toBeCloseTo(-5.0, 1)
+
+    // Other months should be zero
+    expect(result.monthlyReturnsPercent[2024][4]).toBe(0)
+    expect(result.monthlyReturnsPercent[2024][12]).toBe(0)
+  })
+
+  it('calculates monthly returns percentage from daily logs', async () => {
+    const trades: Trade[] = [
+      {
+        dateOpened: new Date('2024-01-15'),
+        timeOpened: '09:30:00',
+        openingPrice: 100,
+        legs: 'Trade 1',
+        pl: 5000,
+        numContracts: 1,
+        fundsAtClose: 105000,
+        marginReq: 20000,
+        strategy: 'Test',
+        openingCommissionsFees: 10,
+        closingCommissionsFees: 10,
+        openingShortLongRatio: 0.5,
+        dateClosed: new Date('2024-01-20')
+      },
+      {
+        dateOpened: new Date('2024-02-15'),
+        timeOpened: '09:30:00',
+        openingPrice: 100,
+        legs: 'Trade 2',
+        pl: 10000,
+        numContracts: 1,
+        fundsAtClose: 115000,
+        marginReq: 20000,
+        strategy: 'Test',
+        openingCommissionsFees: 10,
+        closingCommissionsFees: 10,
+        openingShortLongRatio: 0.5,
+        dateClosed: new Date('2024-02-20')
+      }
+    ]
+
+    const dailyLogs: DailyLogEntry[] = [
+      {
+        date: new Date('2024-01-01'),
+        netLiquidity: 100000,
+        currentFunds: 100000,
+        tradingFunds: 100000,
+        drawdownPct: 0
+      },
+      {
+        date: new Date('2024-01-31'),
+        netLiquidity: 105000,
+        currentFunds: 105000,
+        tradingFunds: 105000,
+        drawdownPct: 0
+      },
+      {
+        date: new Date('2024-02-01'),
+        netLiquidity: 105000,
+        currentFunds: 105000,
+        tradingFunds: 105000,
+        drawdownPct: 0
+      },
+      {
+        date: new Date('2024-02-29'),
+        netLiquidity: 115000,
+        currentFunds: 115000,
+        tradingFunds: 115000,
+        drawdownPct: 0
+      }
+    ]
+
+    const result = await processChartData(trades, dailyLogs)
+
+    expect(result.monthlyReturnsPercent).toBeDefined()
+    expect(result.monthlyReturnsPercent[2024]).toBeDefined()
+
+    // January: +5000 / 100000 (from daily log) = +5%
+    expect(result.monthlyReturnsPercent[2024][1]).toBeCloseTo(5.0, 1)
+
+    // February: +10000 / 105000 (from daily log) = +9.52%
+    expect(result.monthlyReturnsPercent[2024][2]).toBeCloseTo(9.52, 1)
+  })
+
+  it('falls back to trade-based percentages when monthly balances are missing', async () => {
+    const trades: Trade[] = [
+      {
+        dateOpened: new Date('2024-01-10'),
+        timeOpened: '09:30:00',
+        openingPrice: 100,
+        legs: 'Trade 1',
+        pl: 5000,
+        numContracts: 1,
+        fundsAtClose: 105000,
+        marginReq: 20000,
+        strategy: 'Test',
+        openingCommissionsFees: 10,
+        closingCommissionsFees: 10,
+        openingShortLongRatio: 0.5,
+        dateClosed: new Date('2024-01-15')
+      },
+      {
+        dateOpened: new Date('2024-02-12'),
+        timeOpened: '09:30:00',
+        openingPrice: 100,
+        legs: 'Trade 2',
+        pl: 10000,
+        numContracts: 1,
+        fundsAtClose: 115000,
+        marginReq: 20000,
+        strategy: 'Test',
+        openingCommissionsFees: 10,
+        closingCommissionsFees: 10,
+        openingShortLongRatio: 0.5,
+        dateClosed: new Date('2024-02-20')
+      }
+    ]
+
+    // Daily logs only cover January so February should fall back to trade-derived data
+    const dailyLogs: DailyLogEntry[] = [
+      {
+        date: new Date('2024-01-01'),
+        netLiquidity: 100000,
+        currentFunds: 100000,
+        tradingFunds: 100000,
+        drawdownPct: 0
+      },
+      {
+        date: new Date('2024-01-31'),
+        netLiquidity: 105000,
+        currentFunds: 105000,
+        tradingFunds: 105000,
+        drawdownPct: 0
+      }
+    ]
+
+    const result = await processChartData(trades, dailyLogs)
+
+    expect(result.monthlyReturnsPercent[2024]).toBeDefined()
+    expect(result.monthlyReturnsPercent[2024][1]).toBeCloseTo(5.0, 1)
+    expect(result.monthlyReturnsPercent[2024][2]).toBeCloseTo(9.52, 1)
+  })
+
+  it('handles empty trades gracefully', async () => {
+    const result = await processChartData([])
+
+    expect(result.monthlyReturnsPercent).toBeDefined()
+    expect(Object.keys(result.monthlyReturnsPercent)).toHaveLength(0)
+  })
+
+  it('handles single month of trades', async () => {
+    const trades: Trade[] = [
+      {
+        dateOpened: new Date('2024-01-15'),
+        timeOpened: '09:30:00',
+        openingPrice: 100,
+        legs: 'Trade 1',
+        pl: 2000,
+        numContracts: 1,
+        fundsAtClose: 102000,
+        marginReq: 20000,
+        strategy: 'Test',
+        openingCommissionsFees: 10,
+        closingCommissionsFees: 10,
+        openingShortLongRatio: 0.5,
+        dateClosed: new Date('2024-01-20')
+      }
+    ]
+
+    const result = await processChartData(trades)
+
+    expect(result.monthlyReturnsPercent).toBeDefined()
+    expect(result.monthlyReturnsPercent[2024]).toBeDefined()
+    expect(result.monthlyReturnsPercent[2024][1]).toBeCloseTo(2.0, 1)
+
+    // Other months should be zero
+    for (let month = 2; month <= 12; month++) {
+      expect(result.monthlyReturnsPercent[2024][month]).toBe(0)
+    }
+  })
+
+  it('handles negative returns correctly', async () => {
+    const trades: Trade[] = [
+      {
+        dateOpened: new Date('2024-01-15'),
+        timeOpened: '09:30:00',
+        openingPrice: 100,
+        legs: 'Trade 1',
+        pl: -3000,
+        numContracts: 1,
+        fundsAtClose: 97000,
+        marginReq: 20000,
+        strategy: 'Test',
+        openingCommissionsFees: 10,
+        closingCommissionsFees: 10,
+        openingShortLongRatio: 0.5,
+        dateClosed: new Date('2024-01-20')
+      }
+    ]
+
+    const result = await processChartData(trades)
+
+    expect(result.monthlyReturnsPercent).toBeDefined()
+    // -3000 / 100000 = -3%
+    expect(result.monthlyReturnsPercent[2024][1]).toBeCloseTo(-3.0, 1)
+  })
+
+  it('maintains consistency between dollar and percent returns', async () => {
+    const trades: Trade[] = [
+      {
+        dateOpened: new Date('2024-01-15'),
+        timeOpened: '09:30:00',
+        openingPrice: 100,
+        legs: 'Trade 1',
+        pl: 5000,
+        numContracts: 1,
+        fundsAtClose: 105000,
+        marginReq: 20000,
+        strategy: 'Test',
+        openingCommissionsFees: 10,
+        closingCommissionsFees: 10,
+        openingShortLongRatio: 0.5,
+        dateClosed: new Date('2024-01-20')
+      }
+    ]
+
+    const result = await processChartData(trades)
+
+    // Dollar amount should match
+    expect(result.monthlyReturns[2024][1]).toBe(5000)
+
+    // Percentage should be 5% (5000 / 100000)
+    expect(result.monthlyReturnsPercent[2024][1]).toBeCloseTo(5.0, 1)
+  })
+
+  it('handles multiple trades in same month', async () => {
+    const trades: Trade[] = [
+      {
+        dateOpened: new Date('2024-01-05'),
+        timeOpened: '09:30:00',
+        openingPrice: 100,
+        legs: 'Trade 1',
+        pl: 2000,
+        numContracts: 1,
+        fundsAtClose: 102000,
+        marginReq: 20000,
+        strategy: 'Test',
+        openingCommissionsFees: 10,
+        closingCommissionsFees: 10,
+        openingShortLongRatio: 0.5,
+        dateClosed: new Date('2024-01-10')
+      },
+      {
+        dateOpened: new Date('2024-01-15'),
+        timeOpened: '09:30:00',
+        openingPrice: 100,
+        legs: 'Trade 2',
+        pl: 3000,
+        numContracts: 1,
+        fundsAtClose: 105000,
+        marginReq: 20000,
+        strategy: 'Test',
+        openingCommissionsFees: 10,
+        closingCommissionsFees: 10,
+        openingShortLongRatio: 0.5,
+        dateClosed: new Date('2024-01-20')
+      }
+    ]
+
+    const result = await processChartData(trades)
+
+    // Total dollar return: 5000
+    expect(result.monthlyReturns[2024][1]).toBe(5000)
+
+    // Percentage: 5000 / 100000 = 5%
+    expect(result.monthlyReturnsPercent[2024][1]).toBeCloseTo(5.0, 1)
+  })
+
+  it('handles trades spanning multiple years', async () => {
+    const trades: Trade[] = [
+      {
+        dateOpened: new Date('2023-12-15'),
+        timeOpened: '09:30:00',
+        openingPrice: 100,
+        legs: 'Trade 1',
+        pl: 2000,
+        numContracts: 1,
+        fundsAtClose: 102000,
+        marginReq: 20000,
+        strategy: 'Test',
+        openingCommissionsFees: 10,
+        closingCommissionsFees: 10,
+        openingShortLongRatio: 0.5,
+        dateClosed: new Date('2023-12-20')
+      },
+      {
+        dateOpened: new Date('2024-01-15'),
+        timeOpened: '09:30:00',
+        openingPrice: 100,
+        legs: 'Trade 2',
+        pl: 3060,
+        numContracts: 1,
+        fundsAtClose: 105060,
+        marginReq: 20000,
+        strategy: 'Test',
+        openingCommissionsFees: 10,
+        closingCommissionsFees: 10,
+        openingShortLongRatio: 0.5,
+        dateClosed: new Date('2024-01-20')
+      }
+    ]
+
+    const result = await processChartData(trades)
+
+    expect(result.monthlyReturnsPercent[2023]).toBeDefined()
+    expect(result.monthlyReturnsPercent[2024]).toBeDefined()
+
+    // Dec 2023: 2000 / 100000 = 2%
+    expect(result.monthlyReturnsPercent[2023][12]).toBeCloseTo(2.0, 1)
+
+    // Jan 2024: 3060 / 102000 = 3% (compounded from previous month)
+    expect(result.monthlyReturnsPercent[2024][1]).toBeCloseTo(3.0, 1)
+  })
+})


### PR DESCRIPTION
- Implemented view mode toggle in DayOfWeekChart, MonthlyReturnsChart, and TradeSequenceChart components to switch between dollar and percentage views.
- Updated chart data processing to calculate average P/L and monthly returns in both dollars and percentages.
- Enhanced SnapshotChartData interface to include avgPlPercent for day of week data and monthlyReturnsPercent for monthly returns.
- Added unit tests for day of week and monthly returns percentage calculations to ensure accuracy and consistency.

# TradeBlocks Pull Request

## 🧱 What's Changed

<!-- Describe your changes here -->

## ✅ Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)

## 🧪 Testing

- [ ] I have tested these changes locally
- [ ] The app starts without errors
- [ ] All existing functionality still works
- [ ] New features work as expected

## 📋 Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have updated documentation if needed

## 🚀 Deployment Notes

<!-- Any special deployment considerations? -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

---

**Ready to build! 🧱** This PR will automatically deploy a preview on Vercel.