### PR TITLE
feat: Time-aware daily exposure tracking with Report Builder integration

### DIFF
--- a/app/(platform)/block-stats/page.tsx
+++ b/app/(platform)/block-stats/page.tsx
@@ -76,7 +76,7 @@ export default function BlockStatsPage() {
   >({});
   const [, setIsCalculating] = useState(false);
   const [filteredTrades, setFilteredTrades] = useState<Trade[]>([]);
-  const [peakDailyExposure, setPeakDailyExposure] = useState<{
+  const [peakDailyExposurePercent, setPeakDailyExposurePercent] = useState<{
     date: string;
     exposure: number;
     exposurePercent: number;
@@ -133,7 +133,7 @@ export default function BlockStatsPage() {
       setFilteredTrades([]);
       setPortfolioStats(null);
       setStrategyStats({});
-      setPeakDailyExposure(null);
+      setPeakDailyExposurePercent(null);
       setDataError(null);
       return;
     }
@@ -145,7 +145,7 @@ export default function BlockStatsPage() {
       setFilteredTrades([]);
       setPortfolioStats(null);
       setStrategyStats({});
-      setPeakDailyExposure(null);
+      setPeakDailyExposurePercent(null);
       setIsLoadingData(true);
       setDataError(null);
 
@@ -170,7 +170,7 @@ export default function BlockStatsPage() {
             setDailyLogs(cachedSnapshot.filteredDailyLogs);
             setFilteredTrades(cachedSnapshot.filteredTrades);
             setPortfolioStats(cachedSnapshot.portfolioStats);
-            setPeakDailyExposure(cachedSnapshot.chartData.peakDailyExposure);
+            setPeakDailyExposurePercent(cachedSnapshot.chartData.peakDailyExposurePercent);
 
             // Calculate strategy stats from cached trades
             const calculator = new PortfolioStatsCalculator();
@@ -210,7 +210,7 @@ export default function BlockStatsPage() {
       setPortfolioStats(null);
       setStrategyStats({});
       setFilteredTrades([]);
-      setPeakDailyExposure(null);
+      setPeakDailyExposurePercent(null);
       return;
     }
 
@@ -241,7 +241,7 @@ export default function BlockStatsPage() {
 
         setFilteredTrades(snapshot.filteredTrades);
         setPortfolioStats(snapshot.portfolioStats);
-        setPeakDailyExposure(snapshot.chartData.peakDailyExposure);
+        setPeakDailyExposurePercent(snapshot.chartData.peakDailyExposurePercent);
 
         const calculator = new PortfolioStatsCalculator();
         const strategies = calculator.calculateStrategyStats(
@@ -942,9 +942,9 @@ export default function BlockStatsPage() {
         />
         <MetricCard
           title="Peak Exposure"
-          value={peakDailyExposure?.exposurePercent || 0}
+          value={peakDailyExposurePercent?.exposurePercent || 0}
           format="percentage"
-          subtitle={peakDailyExposure ? `$${peakDailyExposure.exposure.toLocaleString('en-US', { maximumFractionDigits: 0 })}` : undefined}
+          subtitle={peakDailyExposurePercent ? `$${peakDailyExposurePercent.exposure.toLocaleString('en-US', { maximumFractionDigits: 0 })}` : undefined}
           tooltip={{
             flavor:
               "Maximum daily risk - the most capital at risk on any single day.",

--- a/components/performance-charts/performance-metrics.tsx
+++ b/components/performance-charts/performance-metrics.tsx
@@ -90,7 +90,7 @@ export function PerformanceMetrics({ className }: PerformanceMetricsProps) {
     )
   }
 
-  const { portfolioStats, trades, peakDailyExposure } = data
+  const { portfolioStats, trades, peakDailyExposurePercent } = data
 
   // Calculate additional metrics
   const dateRange = trades.length > 0 ? {
@@ -201,16 +201,16 @@ export function PerformanceMetrics({ className }: PerformanceMetricsProps) {
               <Shield className="h-3 w-3" />
               Peak Exposure
             </div>
-            {peakDailyExposure ? (
+            {peakDailyExposurePercent ? (
               <div className="font-semibold text-amber-600 dark:text-amber-400">
                 {new Intl.NumberFormat('en-US', {
                   style: 'currency',
                   currency: 'USD',
                   minimumFractionDigits: 0,
                   maximumFractionDigits: 0
-                }).format(peakDailyExposure.exposure)}
+                }).format(peakDailyExposurePercent.exposure)}
                 <span className="text-xs ml-1">
-                  ({peakDailyExposure.exposurePercent.toFixed(1)}%)
+                  ({peakDailyExposurePercent.exposurePercent.toFixed(1)}%)
                 </span>
               </div>
             ) : (

--- a/lib/calculations/daily-exposure.ts
+++ b/lib/calculations/daily-exposure.ts
@@ -235,6 +235,7 @@ export function calculateDailyExposure(
     let runningPositions = carryOverPositions
     let dayPeakExposure = runningExposure
     let dayPeakPositions = runningPositions
+    // Default to midnight (00:00) for days with only carry-over exposure and no events
     let dayPeakTimeMinutes = 0
 
     for (const event of dayEvents) {
@@ -407,8 +408,8 @@ export function calculateExposureAtTradeOpen(
     return result
   }
 
-  // Sort events by timestamp, with opens before closes at same time
-  // This ensures we see the state before adding the new trade
+  // Sort events by timestamp, with closes before opens at same time
+  // This ensures when we process an open, all prior closes have been applied
   events.sort((a, b) => {
     if (a.timestamp !== b.timestamp) {
       return a.timestamp - b.timestamp

--- a/lib/models/enriched-trade.ts
+++ b/lib/models/enriched-trade.ts
@@ -50,9 +50,9 @@ export interface EnrichedTrade extends Trade {
   // Sequential
   tradeNumber?: number          // 1-indexed trade sequence
 
-  // Portfolio exposure on trade date
-  exposureOnOpen?: number       // Daily portfolio exposure % when this trade was opened
-  exposureOnOpenDollars?: number // Daily portfolio exposure $ when this trade was opened
+  // Portfolio exposure at exact moment trade opened
+  exposureOnOpen?: number       // Portfolio exposure % at the exact moment this trade was opened
+  exposureOnOpenDollars?: number // Portfolio exposure $ at the exact moment this trade was opened
 
   // Custom fields from trade CSV (inherited from Trade.customFields)
   // customFields?: Record<string, number | string> - already inherited from Trade

--- a/lib/models/enriched-trade.ts
+++ b/lib/models/enriched-trade.ts
@@ -50,6 +50,10 @@ export interface EnrichedTrade extends Trade {
   // Sequential
   tradeNumber?: number          // 1-indexed trade sequence
 
+  // Portfolio exposure on trade date
+  exposureOnOpen?: number       // Daily portfolio exposure % when this trade was opened
+  exposureOnOpenDollars?: number // Daily portfolio exposure $ when this trade was opened
+
   // Custom fields from trade CSV (inherited from Trade.customFields)
   // customFields?: Record<string, number | string> - already inherited from Trade
 

--- a/lib/models/report-config.ts
+++ b/lib/models/report-config.ts
@@ -278,8 +278,8 @@ export const REPORT_FIELDS: FieldInfo[] = [
   { field: 'weekOfYear', label: 'Week of Year', category: 'timing', description: 'ISO week number when opened (1-52)' },
 
   // Portfolio context
-  { field: 'exposureOnOpen', label: 'Portfolio Exposure %', category: 'risk', unit: '%', description: 'Total portfolio margin exposure as % of equity on the day this trade opened - shows how much risk was deployed when entering' },
-  { field: 'exposureOnOpenDollars', label: 'Portfolio Exposure $', category: 'risk', unit: '$', description: 'Total portfolio margin exposure in dollars on the day this trade opened' }
+  { field: 'exposureOnOpen', label: 'Portfolio Exposure %', category: 'risk', unit: '%', description: 'Peak portfolio margin exposure as % of equity on the day this trade opened - shows the maximum risk deployed during that trading day' },
+  { field: 'exposureOnOpenDollars', label: 'Portfolio Exposure $', category: 'risk', unit: '$', description: 'Peak portfolio margin exposure in dollars on the day this trade opened - shows the maximum risk deployed during that trading day' }
 ]
 
 /**

--- a/lib/models/report-config.ts
+++ b/lib/models/report-config.ts
@@ -278,8 +278,8 @@ export const REPORT_FIELDS: FieldInfo[] = [
   { field: 'weekOfYear', label: 'Week of Year', category: 'timing', description: 'ISO week number when opened (1-52)' },
 
   // Portfolio context
-  { field: 'exposureOnOpen', label: 'Portfolio Exposure %', category: 'risk', unit: '%', description: 'Peak portfolio margin exposure as % of equity on the day this trade opened - shows the maximum risk deployed during that trading day' },
-  { field: 'exposureOnOpenDollars', label: 'Portfolio Exposure $', category: 'risk', unit: '$', description: 'Peak portfolio margin exposure in dollars on the day this trade opened - shows the maximum risk deployed during that trading day' }
+  { field: 'exposureOnOpen', label: 'Portfolio Exposure %', category: 'risk', unit: '%', description: 'Portfolio margin exposure as % of equity at the exact moment this trade opened - shows how much risk was deployed when entering' },
+  { field: 'exposureOnOpenDollars', label: 'Portfolio Exposure $', category: 'risk', unit: '$', description: 'Portfolio margin exposure in dollars at the exact moment this trade opened - shows total margin at risk when entering' }
 ]
 
 /**

--- a/lib/models/report-config.ts
+++ b/lib/models/report-config.ts
@@ -179,6 +179,9 @@ export type ReportField =
   | 'isWinner'
   // Derived: Sequential
   | 'tradeNumber'
+  // Derived: Portfolio context
+  | 'exposureOnOpen'
+  | 'exposureOnOpenDollars'
 
 /**
  * Field category for organizing fields in UI
@@ -272,7 +275,11 @@ export const REPORT_FIELDS: FieldInfo[] = [
   { field: 'timeOfDayMinutes', label: 'Time of Day', category: 'timing', description: 'Exact time when opened as minutes since midnight (e.g., 11:45 = 705). Useful for scatter plots to analyze floating-time or multiple-entry trades' },
   { field: 'dayOfMonth', label: 'Day of Month', category: 'timing', description: 'Day of month when opened (1-31)' },
   { field: 'monthOfYear', label: 'Month of Year', category: 'timing', description: 'Month when opened (1=January through 12=December)' },
-  { field: 'weekOfYear', label: 'Week of Year', category: 'timing', description: 'ISO week number when opened (1-52)' }
+  { field: 'weekOfYear', label: 'Week of Year', category: 'timing', description: 'ISO week number when opened (1-52)' },
+
+  // Portfolio context
+  { field: 'exposureOnOpen', label: 'Portfolio Exposure %', category: 'risk', unit: '%', description: 'Total portfolio margin exposure as % of equity on the day this trade opened - shows how much risk was deployed when entering' },
+  { field: 'exposureOnOpenDollars', label: 'Portfolio Exposure $', category: 'risk', unit: '$', description: 'Total portfolio margin exposure in dollars on the day this trade opened' }
 ]
 
 /**

--- a/lib/stores/performance-store.ts
+++ b/lib/stores/performance-store.ts
@@ -213,12 +213,15 @@ export const usePerformanceStore = create<PerformanceStore>((set, get) => ({
 
           // Try to get cached enriched trades, fall back to computing them
           // Note: Static datasets aren't cached - always compute fresh to pick up new datasets
+          // Also recompute if we have daily exposure data (for exposureOnOpen field)
           let enrichedTradesData = await getEnrichedTradesCache(blockId)
-          if (!enrichedTradesData || staticDatasetsWithRows.length > 0) {
-            // Cache miss or static datasets present - compute enriched trades
+          const hasDailyExposure = cachedSnapshot.chartData.dailyExposure && cachedSnapshot.chartData.dailyExposure.length > 0
+          if (!enrichedTradesData || staticDatasetsWithRows.length > 0 || hasDailyExposure) {
+            // Cache miss, static datasets present, or daily exposure available - compute enriched trades
             enrichedTradesData = enrichTrades(cachedSnapshot.filteredTrades, {
               dailyLogs: cachedSnapshot.filteredDailyLogs,
-              staticDatasets: staticDatasetsWithRows
+              staticDatasets: staticDatasetsWithRows,
+              dailyExposure: cachedSnapshot.chartData.dailyExposure
             })
           }
 
@@ -264,7 +267,8 @@ export const usePerformanceStore = create<PerformanceStore>((set, get) => ({
       // Compute enriched trades for filtered result (smaller set = faster)
       const enrichedTradesData = enrichTrades(snapshot.filteredTrades, {
         dailyLogs: snapshot.filteredDailyLogs,
-        staticDatasets: staticDatasetsWithRows
+        staticDatasets: staticDatasetsWithRows,
+        dailyExposure: snapshot.chartData.dailyExposure
       })
 
       set({
@@ -318,7 +322,8 @@ export const usePerformanceStore = create<PerformanceStore>((set, get) => ({
     // Compute enriched trades for the filtered result
     const enrichedTradesData = enrichTrades(snapshot.filteredTrades, {
       dailyLogs: snapshot.filteredDailyLogs,
-      staticDatasets: staticDatasetsWithRows
+      staticDatasets: staticDatasetsWithRows,
+      dailyExposure: snapshot.chartData.dailyExposure
     })
 
     set(state => ({

--- a/lib/stores/performance-store.ts
+++ b/lib/stores/performance-store.ts
@@ -213,15 +213,15 @@ export const usePerformanceStore = create<PerformanceStore>((set, get) => ({
 
           // Try to get cached enriched trades, fall back to computing them
           // Note: Static datasets aren't cached - always compute fresh to pick up new datasets
-          // Also recompute if we have daily exposure data (for exposureOnOpen field)
+          // Also recompute if we have equity curve data (for exposureOnOpen field)
           let enrichedTradesData = await getEnrichedTradesCache(blockId)
-          const hasDailyExposure = cachedSnapshot.chartData.dailyExposure && cachedSnapshot.chartData.dailyExposure.length > 0
-          if (!enrichedTradesData || staticDatasetsWithRows.length > 0 || hasDailyExposure) {
-            // Cache miss, static datasets present, or daily exposure available - compute enriched trades
+          const hasEquityCurve = cachedSnapshot.chartData.equityCurve && cachedSnapshot.chartData.equityCurve.length > 0
+          if (!enrichedTradesData || staticDatasetsWithRows.length > 0 || hasEquityCurve) {
+            // Cache miss, static datasets present, or equity curve available - compute enriched trades
             enrichedTradesData = enrichTrades(cachedSnapshot.filteredTrades, {
               dailyLogs: cachedSnapshot.filteredDailyLogs,
               staticDatasets: staticDatasetsWithRows,
-              dailyExposure: cachedSnapshot.chartData.dailyExposure
+              equityCurve: cachedSnapshot.chartData.equityCurve
             })
           }
 
@@ -268,7 +268,7 @@ export const usePerformanceStore = create<PerformanceStore>((set, get) => ({
       const enrichedTradesData = enrichTrades(snapshot.filteredTrades, {
         dailyLogs: snapshot.filteredDailyLogs,
         staticDatasets: staticDatasetsWithRows,
-        dailyExposure: snapshot.chartData.dailyExposure
+        equityCurve: snapshot.chartData.equityCurve
       })
 
       set({
@@ -323,7 +323,7 @@ export const usePerformanceStore = create<PerformanceStore>((set, get) => ({
     const enrichedTradesData = enrichTrades(snapshot.filteredTrades, {
       dailyLogs: snapshot.filteredDailyLogs,
       staticDatasets: staticDatasetsWithRows,
-      dailyExposure: snapshot.chartData.dailyExposure
+      equityCurve: snapshot.chartData.equityCurve
     })
 
     set(state => ({

--- a/lib/stores/settings-store.ts
+++ b/lib/stores/settings-store.ts
@@ -269,6 +269,33 @@ const BUILT_IN_SAVED_REPORTS: ReportConfig[] = [
     createdAt: '2024-01-01T00:00:00.000Z',
     updatedAt: '2024-01-01T00:00:00.000Z'
   },
+  {
+    id: 'builtin-exposure-vs-pl',
+    name: 'Exposure vs P/L %',
+    filter: { conditions: [], logic: 'and' },
+    chartType: 'scatter',
+    xAxis: { field: 'exposureOnOpen', label: 'Portfolio Exposure %' },
+    yAxis: { field: 'plPct', label: 'P/L %' },
+    colorBy: { field: 'rom', label: 'ROM %' },
+    category: 'risk',
+    isBuiltIn: true,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z'
+  },
+  {
+    id: 'builtin-exposure-breakdown',
+    name: 'Exposure Level Breakdown',
+    filter: { conditions: [], logic: 'and' },
+    chartType: 'table',
+    xAxis: { field: 'exposureOnOpen', label: 'Portfolio Exposure %' },
+    yAxis: { field: 'plPct', label: '' },
+    tableBuckets: [10, 20, 30, 40],
+    tableColumns: ['count', 'winRate', 'plPct:avg', 'rom:avg'],
+    category: 'risk',
+    isBuiltIn: true,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z'
+  },
 
   // Table Reports (grouped with Market Analysis)
   {

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "private": true,
   "workspaces": [

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks-mcp",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "MCP server for options trade analysis - works with Claude Desktop/Cowork",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "type": "module",

--- a/tests/unit/daily-exposure.test.ts
+++ b/tests/unit/daily-exposure.test.ts
@@ -1,9 +1,10 @@
 /**
- * Unit tests for daily exposure calculation using sweep-line algorithm.
+ * Unit tests for daily exposure calculation using time-aware sweep-line algorithm.
  *
  * Tests verify:
  * - Basic exposure calculation with single and multiple trades
  * - Overlapping positions (concurrent margin accumulation)
+ * - Time-aware intraday tracking (sequential vs concurrent trades)
  * - Percentage exposure calculation with equity curve
  * - Peak exposure tracking (by dollars and percentage)
  * - Edge cases (empty input, no margin, invalid dates, open positions)
@@ -71,14 +72,16 @@ describe('calculateDailyExposure', () => {
       const trades = [
         createTrade({
           dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
           dateClosed: etDate('2024-01-03'),
+          timeClosed: '15:00:00',
           marginReq: 1000,
         }),
       ]
 
       const result = calculateDailyExposure(trades, [])
 
-      // Should have exposure for 01-01, 01-02, 01-03 (close day still open)
+      // Should have exposure for 01-01, 01-02, 01-03
       expect(result.dailyExposure.length).toBe(3)
 
       // All days should show $1000 exposure, 1 position
@@ -92,12 +95,16 @@ describe('calculateDailyExposure', () => {
       const trades = [
         createTrade({
           dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
           dateClosed: etDate('2024-01-03'),
+          timeClosed: '10:00:00',
           marginReq: 1000,
         }),
         createTrade({
           dateOpened: etDate('2024-01-02'),
+          timeOpened: '09:30:00',
           dateClosed: etDate('2024-01-04'),
+          timeClosed: '15:00:00',
           marginReq: 2000,
         }),
       ]
@@ -116,12 +123,12 @@ describe('calculateDailyExposure', () => {
       expect(exposureByDate.get('2024-01-02')?.exposure).toBe(3000)
       expect(exposureByDate.get('2024-01-02')?.openPositions).toBe(2)
 
-      // 01-03: Trade 1 closes at end, Trade 2 still open (1000 + 2000 = 3000)
-      // Note: close day still shows position as open
+      // 01-03: Trade 1 closes at 10:00, Trade 2 still open
+      // Peak is at 09:30 when Trade 2 opens (both open: 3000)
       expect(exposureByDate.get('2024-01-03')?.exposure).toBe(3000)
       expect(exposureByDate.get('2024-01-03')?.openPositions).toBe(2)
 
-      // 01-04: Trade 1 closed (removed day after), Trade 2 closes at end (2000)
+      // 01-04: Only Trade 2 open (2000)
       expect(exposureByDate.get('2024-01-04')?.exposure).toBe(2000)
       expect(exposureByDate.get('2024-01-04')?.openPositions).toBe(1)
     })
@@ -130,7 +137,9 @@ describe('calculateDailyExposure', () => {
       const trades = [
         createTrade({
           dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
           dateClosed: etDate('2024-01-01'),
+          timeClosed: '15:00:00',
           marginReq: 1000,
         }),
       ]
@@ -145,12 +154,200 @@ describe('calculateDailyExposure', () => {
     })
   })
 
+  describe('time-aware intraday tracking', () => {
+    it('should show peak of 1x margin for sequential same-day trades', () => {
+      // 7 sequential trades that don't overlap - like klask's example
+      // Each opens after the previous one closes
+      const trades = [
+        createTrade({
+          dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
+          dateClosed: etDate('2024-01-01'),
+          timeClosed: '10:00:00',
+          marginReq: 1000,
+        }),
+        createTrade({
+          dateOpened: etDate('2024-01-01'),
+          timeOpened: '10:30:00',
+          dateClosed: etDate('2024-01-01'),
+          timeClosed: '11:00:00',
+          marginReq: 1000,
+        }),
+        createTrade({
+          dateOpened: etDate('2024-01-01'),
+          timeOpened: '11:30:00',
+          dateClosed: etDate('2024-01-01'),
+          timeClosed: '12:00:00',
+          marginReq: 1000,
+        }),
+        createTrade({
+          dateOpened: etDate('2024-01-01'),
+          timeOpened: '12:30:00',
+          dateClosed: etDate('2024-01-01'),
+          timeClosed: '13:00:00',
+          marginReq: 1000,
+        }),
+        createTrade({
+          dateOpened: etDate('2024-01-01'),
+          timeOpened: '13:30:00',
+          dateClosed: etDate('2024-01-01'),
+          timeClosed: '14:00:00',
+          marginReq: 1000,
+        }),
+        createTrade({
+          dateOpened: etDate('2024-01-01'),
+          timeOpened: '14:30:00',
+          dateClosed: etDate('2024-01-01'),
+          timeClosed: '15:00:00',
+          marginReq: 1000,
+        }),
+        createTrade({
+          dateOpened: etDate('2024-01-01'),
+          timeOpened: '15:30:00',
+          dateClosed: etDate('2024-01-01'),
+          timeClosed: '16:00:00',
+          marginReq: 1000,
+        }),
+      ]
+
+      const result = calculateDailyExposure(trades, [])
+
+      // Should only have 1 day
+      expect(result.dailyExposure.length).toBe(1)
+
+      // Peak should be 1000, not 7000 (only one trade open at any time)
+      expect(result.dailyExposure[0].exposure).toBe(1000)
+      expect(result.dailyExposure[0].openPositions).toBe(1)
+    })
+
+    it('should accumulate margin for truly concurrent intraday trades', () => {
+      // Two trades that overlap in time
+      const trades = [
+        createTrade({
+          dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
+          dateClosed: etDate('2024-01-01'),
+          timeClosed: '12:00:00',
+          marginReq: 1000,
+        }),
+        createTrade({
+          dateOpened: etDate('2024-01-01'),
+          timeOpened: '10:00:00',
+          dateClosed: etDate('2024-01-01'),
+          timeClosed: '11:00:00',
+          marginReq: 2000,
+        }),
+      ]
+
+      const result = calculateDailyExposure(trades, [])
+
+      // Peak should be 3000 (both trades open from 10:00-11:00)
+      expect(result.dailyExposure[0].exposure).toBe(3000)
+      expect(result.dailyExposure[0].openPositions).toBe(2)
+    })
+
+    it('should track peak time correctly', () => {
+      const trades = [
+        createTrade({
+          dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
+          dateClosed: etDate('2024-01-01'),
+          timeClosed: '15:00:00',
+          marginReq: 1000,
+        }),
+        createTrade({
+          dateOpened: etDate('2024-01-01'),
+          timeOpened: '11:00:00',
+          dateClosed: etDate('2024-01-01'),
+          timeClosed: '13:00:00',
+          marginReq: 2000,
+        }),
+      ]
+
+      const result = calculateDailyExposure(trades, [])
+
+      // Peak occurs at 11:00 when second trade opens
+      expect(result.dailyExposure[0].peakTime).toBe('11:00:00')
+      expect(result.dailyExposure[0].exposure).toBe(3000)
+    })
+
+    it('should handle trades opening and closing at exact same time', () => {
+      // Trade 1 closes at 10:00, Trade 2 opens at 10:00
+      const trades = [
+        createTrade({
+          dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:00:00',
+          dateClosed: etDate('2024-01-01'),
+          timeClosed: '10:00:00',
+          marginReq: 1000,
+        }),
+        createTrade({
+          dateOpened: etDate('2024-01-01'),
+          timeOpened: '10:00:00',
+          dateClosed: etDate('2024-01-01'),
+          timeClosed: '11:00:00',
+          marginReq: 2000,
+        }),
+      ]
+
+      const result = calculateDailyExposure(trades, [])
+
+      // At 10:00, opens happen before closes, so momentarily both are open
+      // Peak should be 3000
+      expect(result.dailyExposure[0].exposure).toBe(3000)
+      expect(result.dailyExposure[0].openPositions).toBe(2)
+    })
+
+    it('should handle mixed sequential and concurrent trades', () => {
+      const trades = [
+        // Morning: sequential trades
+        createTrade({
+          dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
+          dateClosed: etDate('2024-01-01'),
+          timeClosed: '10:00:00',
+          marginReq: 1000,
+        }),
+        createTrade({
+          dateOpened: etDate('2024-01-01'),
+          timeOpened: '10:30:00',
+          dateClosed: etDate('2024-01-01'),
+          timeClosed: '11:00:00',
+          marginReq: 1000,
+        }),
+        // Afternoon: concurrent trades
+        createTrade({
+          dateOpened: etDate('2024-01-01'),
+          timeOpened: '13:00:00',
+          dateClosed: etDate('2024-01-01'),
+          timeClosed: '15:00:00',
+          marginReq: 1500,
+        }),
+        createTrade({
+          dateOpened: etDate('2024-01-01'),
+          timeOpened: '14:00:00',
+          dateClosed: etDate('2024-01-01'),
+          timeClosed: '15:30:00',
+          marginReq: 2000,
+        }),
+      ]
+
+      const result = calculateDailyExposure(trades, [])
+
+      // Peak is when afternoon trades overlap: 1500 + 2000 = 3500
+      expect(result.dailyExposure[0].exposure).toBe(3500)
+      expect(result.dailyExposure[0].openPositions).toBe(2)
+    })
+  })
+
   describe('percentage exposure calculation', () => {
     it('should calculate exposurePercent using equity curve', () => {
       const trades = [
         createTrade({
           dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
           dateClosed: etDate('2024-01-02'),
+          timeClosed: '15:00:00',
           marginReq: 1000,
         }),
       ]
@@ -177,7 +374,9 @@ describe('calculateDailyExposure', () => {
       const trades = [
         createTrade({
           dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
           dateClosed: etDate('2024-01-05'),
+          timeClosed: '15:00:00',
           marginReq: 1000,
         }),
       ]
@@ -210,7 +409,9 @@ describe('calculateDailyExposure', () => {
       const trades = [
         createTrade({
           dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
           dateClosed: etDate('2024-01-02'),
+          timeClosed: '15:00:00',
           marginReq: 1000,
         }),
       ]
@@ -229,12 +430,16 @@ describe('calculateDailyExposure', () => {
       const trades = [
         createTrade({
           dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
           dateClosed: etDate('2024-01-05'),
+          timeClosed: '15:00:00',
           marginReq: 1000,
         }),
         createTrade({
           dateOpened: etDate('2024-01-02'),
+          timeOpened: '09:30:00',
           dateClosed: etDate('2024-01-03'),
+          timeClosed: '15:00:00',
           marginReq: 2000,
         }),
       ]
@@ -253,7 +458,9 @@ describe('calculateDailyExposure', () => {
       const trades = [
         createTrade({
           dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
           dateClosed: etDate('2024-01-03'),
+          timeClosed: '15:00:00',
           marginReq: 1000,
         }),
       ]
@@ -277,12 +484,16 @@ describe('calculateDailyExposure', () => {
       const trades = [
         createTrade({
           dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
           dateClosed: etDate('2024-01-02'),
+          timeClosed: '15:00:00',
           marginReq: 5000,
         }),
         createTrade({
           dateOpened: etDate('2024-01-03'),
+          timeOpened: '09:30:00',
           dateClosed: etDate('2024-01-04'),
+          timeClosed: '15:00:00',
           marginReq: 2000,
         }),
       ]
@@ -311,7 +522,9 @@ describe('calculateDailyExposure', () => {
         createTrade({ marginReq: -100 }),
         createTrade({
           dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
           dateClosed: etDate('2024-01-02'),
+          timeClosed: '15:00:00',
           marginReq: 1000,
         }),
       ]
@@ -331,7 +544,9 @@ describe('calculateDailyExposure', () => {
         createTrade({ dateOpened: new Date('invalid'), marginReq: 1000 }),
         createTrade({
           dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
           dateClosed: etDate('2024-01-02'),
+          timeClosed: '15:00:00',
           marginReq: 1000,
         }),
       ]
@@ -345,7 +560,9 @@ describe('calculateDailyExposure', () => {
       const trades = [
         createTrade({
           dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
           dateClosed: undefined,
+          timeClosed: undefined,
           marginReq: 1000,
         }),
       ]
@@ -364,6 +581,7 @@ describe('calculateDailyExposure', () => {
       const trades = [
         createTrade({
           dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
           dateClosed: new Date('invalid'),
           marginReq: 1000,
         }),
@@ -382,7 +600,9 @@ describe('calculateDailyExposure', () => {
         createTrade({ marginReq: -Infinity }),
         createTrade({
           dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
           dateClosed: etDate('2024-01-02'),
+          timeClosed: '15:00:00',
           marginReq: 1000,
         }),
       ]
@@ -405,6 +625,58 @@ describe('calculateDailyExposure', () => {
       expect(result.peakDailyExposure).toBeNull()
       expect(result.peakDailyExposurePercent).toBeNull()
     })
+
+    it('should default to end of day when timeClosed is missing', () => {
+      const trades = [
+        createTrade({
+          dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
+          dateClosed: etDate('2024-01-01'),
+          timeClosed: undefined, // Missing close time
+          marginReq: 1000,
+        }),
+        createTrade({
+          dateOpened: etDate('2024-01-01'),
+          timeOpened: '14:00:00',
+          dateClosed: etDate('2024-01-01'),
+          timeClosed: '15:00:00',
+          marginReq: 2000,
+        }),
+      ]
+
+      const result = calculateDailyExposure(trades, [])
+
+      // Trade 1 has no close time, defaults to 23:59
+      // Trade 2 closes at 15:00
+      // They overlap from 14:00-15:00, peak = 3000
+      expect(result.dailyExposure[0].exposure).toBe(3000)
+    })
+
+    it('should default to start of day when timeOpened is missing', () => {
+      const trades = [
+        createTrade({
+          dateOpened: etDate('2024-01-01'),
+          timeOpened: '', // Missing open time - defaults to 00:00
+          dateClosed: etDate('2024-01-01'),
+          timeClosed: '10:00:00',
+          marginReq: 1000,
+        }),
+        createTrade({
+          dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:00:00',
+          dateClosed: etDate('2024-01-01'),
+          timeClosed: '11:00:00',
+          marginReq: 2000,
+        }),
+      ]
+
+      const result = calculateDailyExposure(trades, [])
+
+      // Trade 1 opens at 00:00 (default), closes at 10:00
+      // Trade 2 opens at 09:00, closes at 11:00
+      // They overlap from 09:00-10:00, peak = 3000
+      expect(result.dailyExposure[0].exposure).toBe(3000)
+    })
   })
 
   describe('sweep-line algorithm correctness', () => {
@@ -412,17 +684,23 @@ describe('calculateDailyExposure', () => {
       const trades = [
         createTrade({
           dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
           dateClosed: etDate('2024-01-03'),
+          timeClosed: '15:00:00',
           marginReq: 1000,
         }),
         createTrade({
           dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
           dateClosed: etDate('2024-01-03'),
+          timeClosed: '15:00:00',
           marginReq: 500,
         }),
         createTrade({
           dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
           dateClosed: etDate('2024-01-02'),
+          timeClosed: '15:00:00',
           marginReq: 200,
         }),
       ]
@@ -432,15 +710,16 @@ describe('calculateDailyExposure', () => {
       const exposureByDate = new Map<string, DailyExposurePoint>()
       result.dailyExposure.forEach(p => exposureByDate.set(dateKey(p.date), p))
 
-      // 01-01: All three trades open (1000 + 500 + 200 = 1700)
+      // 01-01: All three trades open at same time (1000 + 500 + 200 = 1700)
       expect(exposureByDate.get('2024-01-01')?.exposure).toBe(1700)
       expect(exposureByDate.get('2024-01-01')?.openPositions).toBe(3)
 
-      // 01-02: Trade 3 closes at end of day, still counted (1000 + 500 + 200 = 1700)
+      // 01-02: All three still open at start of day, trade 3 closes at 15:00
+      // Peak is at start of day: 1700
       expect(exposureByDate.get('2024-01-02')?.exposure).toBe(1700)
       expect(exposureByDate.get('2024-01-02')?.openPositions).toBe(3)
 
-      // 01-03: Trade 3 removed (day after close), trades 1 & 2 close at end (1000 + 500 = 1500)
+      // 01-03: Trades 1 & 2 still open (1000 + 500 = 1500)
       expect(exposureByDate.get('2024-01-03')?.exposure).toBe(1500)
       expect(exposureByDate.get('2024-01-03')?.openPositions).toBe(2)
     })
@@ -449,17 +728,23 @@ describe('calculateDailyExposure', () => {
       const trades = [
         createTrade({
           dateOpened: etDate('2024-01-05'),
+          timeOpened: '09:30:00',
           dateClosed: etDate('2024-01-06'),
+          timeClosed: '15:00:00',
           marginReq: 1000,
         }),
         createTrade({
           dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
           dateClosed: etDate('2024-01-02'),
+          timeClosed: '15:00:00',
           marginReq: 500,
         }),
         createTrade({
           dateOpened: etDate('2024-01-03'),
+          timeOpened: '09:30:00',
           dateClosed: etDate('2024-01-04'),
+          timeClosed: '15:00:00',
           marginReq: 200,
         }),
       ]
@@ -474,12 +759,14 @@ describe('calculateDailyExposure', () => {
       }
     })
 
-    it('should fill gaps between event dates', () => {
+    it('should fill gaps between event dates for multi-day positions', () => {
       // Trade that spans many days with no other events
       const trades = [
         createTrade({
           dateOpened: etDate('2024-01-01'),
+          timeOpened: '09:30:00',
           dateClosed: etDate('2024-01-10'),
+          timeClosed: '15:00:00',
           marginReq: 1000,
         }),
       ]
@@ -497,43 +784,42 @@ describe('calculateDailyExposure', () => {
     })
   })
 
-  describe('regression tests', () => {
-    it('should count close day as having open position', () => {
-      // This is an important semantic: on the day a trade closes,
-      // it should still be counted as having an open position for exposure purposes
+  describe('carry-over between days', () => {
+    it('should carry open positions from previous day', () => {
+      // Trade opens day 1, another opens day 2, first closes day 3
       const trades = [
         createTrade({
           dateOpened: etDate('2024-01-01'),
-          dateClosed: etDate('2024-01-02'),
+          timeOpened: '09:30:00',
+          dateClosed: etDate('2024-01-03'),
+          timeClosed: '10:00:00',
           marginReq: 1000,
+        }),
+        createTrade({
+          dateOpened: etDate('2024-01-02'),
+          timeOpened: '14:00:00',
+          dateClosed: etDate('2024-01-04'),
+          timeClosed: '15:00:00',
+          marginReq: 2000,
         }),
       ]
 
       const result = calculateDailyExposure(trades, [])
-
       const exposureByDate = new Map<string, DailyExposurePoint>()
       result.dailyExposure.forEach(p => exposureByDate.set(dateKey(p.date), p))
 
-      // Both open day and close day should show position
-      expect(exposureByDate.get('2024-01-01')?.openPositions).toBe(1)
-      expect(exposureByDate.get('2024-01-02')?.openPositions).toBe(1)
-    })
+      // 01-01: Only trade 1 (1000)
+      expect(exposureByDate.get('2024-01-01')?.exposure).toBe(1000)
 
-    it('should not include day after close in exposure', () => {
-      const trades = [
-        createTrade({
-          dateOpened: etDate('2024-01-01'),
-          dateClosed: etDate('2024-01-02'),
-          marginReq: 1000,
-        }),
-      ]
+      // 01-02: Trade 1 carried over + trade 2 opens (3000)
+      expect(exposureByDate.get('2024-01-02')?.exposure).toBe(3000)
 
-      const result = calculateDailyExposure(trades, [])
+      // 01-03: Both carried over, trade 1 closes at 10:00
+      // Peak is at start of day (before any events): 3000
+      expect(exposureByDate.get('2024-01-03')?.exposure).toBe(3000)
 
-      const dates = result.dailyExposure.map(p => dateKey(p.date))
-
-      // Should NOT include 01-03 (day after close)
-      expect(dates).not.toContain('2024-01-03')
+      // 01-04: Only trade 2 (2000)
+      expect(exposureByDate.get('2024-01-04')?.exposure).toBe(2000)
     })
   })
 })


### PR DESCRIPTION
## Summary

- **Time-aware daily exposure calculation**: Updated `calculateDailyExposure` to track concurrent positions using `timeOpened`/`timeClosed` instead of summing all trades on a calendar day. 7 sequential trades now correctly shows 1× margin instead of 7×.
- **Fixed peak exposure metric**: Block stats card now uses `peakDailyExposurePercent` to show maximum portfolio exposure %, matching the chart's % mode.
- **Report Builder integration**: Added `exposureOnOpen` and `exposureOnOpenDollars` fields to enriched trades, allowing users to filter and analyze trades by portfolio exposure level when opened.
- **Built-in reports**: Added "Exposure vs P/L %" scatter plot and "Exposure Level Breakdown" table with buckets at 10%, 20%, 30%, 40%.

## Test plan

- [x] Run `npm test -- tests/unit/daily-exposure.test.ts` - 27 tests pass
- [x] Run `npm run build` - Production build succeeds
- [x] Load a block with intraday trading activity and verify exposure chart shows peak concurrent margin
- [x] Verify block stats card shows peak exposure % matching chart % mode
- [x] Open Report Builder and verify `exposureOnOpen` field is available
- [x] Load built-in "Exposure vs P/L %" and "Exposure Level Breakdown" reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)