### PR TITLE
v2.4 Backtest Optimization Tools

### DIFF
--- a/.planning/MILESTONES.md
+++ b/.planning/MILESTONES.md
@@ -1,5 +1,57 @@
 # Project Milestones: TradeBlocks
 
+## v2.4 Backtest Optimization Tools (Shipped: 2026-01-19)
+
+**Delivered:** MCP tools for data-driven filter optimization: find_predictive_fields for correlation analysis and filter_curve for threshold sweeping with sweet spot detection.
+
+**Phases completed:** 32-34 (3 plans total)
+
+**Key accomplishments:**
+
+- `find_predictive_fields` MCP tool ranking all numeric fields by Pearson correlation with P/L
+- `filter_curve` MCP tool with bidirectional threshold sweeping (lt/gt/both modes) and auto-generated percentile thresholds
+- Sweet spot detection with combined improvement scoring (winRateDelta * avgPlDelta)
+- Fixed CLI --call mode to apply Zod schema parsing, eliminating runtime default workarounds
+
+**Stats:**
+
+- 10 files modified
+- +1,565 / -21 lines of TypeScript
+- 3 phases, 3 plans
+- 1 day (2026-01-19)
+
+**Git range:** `1868a0f` → `4047d50`
+
+**What's next:** Planning next milestone
+
+---
+
+## v2.3 Workspace Packages (Shipped: 2026-01-19)
+
+**Delivered:** Converted lib/ to @tradeblocks/lib workspace package for clean imports across the monorepo.
+
+**Phases completed:** 29-31 (4 plans total)
+
+**Key accomplishments:**
+
+- @tradeblocks/lib workspace package with barrel exports (81 files)
+- MCP server imports from workspace package (bundler moduleResolution)
+- Next.js app imports migrated (127+ files)
+- Test imports migrated with Jest moduleNameMapper (62 files)
+- Removed legacy @/lib/* path alias
+
+**Stats:**
+
+- 189+ files modified
+- 3 phases, 4 plans
+- ~7 hours execution time
+
+**Git range:** See [v2.3 archive](milestones/v2.3-workspace-packages.md)
+
+**What's next:** v2.4 Backtest Optimization Tools ✓
+
+---
+
 ## v2.2 Historical Risk-Free Rates (Shipped: 2026-01-18)
 
 **Delivered:** Historical Treasury rates (2013-2026) embedded for accurate Sharpe/Sortino calculations that reflect actual market conditions, replacing fixed 2% assumption.

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -50,6 +50,12 @@ Make trading analytics accessible and understandable. Complex analysis should be
 - ✓ Test imports migrated with Jest moduleNameMapper (62 files) — v2.3
 - ✓ Removed legacy @/lib/* path alias — v2.3
 
+**v2.4 Backtest Optimization Tools:**
+- ✓ find_predictive_fields tool for Pearson correlation analysis of all numeric fields vs P/L — v2.4
+- ✓ filter_curve tool with bidirectional threshold sweeping (lt/gt/both modes) — v2.4
+- ✓ Sweet spot detection with combined improvement scoring (winRateDelta * avgPlDelta) — v2.4
+- ✓ CLI --call mode fixed to apply Zod schema parsing for proper defaults — v2.4
+
 ### Active
 
 (None — planning next milestone)
@@ -62,14 +68,15 @@ Make trading analytics accessible and understandable. Complex analysis should be
 
 ## Context
 
-**Current state (v2.3):**
+**Current state (v2.4):**
 - Next.js 15 web application with client-side computation
-- MCP server (`tradeblocks-mcp`) with 26 tools at packages/mcp-server/
+- MCP server (`tradeblocks-mcp`) with 28 tools at packages/mcp-server/
 - 6 agent skills at packages/agent-skills/
 - Shared library at packages/lib/ (81 files, barrel exports)
-- ~16,600 LOC in packages/, ~12,500 LOC in WFA-related files
+- ~18,200 LOC in packages/, ~12,500 LOC in WFA-related files
 - 1024 tests (65 test suites)
 - Embedded historical Treasury rates (2013-2026) for accurate risk metrics
+- Backtest optimization tools for data-driven filter development
 
 **Architecture:**
 - Monorepo with npm workspaces
@@ -105,6 +112,9 @@ Make trading analytics accessible and understandable. Complex analysis should be
 | Direct TS source consumption for workspace packages | No build step needed, all consumers handle compilation | ✓ Good |
 | Bundler moduleResolution for MCP server | Enables workspace package resolution without .js extensions | ✓ Good |
 | Stores excluded from main lib export | Avoids browser/Node dependency conflicts | ✓ Good |
+| Pearson correlation for field predictiveness | Simple, interpretable, identifies linear relationships | ✓ Good |
+| Sweet spot criteria (winRateDelta > 0, avgPlDelta > 0, ≥20% trades) | Ensures actionable filters that improve both metrics | ✓ Good |
+| Fix CLI handler instead of per-tool workarounds | Single fix ensures all tools work correctly | ✓ Good |
 
 ---
-*Last updated: 2026-01-19 after v2.3 milestone*
+*Last updated: 2026-01-19 after v2.4 milestone*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -7,6 +7,7 @@
 - ✅ [v2.1 Portfolio Comparison](milestones/v2.1-portfolio-comparison.md) (Phases 17-24) — SHIPPED 2026-01-18
 - ✅ [v2.2 Historical Risk-Free Rates](milestones/v2.2-historical-risk-free-rates.md) (Phases 25-28) — SHIPPED 2026-01-18
 - ✅ [v2.3 Workspace Packages](milestones/v2.3-workspace-packages.md) (Phases 29-31) — SHIPPED 2026-01-19
+- 🚧 **v2.4 Backtest Optimization Tools** — Phases 32-34 (in progress)
 
 ## Completed Milestones
 
@@ -102,9 +103,39 @@ See [v1.0 archive](milestones/v1.0-wfa-enhancement.md) for full details.
 
 </details>
 
-### Planning Next Milestone
+### 🚧 v2.4 Backtest Optimization Tools (In Progress)
 
-No active milestone. Ready to plan next features.
+**Milestone Goal:** Add MCP tools that help users identify which entry conditions predict trade success, enabling data-driven filter optimization for backtests.
+
+#### Phase 32: find-predictive-fields
+
+**Goal**: Tool that scans all numeric fields, calculates correlation with P/L, and returns ranked list of predictive factors
+**Depends on**: Previous milestone complete
+**Research**: Unlikely (internal patterns, builds on existing field infrastructure)
+**Plans**: TBD
+
+Plans:
+- [ ] 32-01: TBD (run /gsd:plan-phase 32 to break down)
+
+#### Phase 33: filter-curve
+
+**Goal**: Tool that sweeps thresholds for a field with bidirectional analysis (lt/gt/both modes), returns full outcome curve, and surfaces sweet spots
+**Depends on**: Phase 32
+**Research**: Unlikely (builds on existing query infrastructure)
+**Plans**: TBD
+
+Plans:
+- [ ] 33-01: TBD
+
+#### Phase 34: report-tools-fixes
+
+**Goal**: Fix `aggregate_by_field` bug and any related issues discovered during exploration
+**Depends on**: Phase 33
+**Research**: Unlikely (bug fixes)
+**Plans**: TBD
+
+Plans:
+- [ ] 34-01: TBD
 
 ## Progress
 
@@ -115,6 +146,7 @@ No active milestone. Ready to plan next features.
 | v2.1 Portfolio Comparison | 17-24 | 9 | Complete | 2026-01-18 |
 | v2.2 Historical Risk-Free Rates | 25-28 | 6 | Complete | 2026-01-18 |
 | v2.3 Workspace Packages | 29-31 | 4 | Complete | 2026-01-19 |
+| v2.4 Backtest Optimization Tools | 32-34 | TBD | In progress | - |
 
 ## Audit Notes
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -129,13 +129,13 @@ Plans:
 
 #### Phase 34: report-tools-fixes
 
-**Goal**: Fix `aggregate_by_field` bug and any related issues discovered during exploration
+**Goal**: Fix Zod default parameters not applying in MCP SDK CLI mode for report tools
 **Depends on**: Phase 33
 **Research**: Unlikely (bug fixes)
-**Plans**: TBD
+**Plans**: 1/1 complete
 
 Plans:
-- [ ] 34-01: TBD
+- [x] 34-01: Fix runtime defaults for aggregate_by_field, run_filtered_query, get_field_statistics - completed 2026-01-19
 
 ## Progress
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -117,15 +117,15 @@ See [v1.0 archive](milestones/v1.0-wfa-enhancement.md) for full details.
 Plans:
 - [x] 32-01: find_predictive_fields MCP tool — completed 2026-01-19
 
-#### Phase 33: filter-curve
+#### Phase 33: filter-curve ✅
 
 **Goal**: Tool that sweeps thresholds for a field with bidirectional analysis (lt/gt/both modes), returns full outcome curve, and surfaces sweet spots
 **Depends on**: Phase 32
 **Research**: Unlikely (builds on existing query infrastructure)
-**Plans**: TBD
+**Plans**: 1/1 complete
 
 Plans:
-- [ ] 33-01: TBD
+- [x] 33-01: filter_curve MCP tool — completed 2026-01-19
 
 #### Phase 34: report-tools-fixes
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -7,9 +7,24 @@
 - ✅ [v2.1 Portfolio Comparison](milestones/v2.1-portfolio-comparison.md) (Phases 17-24) — SHIPPED 2026-01-18
 - ✅ [v2.2 Historical Risk-Free Rates](milestones/v2.2-historical-risk-free-rates.md) (Phases 25-28) — SHIPPED 2026-01-18
 - ✅ [v2.3 Workspace Packages](milestones/v2.3-workspace-packages.md) (Phases 29-31) — SHIPPED 2026-01-19
-- 🚧 **v2.4 Backtest Optimization Tools** — Phases 32-34 (in progress)
+- ✅ [v2.4 Backtest Optimization Tools](milestones/v2.4-backtest-optimization-tools.md) (Phases 32-34) — SHIPPED 2026-01-19
 
 ## Completed Milestones
+
+<details>
+<summary>✅ v2.4 Backtest Optimization Tools (Phases 32-34) — SHIPPED 2026-01-19</summary>
+
+MCP tools for data-driven filter optimization: find_predictive_fields for correlation analysis and filter_curve for threshold sweeping with sweet spot detection.
+
+- [x] Phase 32: find-predictive-fields (1/1 plan) — completed 2026-01-19
+- [x] Phase 33: filter-curve (1/1 plan) — completed 2026-01-19
+- [x] Phase 34: report-tools-fixes (1/1 plan) — completed 2026-01-19
+
+**Stats:** 3 phases, 3 plans, 1 day execution time
+
+See [v2.4 archive](milestones/v2.4-backtest-optimization-tools.md) for full details.
+
+</details>
 
 <details>
 <summary>✅ v2.3 Workspace Packages (Phases 29-31) — SHIPPED 2026-01-19</summary>
@@ -103,40 +118,6 @@ See [v1.0 archive](milestones/v1.0-wfa-enhancement.md) for full details.
 
 </details>
 
-### 🚧 v2.4 Backtest Optimization Tools (In Progress)
-
-**Milestone Goal:** Add MCP tools that help users identify which entry conditions predict trade success, enabling data-driven filter optimization for backtests.
-
-#### Phase 32: find-predictive-fields ✅
-
-**Goal**: Tool that scans all numeric fields, calculates correlation with P/L, and returns ranked list of predictive factors
-**Depends on**: Previous milestone complete
-**Research**: Unlikely (internal patterns, builds on existing field infrastructure)
-**Plans**: 1/1 complete
-
-Plans:
-- [x] 32-01: find_predictive_fields MCP tool — completed 2026-01-19
-
-#### Phase 33: filter-curve ✅
-
-**Goal**: Tool that sweeps thresholds for a field with bidirectional analysis (lt/gt/both modes), returns full outcome curve, and surfaces sweet spots
-**Depends on**: Phase 32
-**Research**: Unlikely (builds on existing query infrastructure)
-**Plans**: 1/1 complete
-
-Plans:
-- [x] 33-01: filter_curve MCP tool — completed 2026-01-19
-
-#### Phase 34: report-tools-fixes
-
-**Goal**: Fix Zod default parameters not applying in MCP SDK CLI mode for report tools
-**Depends on**: Phase 33
-**Research**: Unlikely (bug fixes)
-**Plans**: 1/1 complete
-
-Plans:
-- [x] 34-01: Fix runtime defaults for aggregate_by_field, run_filtered_query, get_field_statistics - completed 2026-01-19
-
 ## Progress
 
 | Milestone | Phases | Plans | Status | Shipped |
@@ -146,7 +127,7 @@ Plans:
 | v2.1 Portfolio Comparison | 17-24 | 9 | Complete | 2026-01-18 |
 | v2.2 Historical Risk-Free Rates | 25-28 | 6 | Complete | 2026-01-18 |
 | v2.3 Workspace Packages | 29-31 | 4 | Complete | 2026-01-19 |
-| v2.4 Backtest Optimization Tools | 32-34 | TBD | In progress | - |
+| v2.4 Backtest Optimization Tools | 32-34 | 3 | Complete | 2026-01-19 |
 
 ## Audit Notes
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -107,15 +107,15 @@ See [v1.0 archive](milestones/v1.0-wfa-enhancement.md) for full details.
 
 **Milestone Goal:** Add MCP tools that help users identify which entry conditions predict trade success, enabling data-driven filter optimization for backtests.
 
-#### Phase 32: find-predictive-fields
+#### Phase 32: find-predictive-fields ✅
 
 **Goal**: Tool that scans all numeric fields, calculates correlation with P/L, and returns ranked list of predictive factors
 **Depends on**: Previous milestone complete
 **Research**: Unlikely (internal patterns, builds on existing field infrastructure)
-**Plans**: TBD
+**Plans**: 1/1 complete
 
 Plans:
-- [ ] 32-01: TBD (run /gsd:plan-phase 32 to break down)
+- [x] 32-01: find_predictive_fields MCP tool — completed 2026-01-19
 
 #### Phase 33: filter-curve
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -10,12 +10,12 @@ See: .planning/PROJECT.md (updated 2026-01-19)
 ## Current Position
 
 Milestone: v2.4 Backtest Optimization Tools
-Phase: 33 of 34 (filter-curve)
+Phase: 34 of 34 (report-tools-fixes)
 Plan: 01 complete
-Status: Phase complete
-Last activity: 2026-01-19 — Completed 33-01-PLAN.md
+Status: Milestone complete
+Last activity: 2026-01-19 — Completed 34-01-PLAN.md
 
-Progress: ██████░░░░ 67% (2/3 phases)
+Progress: ██████████ 100% (3/3 phases)
 
 ## Historical Context
 
@@ -32,9 +32,9 @@ All decisions now captured in PROJECT.md Key Decisions table.
 ## Session Continuity
 
 Last session: 2026-01-19
-Stopped at: Completed 33-01-PLAN.md
+Stopped at: Completed 34-01-PLAN.md
 Resume file: None
-Next: Plan Phase 34 (/gsd:plan-phase 34)
+Next: Complete milestone v2.4 (archive, tag, update docs)
 
 ## Testing Infrastructure
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,20 +5,21 @@
 See: .planning/PROJECT.md (updated 2026-01-19)
 
 **Core value:** Make trading analytics accessible and understandable through web UI and AI-assisted workflows
-**Current focus:** Backtest optimization tools for MCP server
+**Current focus:** Planning next milestone
 
 ## Current Position
 
-Milestone: v2.4 Backtest Optimization Tools
-Phase: 34 of 34 (report-tools-fixes)
-Plan: 01 complete
-Status: Milestone complete
-Last activity: 2026-01-19 — Completed 34-01-PLAN.md
+Milestone: None active (v2.4 shipped)
+Phase: Ready to plan
+Plan: N/A
+Status: Between milestones
+Last activity: 2026-01-19 — Completed v2.4 Backtest Optimization Tools
 
-Progress: ██████████ 100% (3/3 phases)
+Progress: All milestones complete through v2.4
 
 ## Historical Context
 
+See [v2.4 archive](milestones/v2.4-backtest-optimization-tools.md) for backtest optimization tools.
 See [v2.3 archive](milestones/v2.3-workspace-packages.md) for workspace package migration details.
 See [v2.2 archive](milestones/v2.2-historical-risk-free-rates.md) for risk-free rate implementation details.
 See [v2.1 archive](milestones/v2.1-portfolio-comparison.md) for portfolio comparison tools.
@@ -32,9 +33,9 @@ All decisions now captured in PROJECT.md Key Decisions table.
 ## Session Continuity
 
 Last session: 2026-01-19
-Stopped at: Completed 34-01-PLAN.md
+Stopped at: v2.4 milestone complete
 Resume file: None
-Next: Complete milestone v2.4 (archive, tag, update docs)
+Next: `/gsd:discuss-milestone` to plan next milestone
 
 ## Testing Infrastructure
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,17 +5,17 @@
 See: .planning/PROJECT.md (updated 2026-01-19)
 
 **Core value:** Make trading analytics accessible and understandable through web UI and AI-assisted workflows
-**Current focus:** Planning next milestone
+**Current focus:** Backtest optimization tools for MCP server
 
 ## Current Position
 
-Milestone: None active
-Phase: -
-Plan: -
-Status: Ready to plan next milestone
-Last activity: 2026-01-19 — v2.3 milestone complete
+Milestone: v2.4 Backtest Optimization Tools
+Phase: 32 of 34 (find-predictive-fields)
+Plan: Not started
+Status: Ready to plan
+Last activity: 2026-01-19 — Milestone v2.4 created
 
-Progress: Ready for next milestone
+Progress: ░░░░░░░░░░ 0%
 
 ## Historical Context
 
@@ -32,9 +32,9 @@ All decisions now captured in PROJECT.md Key Decisions table.
 ## Session Continuity
 
 Last session: 2026-01-19
-Stopped at: v2.3 milestone shipped
+Stopped at: Milestone v2.4 initialization
 Resume file: None
-Next: Plan next milestone (/gsd:discuss-milestone)
+Next: Plan Phase 32 (/gsd:plan-phase 32)
 
 ## Testing Infrastructure
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -11,11 +11,11 @@ See: .planning/PROJECT.md (updated 2026-01-19)
 
 Milestone: v2.4 Backtest Optimization Tools
 Phase: 32 of 34 (find-predictive-fields)
-Plan: Not started
-Status: Ready to plan
-Last activity: 2026-01-19 — Milestone v2.4 created
+Plan: 01 complete
+Status: Phase complete
+Last activity: 2026-01-19 — Completed 32-01-PLAN.md
 
-Progress: ░░░░░░░░░░ 0%
+Progress: ███░░░░░░░ 33% (1/3 phases)
 
 ## Historical Context
 
@@ -32,9 +32,9 @@ All decisions now captured in PROJECT.md Key Decisions table.
 ## Session Continuity
 
 Last session: 2026-01-19
-Stopped at: Milestone v2.4 initialization
+Stopped at: Completed 32-01-PLAN.md
 Resume file: None
-Next: Plan Phase 32 (/gsd:plan-phase 32)
+Next: Plan Phase 33 (/gsd:plan-phase 33)
 
 ## Testing Infrastructure
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -10,12 +10,12 @@ See: .planning/PROJECT.md (updated 2026-01-19)
 ## Current Position
 
 Milestone: v2.4 Backtest Optimization Tools
-Phase: 32 of 34 (find-predictive-fields)
+Phase: 33 of 34 (filter-curve)
 Plan: 01 complete
 Status: Phase complete
-Last activity: 2026-01-19 — Completed 32-01-PLAN.md
+Last activity: 2026-01-19 — Completed 33-01-PLAN.md
 
-Progress: ███░░░░░░░ 33% (1/3 phases)
+Progress: ██████░░░░ 67% (2/3 phases)
 
 ## Historical Context
 
@@ -32,9 +32,9 @@ All decisions now captured in PROJECT.md Key Decisions table.
 ## Session Continuity
 
 Last session: 2026-01-19
-Stopped at: Completed 32-01-PLAN.md
+Stopped at: Completed 33-01-PLAN.md
 Resume file: None
-Next: Plan Phase 33 (/gsd:plan-phase 33)
+Next: Plan Phase 34 (/gsd:plan-phase 34)
 
 ## Testing Infrastructure
 

--- a/.planning/milestones/v2.4-backtest-optimization-tools.md
+++ b/.planning/milestones/v2.4-backtest-optimization-tools.md
@@ -1,0 +1,80 @@
+# Milestone v2.4: Backtest Optimization Tools
+
+**Status:** ✅ SHIPPED 2026-01-19
+**Phases:** 32-34
+**Total Plans:** 3
+
+## Overview
+
+MCP tools that help users identify which entry conditions predict trade success, enabling data-driven filter optimization for backtests.
+
+## Phases
+
+### Phase 32: find-predictive-fields
+
+**Goal**: Tool that scans all numeric fields, calculates correlation with P/L, and returns ranked list of predictive factors
+**Depends on**: Previous milestone complete
+**Plans**: 1 plan
+
+Plans:
+- [x] 32-01: find_predictive_fields MCP tool — completed 2026-01-19
+
+**Details:**
+- Pearson correlation-based analysis ranking all numeric fields by P/L correlation
+- Interpretation labels (strong/moderate/weak/negligible) based on |r| thresholds
+- Support for strategy, date range, and custom fields filtering
+- Runtime defaults pattern established for Zod schema handling
+
+### Phase 33: filter-curve
+
+**Goal**: Tool that sweeps thresholds for a field with bidirectional analysis (lt/gt/both modes), returns full outcome curve, and surfaces sweet spots
+**Depends on**: Phase 32
+**Plans**: 1 plan
+
+Plans:
+- [x] 33-01: filter_curve MCP tool — completed 2026-01-19
+
+**Details:**
+- Bidirectional threshold analysis (lt/gt/both modes)
+- Auto-generated thresholds from percentiles [5, 10, 25, 50, 75, 90, 95]
+- Custom threshold support overrides auto-generation
+- Sweet spot detection with combined improvement scoring (winRateDelta * avgPlDelta)
+- Full strategy/date pre-filter support
+
+### Phase 34: report-tools-fixes
+
+**Goal**: Fix Zod default parameters not applying in MCP SDK CLI mode for report tools
+**Depends on**: Phase 33
+**Plans**: 1 plan
+
+Plans:
+- [x] 34-01: Fix runtime defaults for aggregate_by_field, run_filtered_query, get_field_statistics — completed 2026-01-19
+
+**Details:**
+- Identified root cause: CLI --call handler bypassed Zod parsing
+- Fixed cli-handler.ts to call inputSchema.safeParse() before invoking tool handlers
+- Removed runtime default workarounds from 5 tools (cleaner codebase)
+
+---
+
+## Milestone Summary
+
+**Key Decisions:**
+- Fix at CLI handler level rather than patching each tool individually
+- Sweet spot criteria: winRateDelta > 0 AND avgPlDelta > 0 AND percentOfTrades >= 20%
+- Use Pearson correlation for linear relationship detection
+- Rank by absolute correlation (both positive and negative are predictive)
+
+**Issues Resolved:**
+- CLI --call mode now applies Zod schema parsing like normal MCP server mode
+- All current and future tools work correctly in CLI test mode without per-tool workarounds
+
+**Issues Deferred:**
+- None
+
+**Technical Debt Incurred:**
+- None
+
+---
+
+_For current project status, see .planning/ROADMAP.md_

--- a/.planning/phases/32-find-predictive-fields/32-01-PLAN.md
+++ b/.planning/phases/32-find-predictive-fields/32-01-PLAN.md
@@ -1,0 +1,196 @@
+---
+phase: 32-find-predictive-fields
+plan: 01
+type: execute
+domain: mcp-server
+---
+
+<objective>
+Create MCP tool that identifies which trade entry conditions predict profitability.
+
+Purpose: Enable data-driven filter optimization by showing users which fields (VIX level, time of day, etc.) correlate most strongly with trade P/L.
+Output: New `find_predictive_fields` MCP tool that scans all numeric fields and returns ranked correlation data.
+</objective>
+
+<execution_context>
+~/.claude/get-shit-done/workflows/execute-phase.md
+~/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+
+# Key source files
+@packages/mcp-server/src/tools/reports.ts
+@packages/lib/models/report-config.ts
+@packages/lib/calculations/statistical-utils.ts
+
+# Existing patterns to follow
+The tool should follow the pattern established by get_field_statistics and aggregate_by_field:
+- Use loadBlock() for data loading
+- Use enrichTrades() inline implementation for field enrichment
+- Use getTradeFieldValue() for field extraction
+- Use createToolOutput() for JSON-first response format
+- Support optional strategy and date range pre-filters
+
+# Dependencies available
+- pearsonCorrelation from @tradeblocks/lib - already exported and handles edge cases
+- REPORT_FIELDS from @tradeblocks/lib - defines all standard numeric fields
+- CLI test mode exists: `TRADEBLOCKS_DATA_DIR=~/backtests tradeblocks-mcp --call <tool> '<json>'`
+
+# Key decisions
+- Use Pearson correlation (linear relationship detection)
+- Rank by absolute correlation value (both positive and negative correlations are predictive)
+- Require minimum sample size (default: 30) for reliable correlation
+- Include interpretation guidance (|r| > 0.7 strong, > 0.4 moderate, > 0.2 weak)
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create find_predictive_fields MCP tool</name>
+  <files>packages/mcp-server/src/tools/reports.ts</files>
+  <action>
+Add new MCP tool `find_predictive_fields` to reports.ts. Implementation details:
+
+1. **Input schema** (Zod):
+   - blockId: string (required) - Block folder name
+   - strategy: string (optional) - Pre-filter by strategy name
+   - startDate: string (optional) - Pre-filter start date (YYYY-MM-DD)
+   - endDate: string (optional) - Pre-filter end date (YYYY-MM-DD)
+   - targetField: string (default: "pl") - Field to correlate against (usually P/L)
+   - minSamples: number (default: 30, min: 10) - Minimum trades with valid values for reliable correlation
+   - includeCustomFields: boolean (default: true) - Include custom fields from CSV
+
+2. **Logic**:
+   - Load block, apply strategy/date filters
+   - Enrich trades using existing enrichTrades()
+   - Build list of fields to analyze:
+     - Static fields from REPORT_FIELDS
+     - Custom fields from trades (if includeCustomFields)
+     - Skip targetField itself
+   - For each field:
+     - Extract (fieldValue, targetValue) pairs where both are non-null
+     - Skip if sampleSize < minSamples
+     - Calculate Pearson correlation using imported pearsonCorrelation from statistical-utils
+   - Sort by absolute correlation (descending)
+   - Add interpretation: |r| >= 0.7 = "strong", >= 0.4 = "moderate", >= 0.2 = "weak", else "negligible"
+
+3. **Output structure**:
+   - Summary line: "Found X predictive fields out of Y analyzed"
+   - Structured data:
+     - blockId, targetField, filters applied
+     - totalFieldsAnalyzed, fieldsWithSufficientData
+     - rankedFields: array of { field, label, correlation, absCorrelation, sampleSize, interpretation, direction: "positive" | "negative" }
+     - fieldsSkipped: array of { field, label, reason: "insufficient_samples" | "no_variance", sampleSize }
+
+4. **Import pearsonCorrelation**: Add import at top of file:
+   ```typescript
+   import { pearsonCorrelation } from "@tradeblocks/lib";
+   ```
+
+CRITICAL: Follow the exact pattern of other tools in reports.ts. Use inline enrichTrades() - do NOT try to import it from lib (browser deps). Use getTradeFieldValue() helper already in the file.
+  </action>
+  <verify>npm run typecheck passes in packages/mcp-server/</verify>
+  <done>
+- Tool registered with proper Zod schema
+- Correlation calculation works for all standard REPORT_FIELDS
+- Custom fields included when available
+- Fields ranked by |correlation|
+- Interpretation labels assigned correctly
+- Skipped fields tracked with reasons
+- TypeScript compiles without errors
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: CLI test verification with real data</name>
+  <files>packages/mcp-server/src/tools/reports.ts</files>
+  <action>
+Test the new tool using CLI test mode with actual backtest data.
+
+1. **Build MCP server**:
+   ```bash
+   cd packages/mcp-server && npm run build
+   ```
+
+2. **Run find_predictive_fields**:
+   ```bash
+   TRADEBLOCKS_DATA_DIR=~/backtests tradeblocks-mcp --call find_predictive_fields '{"blockId":"<real-block-id>"}'
+   ```
+   Replace `<real-block-id>` with an actual block folder name from `~/backtests/`.
+
+3. **Verify output**:
+   - Check that fields are ranked by absolute correlation
+   - Verify sample sizes are reasonable (>= minSamples for included fields)
+   - Confirm interpretation labels match correlation values
+   - Ensure both positive and negative correlations appear
+   - Check that skipped fields show proper reasons
+
+4. **Test with filters** (if multiple strategies exist):
+   ```bash
+   TRADEBLOCKS_DATA_DIR=~/backtests tradeblocks-mcp --call find_predictive_fields '{"blockId":"<block-id>","strategy":"<strategy-name>"}'
+   ```
+
+5. **Test edge cases**:
+   - Test with minSamples=10 (lower threshold)
+   - Test with targetField="rom" (alternate target)
+
+If any test reveals issues, fix them in reports.ts before proceeding.
+  </action>
+  <verify>CLI test returns valid JSON with ranked correlations</verify>
+  <done>
+- Tool returns properly formatted JSON output
+- Correlations are calculated correctly (spot check: openingVix, durationHours should have some correlation)
+- Edge cases handled (empty blocks, insufficient data)
+- Performance acceptable (< 5s for typical portfolio)
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+Before declaring phase complete:
+- [ ] `npm run typecheck` passes in packages/mcp-server/
+- [ ] CLI test with real data returns valid output
+- [ ] At least one field shows moderate or strong correlation
+- [ ] Skipped fields array populated with reasons
+- [ ] Output follows JSON-first pattern (createToolOutput)
+</verification>
+
+<success_criteria>
+- find_predictive_fields tool registered and working
+- Correlations calculated using Pearson method
+- Fields ranked by predictive strength
+- Interpretation guidance included
+- CLI test verification passed
+- Code follows existing patterns in reports.ts
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/32-find-predictive-fields/32-01-SUMMARY.md`:
+
+# Phase 32 Plan 01: find-predictive-fields Tool Summary
+
+**[One-liner: what shipped]**
+
+## Accomplishments
+- [Key outcomes]
+
+## Files Created/Modified
+- `packages/mcp-server/src/tools/reports.ts` - Added find_predictive_fields tool
+
+## Decisions Made
+- [Any implementation choices]
+
+## Issues Encountered
+- [Problems and resolutions, or "None"]
+
+## CLI Test Results
+- [Sample output from verification]
+
+## Next Step
+Phase 32 complete, ready for Phase 33 (filter-curve tool)
+</output>

--- a/.planning/phases/32-find-predictive-fields/32-01-SUMMARY.md
+++ b/.planning/phases/32-find-predictive-fields/32-01-SUMMARY.md
@@ -1,0 +1,131 @@
+---
+phase: 32-find-predictive-fields
+plan: 01
+subsystem: mcp-server
+tags: [pearson-correlation, statistics, backtest-optimization]
+
+# Dependency graph
+requires:
+  - phase: mcp-server-setup
+    provides: MCP tool registration patterns, report tools infrastructure
+provides:
+  - find_predictive_fields MCP tool for correlation analysis
+  - Field-to-P/L correlation ranking
+affects: [33-filter-curve, 34-parameter-sweep]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns: [runtime-defaults-for-zod, field-validation-guards]
+
+key-files:
+  created: []
+  modified: [packages/mcp-server/src/tools/reports.ts]
+
+key-decisions:
+  - "Apply Zod defaults at runtime since MCP SDK may not apply them"
+  - "Use Pearson correlation for linear relationship detection"
+  - "Rank by absolute correlation (both positive and negative are predictive)"
+  - "Require minimum 30 samples by default for reliable correlation"
+
+patterns-established:
+  - "Runtime defaults pattern: rawParam ?? defaultValue"
+  - "Guard pattern for getTradeFieldValue against undefined fields"
+
+issues-created: []
+
+# Metrics
+duration: 25min
+completed: 2026-01-19
+---
+
+# Phase 32 Plan 01: find-predictive-fields Tool Summary
+
+**Pearson correlation-based MCP tool that ranks all numeric fields by their predictive strength for P/L, enabling data-driven filter optimization**
+
+## Performance
+
+- **Duration:** 25 min
+- **Started:** 2026-01-19
+- **Completed:** 2026-01-19
+- **Tasks:** 2
+- **Files modified:** 1
+
+## Accomplishments
+- Created find_predictive_fields MCP tool that calculates correlations between all numeric fields and a target field
+- Implemented proper ranking by absolute correlation value
+- Added interpretation labels (strong/moderate/weak/negligible) based on |r| thresholds
+- Added support for strategy, date range, and custom fields filtering
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Create find_predictive_fields MCP tool** - `9b0bbbf` (feat)
+2. **Task 2: CLI test verification + fixes** - `ef3b158` (fix)
+
+## Files Created/Modified
+- `packages/mcp-server/src/tools/reports.ts` - Added find_predictive_fields tool (~240 lines)
+
+## Decisions Made
+- Used runtime defaults (rawParam ?? defaultValue) instead of relying on Zod defaults, as MCP SDK CLI handler may not apply them
+- Added guard against undefined fields in getTradeFieldValue for robustness
+- Added null check for fieldInfo iteration for safety
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 1 - Bug] Zod defaults not applied by MCP SDK**
+- **Found during:** Task 2 (CLI verification)
+- **Issue:** All correlations returned 0 because minSamples was undefined (not 30 as expected)
+- **Fix:** Apply defaults at runtime: `const minSamples = rawMinSamples ?? 30`
+- **Files modified:** packages/mcp-server/src/tools/reports.ts
+- **Verification:** CLI test returns proper correlations with default minSamples=30
+- **Committed in:** ef3b158
+
+**2. [Rule 3 - Blocking] Guard against undefined field parameter**
+- **Found during:** Task 2 (initial test showed 'Cannot read startsWith of undefined')
+- **Issue:** getTradeFieldValue called with undefined field crashed
+- **Fix:** Added type guard: `if (typeof field !== 'string') return null`
+- **Files modified:** packages/mcp-server/src/tools/reports.ts
+- **Verification:** Tool runs without error
+- **Committed in:** ef3b158
+
+---
+
+**Total deviations:** 2 auto-fixed (1 bug, 1 blocking), 0 deferred
+**Impact on plan:** Both fixes essential for basic functionality. No scope creep.
+
+## Issues Encountered
+- Pre-existing TypeScript strict mode errors in MCP server (unrelated to this change) - noted but not addressed as they don't affect build
+
+## CLI Test Results
+
+```
+CLI Test Results:
+  Target: pl
+  Total fields analyzed: 41
+  Fields with sufficient data: 37
+  Skipped fields: 4
+
+  Interpretation breakdown:
+    strong: 1
+    moderate: 4
+    weak: 6
+    negligible: 26
+```
+
+Sample top correlations:
+- Net P/L: r=+0.9999 (strong) - expected, nearly identical to target
+- Return on Margin: r=+0.5975 (moderate)
+- P/L %: r=+0.5422 (moderate)
+- Is Winner: r=+0.4623 (moderate)
+
+## Next Phase Readiness
+- find_predictive_fields tool complete and working
+- Ready for Phase 33 (filter-curve tool)
+
+---
+*Phase: 32-find-predictive-fields*
+*Completed: 2026-01-19*

--- a/.planning/phases/33-filter-curve/33-01-PLAN.md
+++ b/.planning/phases/33-filter-curve/33-01-PLAN.md
@@ -1,0 +1,213 @@
+---
+phase: 33-filter-curve
+plan: 01
+type: execute
+domain: mcp-server
+---
+
+<objective>
+Create MCP tool that sweeps filter thresholds for a field and returns outcome curves.
+
+Purpose: After find_predictive_fields identifies correlated fields, users need to know WHERE to set the threshold. This tool sweeps across possible values and shows performance at each, enabling data-driven filter optimization.
+Output: New `filter_curve` MCP tool that generates threshold outcome curves and identifies sweet spots.
+</objective>
+
+<execution_context>
+~/.claude/get-shit-done/workflows/execute-phase.md
+~/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+
+# Prior phase summary (dependency)
+@.planning/phases/32-find-predictive-fields/32-01-SUMMARY.md
+
+# Key source files
+@packages/mcp-server/src/tools/reports.ts
+@packages/lib/models/report-config.ts
+
+# Patterns from Phase 32
+The find_predictive_fields tool established:
+- Runtime defaults pattern: `rawParam ?? defaultValue`
+- Guard pattern for getTradeFieldValue
+- Use enrichTrades() inline, getTradeFieldValue() for field extraction
+- createToolOutput() for JSON-first responses
+- Support strategy/date pre-filters
+
+# Available helpers in reports.ts
+- enrichTrades(): Adds derived fields (rom, plPct, durationHours, etc.)
+- getTradeFieldValue(): Extracts field value from enriched trade
+- filterByStrategy(), filterByDateRange(): Pre-filters
+- percentile(): Calculate percentile from sorted array
+- stdDev(): Standard deviation
+
+# CLI test mode
+TRADEBLOCKS_DATA_DIR=~/backtests tradeblocks-mcp --call <tool> '<json>'
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create filter_curve MCP tool</name>
+  <files>packages/mcp-server/src/tools/reports.ts</files>
+  <action>
+Add new MCP tool `filter_curve` to reports.ts. Implementation details:
+
+1. **Input schema** (Zod):
+   - blockId: string (required) - Block folder name
+   - field: string (required) - Field to sweep thresholds on (e.g., "openingVix", "durationHours")
+   - mode: enum "lt" | "gt" | "both" (default: "both") - Direction of filter
+     - "lt": Only show trades where field < threshold
+     - "gt": Only show trades where field > threshold
+     - "both": Show both directions at each threshold
+   - thresholds: number[] (optional) - Custom threshold values to test. If omitted, auto-generate from percentiles.
+   - percentileSteps: number[] (optional, default: [5, 10, 25, 50, 75, 90, 95]) - Percentiles to use for auto-generated thresholds
+   - strategy: string (optional) - Pre-filter by strategy
+   - startDate: string (optional) - Pre-filter start date (YYYY-MM-DD)
+   - endDate: string (optional) - Pre-filter end date (YYYY-MM-DD)
+
+2. **Logic**:
+   - Load block, apply pre-filters, enrich trades
+   - Extract field values, calculate baseline metrics (all trades)
+   - Generate thresholds:
+     - If custom thresholds provided, use those
+     - Otherwise, calculate thresholds from percentileSteps of field distribution
+   - For each threshold, for each mode direction:
+     - Filter trades by condition (field < threshold or field > threshold)
+     - Calculate metrics: count, winRate, avgPl, totalPl, percentOfTrades
+     - Calculate improvement vs baseline: winRateDelta, avgPlDelta
+   - Identify sweet spots: thresholds where both winRate AND avgPl improve over baseline
+
+3. **Output structure**:
+   - Summary: "Filter curve for {field}: {N} thresholds analyzed | {M} sweet spots found"
+   - structuredData:
+     - blockId, field, mode, filters applied
+     - baseline: { count, winRate, avgPl, totalPl } (unfiltered metrics)
+     - thresholds: array sorted by threshold value
+     - For "both" mode, each threshold entry has:
+       - threshold: number
+       - lt: { count, percentOfTrades, winRate, avgPl, totalPl, winRateDelta, avgPlDelta }
+       - gt: { count, percentOfTrades, winRate, avgPl, totalPl, winRateDelta, avgPlDelta }
+     - For "lt" or "gt" mode, flatten to single direction per threshold
+     - sweetSpots: array of { threshold, direction, winRateDelta, avgPlDelta, recommendation }
+       - recommendation: "Consider filtering {field} {direction} {threshold}"
+
+4. **Sweet spot detection**:
+   - A sweet spot is a threshold where:
+     - winRateDelta > 0 (win rate improves)
+     - avgPlDelta > 0 (average P/L improves)
+     - percentOfTrades >= 20% (retains meaningful sample)
+   - Rank sweet spots by (winRateDelta * avgPlDelta) as combined improvement score
+
+CRITICAL: Apply runtime defaults pattern (rawParam ?? defaultValue) for all optional params with defaults.
+  </action>
+  <verify>npm run typecheck passes in packages/mcp-server/</verify>
+  <done>
+- Tool registered with proper Zod schema
+- Threshold sweeping works for both auto-generated and custom thresholds
+- Bidirectional mode ("both") returns lt/gt results at each threshold
+- Baseline metrics calculated correctly
+- Sweet spots identified with meaningful criteria
+- TypeScript compiles without errors
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: CLI test verification with real data</name>
+  <files>packages/mcp-server/src/tools/reports.ts</files>
+  <action>
+Test the new tool using CLI test mode with actual backtest data.
+
+1. **Build MCP server**:
+   ```bash
+   cd packages/mcp-server && npm run build
+   ```
+
+2. **Basic test with auto-generated thresholds**:
+   ```bash
+   TRADEBLOCKS_DATA_DIR=~/backtests tradeblocks-mcp --call filter_curve '{"blockId":"<real-block-id>","field":"openingVix"}'
+   ```
+   Verify:
+   - Baseline metrics present
+   - Thresholds correspond to percentiles of openingVix distribution
+   - Both lt and gt results at each threshold
+   - Sweet spots array populated (may be empty if no improvement found)
+
+3. **Test single direction mode**:
+   ```bash
+   TRADEBLOCKS_DATA_DIR=~/backtests tradeblocks-mcp --call filter_curve '{"blockId":"<block-id>","field":"openingVix","mode":"lt"}'
+   ```
+   Verify output only includes lt results.
+
+4. **Test custom thresholds**:
+   ```bash
+   TRADEBLOCKS_DATA_DIR=~/backtests tradeblocks-mcp --call filter_curve '{"blockId":"<block-id>","field":"openingVix","thresholds":[15,20,25,30]}'
+   ```
+   Verify exactly those 4 thresholds in output.
+
+5. **Test different field** (from Phase 32's find_predictive_fields output):
+   ```bash
+   TRADEBLOCKS_DATA_DIR=~/backtests tradeblocks-mcp --call filter_curve '{"blockId":"<block-id>","field":"durationHours"}'
+   ```
+
+If any test reveals issues, fix them in reports.ts before proceeding.
+  </action>
+  <verify>CLI test returns valid JSON with threshold curves</verify>
+  <done>
+- Tool returns properly formatted JSON output
+- Auto-generated thresholds span the field's distribution
+- Baseline metrics match expected portfolio stats
+- Sweet spots detection produces sensible recommendations
+- Performance acceptable (< 5s for typical portfolio)
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+Before declaring phase complete:
+- [ ] `npm run typecheck` passes in packages/mcp-server/
+- [ ] CLI test with "openingVix" field returns valid threshold curve
+- [ ] Both lt/gt directions work correctly
+- [ ] Custom thresholds override auto-generation
+- [ ] Sweet spots identified with proper criteria
+- [ ] Output follows JSON-first pattern (createToolOutput)
+</verification>
+
+<success_criteria>
+- filter_curve tool registered and working
+- Threshold sweeping generates meaningful data points
+- Bidirectional analysis shows tradeoffs at each threshold
+- Sweet spots help users identify optimal filter values
+- CLI test verification passed
+- Code follows patterns established in Phase 32
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/33-filter-curve/33-01-SUMMARY.md`:
+
+# Phase 33 Plan 01: filter-curve Tool Summary
+
+**[One-liner: what shipped]**
+
+## Accomplishments
+- [Key outcomes]
+
+## Files Created/Modified
+- `packages/mcp-server/src/tools/reports.ts` - Added filter_curve tool
+
+## Decisions Made
+- [Any implementation choices]
+
+## Issues Encountered
+- [Problems and resolutions, or "None"]
+
+## CLI Test Results
+- [Sample output from verification]
+
+## Next Step
+Phase 33 complete, ready for Phase 34 (report-tools-fixes)
+</output>

--- a/.planning/phases/33-filter-curve/33-01-SUMMARY.md
+++ b/.planning/phases/33-filter-curve/33-01-SUMMARY.md
@@ -1,0 +1,119 @@
+---
+phase: 33-filter-curve
+plan: 01
+subsystem: mcp-server
+tags: [mcp, filter, threshold, optimization, correlation]
+
+# Dependency graph
+requires:
+  - phase: 32-find-predictive-fields
+    provides: Field correlation infrastructure, enrichTrades(), getTradeFieldValue()
+provides:
+  - filter_curve MCP tool for threshold sweeping
+  - Bidirectional filter analysis (lt/gt/both)
+  - Sweet spot detection with improvement scoring
+affects: [report-tools, backtest-optimization]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns: [percentile-based threshold generation, bidirectional filter analysis]
+
+key-files:
+  created: []
+  modified: [packages/mcp-server/src/tools/reports.ts]
+
+key-decisions:
+  - "Sweet spot criteria: winRateDelta > 0 AND avgPlDelta > 0 AND percentOfTrades >= 20%"
+  - "Sweet spots ranked by combined score (winRateDelta * avgPlDelta)"
+  - "Default percentile steps: [5, 10, 25, 50, 75, 90, 95] for threshold generation"
+
+patterns-established:
+  - "Bidirectional filter analysis with lt/gt/both modes"
+  - "Threshold sweeping with auto-generation from percentiles"
+
+issues-created: []
+
+# Metrics
+duration: 3min
+completed: 2026-01-19
+---
+
+# Phase 33 Plan 01: filter-curve Tool Summary
+
+**filter_curve MCP tool for threshold sweeping with bidirectional analysis, auto-generated thresholds from percentiles, and sweet spot detection**
+
+## Performance
+
+- **Duration:** 3 min
+- **Started:** 2026-01-19T21:55:31Z
+- **Completed:** 2026-01-19T21:58:26Z
+- **Tasks:** 2/2
+- **Files modified:** 1
+
+## Accomplishments
+
+- Created filter_curve MCP tool with ~314 lines of implementation
+- Bidirectional threshold analysis (lt/gt/both modes)
+- Auto-generated thresholds from percentiles [5,10,25,50,75,90,95]
+- Custom threshold support overrides auto-generation
+- Sweet spot detection with combined improvement scoring
+- Full strategy/date pre-filter support
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Create filter_curve MCP tool** - `cfe908f` (feat)
+2. **Task 2: CLI test verification** - No commit needed (implementation correct on first try)
+
+**Plan metadata:** (this commit)
+
+## Files Created/Modified
+
+- `packages/mcp-server/src/tools/reports.ts` - Added filter_curve tool (~314 lines)
+
+## Decisions Made
+
+- **Sweet spot criteria:** winRateDelta > 0 AND avgPlDelta > 0 AND percentOfTrades >= 20%
+- **Sweet spot ranking:** Combined score = winRateDelta * avgPlDelta
+- **Default percentiles:** [5, 10, 25, 50, 75, 90, 95] for auto-generated thresholds
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None - implementation worked correctly on first attempt.
+
+## CLI Test Results
+
+All 4 test cases passed:
+
+1. **Basic test (openingVix):** 7 auto-generated thresholds, 3 sweet spots found
+2. **Single direction (mode: "lt"):** Output correctly includes only lt results
+3. **Custom thresholds ([15,20,25,30]):** Exactly 4 thresholds in output
+4. **Different field (durationHours):** 5 sweet spots found, demonstrating cross-field utility
+
+Sample output structure:
+```json
+{
+  "summary": "Filter curve for openingVix: 7 thresholds analyzed | 3 sweet spots found",
+  "structuredData": {
+    "baseline": { "count": 3436, "winRate": 58.67, "avgPl": 15572.75 },
+    "thresholds": [...],
+    "sweetSpots": [
+      { "threshold": 17.18, "direction": "lt", "score": 30.49, "recommendation": "Consider filtering openingVix < 17.18" }
+    ]
+  }
+}
+```
+
+## Next Step
+
+Phase 33 complete, ready for Phase 34 (report-tools-fixes)
+
+---
+*Phase: 33-filter-curve*
+*Completed: 2026-01-19*

--- a/.planning/phases/34-report-tools-fixes/34-01-PLAN.md
+++ b/.planning/phases/34-report-tools-fixes/34-01-PLAN.md
@@ -1,0 +1,155 @@
+---
+phase: 34-report-tools-fixes
+plan: 01
+type: execute
+---
+
+<objective>
+Fix Zod default parameters not applying in MCP SDK CLI mode for report tools.
+
+Purpose: Several report tools crash or behave incorrectly when optional parameters with defaults are omitted because the MCP SDK CLI handler doesn't apply Zod `.default()` values.
+
+Output: All report tools work correctly when optional parameters are omitted, using proper runtime defaults.
+</objective>
+
+<execution_context>
+~/.claude/get-shit-done/workflows/execute-phase.md
+./summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/32-find-predictive-fields/32-01-SUMMARY.md
+
+**Bug discovered during Phase 32:**
+The MCP SDK CLI handler (`--call` mode) doesn't apply Zod `.default()` values. Parameters defined with `.default(x)` arrive as `undefined` when omitted by the user.
+
+**Root cause:** The MCP SDK parses JSON input directly without running Zod's `.parse()` which would apply defaults. This is a known SDK limitation.
+
+**Pattern established in Phase 32:** Rename destructured params to `rawParam` and apply defaults at runtime: `const param = rawParam ?? defaultValue`.
+
+**Tools already fixed:**
+- `find_predictive_fields` (Phase 32)
+- `filter_curve` (Phase 33)
+
+**Tools needing fix:**
+1. `aggregate_by_field` - `metrics`, `includeOutOfRange` - CRASHES with "Cannot read properties of undefined (reading 'includes')"
+2. `run_filtered_query` - `logic`, `includeSampleTrades`, `sampleSize` - Returns unexpected results
+3. `get_field_statistics` - `histogramBuckets` - May crash or produce wrong bucket count
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Fix aggregate_by_field runtime defaults</name>
+  <files>packages/mcp-server/src/tools/reports.ts</files>
+  <action>
+In aggregate_by_field handler (around line 875):
+1. Rename destructured params: `metrics` -> `rawMetrics`, `includeOutOfRange` -> `rawIncludeOutOfRange`
+2. Add runtime defaults inside try block:
+   ```typescript
+   const metrics = rawMetrics ?? ["count", "winRate", "avgPl", "totalPl"];
+   const includeOutOfRange = rawIncludeOutOfRange ?? true;
+   ```
+3. Update all usages to use the new const names (should already be correct since we're shadowing)
+  </action>
+  <verify>
+```bash
+TRADEBLOCKS_DATA_DIR=~/backtests tradeblocks-mcp --call aggregate_by_field '{"blockId":"main-port-2026","groupByField":"openingVix","bucketEdges":[15,20,25,30]}'
+```
+Should return valid JSON with default metrics (count, winRate, avgPl, totalPl) without crashing.
+  </verify>
+  <done>aggregate_by_field works when metrics and includeOutOfRange params are omitted</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Fix run_filtered_query runtime defaults</name>
+  <files>packages/mcp-server/src/tools/reports.ts</files>
+  <action>
+In run_filtered_query handler (around line 581):
+1. Rename destructured params: `logic` -> `rawLogic`, `includeSampleTrades` -> `rawIncludeSampleTrades`, `sampleSize` -> `rawSampleSize`
+2. Add runtime defaults inside try block:
+   ```typescript
+   const logic = rawLogic ?? "and";
+   const includeSampleTrades = rawIncludeSampleTrades ?? true;
+   const sampleSize = rawSampleSize ?? 5;
+   ```
+3. Verify code uses const names (should already be correct)
+  </action>
+  <verify>
+```bash
+TRADEBLOCKS_DATA_DIR=~/backtests tradeblocks-mcp --call run_filtered_query '{"blockId":"main-port-2026","conditions":[{"field":"openingVix","operator":"lt","value":20}]}' | jq '.sampleTrades | length'
+```
+Should return 5 (default sampleSize) instead of null.
+  </verify>
+  <done>run_filtered_query returns sample trades by default and uses "and" logic when params omitted</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Fix get_field_statistics runtime defaults</name>
+  <files>packages/mcp-server/src/tools/reports.ts</files>
+  <action>
+In get_field_statistics handler (around line 719):
+1. Rename destructured param: `histogramBuckets` -> `rawHistogramBuckets`
+2. Add runtime default inside try block:
+   ```typescript
+   const histogramBuckets = rawHistogramBuckets ?? 10;
+   ```
+3. Verify code uses const name (should already be correct)
+  </action>
+  <verify>
+```bash
+TRADEBLOCKS_DATA_DIR=~/backtests tradeblocks-mcp --call get_field_statistics '{"blockId":"main-port-2026","field":"openingVix"}' | jq '.histogram | length'
+```
+Should return 10 (default histogramBuckets).
+  </verify>
+  <done>get_field_statistics produces 10 histogram buckets by default</done>
+</task>
+
+</tasks>
+
+<verification>
+Before declaring phase complete:
+- [ ] `TRADEBLOCKS_DATA_DIR=~/backtests tradeblocks-mcp --call aggregate_by_field '{"blockId":"main-port-2026","groupByField":"openingVix","bucketEdges":[15,20,25,30]}'` returns valid JSON
+- [ ] `TRADEBLOCKS_DATA_DIR=~/backtests tradeblocks-mcp --call run_filtered_query '{"blockId":"main-port-2026","conditions":[{"field":"openingVix","operator":"lt","value":20}]}'` returns sampleTrades (not null)
+- [ ] `TRADEBLOCKS_DATA_DIR=~/backtests tradeblocks-mcp --call get_field_statistics '{"blockId":"main-port-2026","field":"openingVix"}'` returns histogram with 10 buckets
+- [ ] `npm run typecheck` passes in packages/mcp-server
+</verification>
+
+<success_criteria>
+- All tasks completed
+- All verification checks pass
+- No TypeScript errors
+- All report tools work correctly when optional parameters are omitted
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/34-report-tools-fixes/34-01-SUMMARY.md`:
+
+# Phase 34 Plan 01: Report Tools Fixes Summary
+
+**[Substantive one-liner]**
+
+## Accomplishments
+
+- [Key outcome 1]
+- [Key outcome 2]
+
+## Files Created/Modified
+
+- `packages/mcp-server/src/tools/reports.ts` - Added runtime defaults for Zod parameters
+
+## Decisions Made
+
+[None - straightforward bug fix]
+
+## Issues Encountered
+
+[Problems and resolutions, or "None"]
+
+## Next Step
+
+Phase 34 complete, ready for milestone completion
+</output>

--- a/.planning/phases/34-report-tools-fixes/34-01-SUMMARY.md
+++ b/.planning/phases/34-report-tools-fixes/34-01-SUMMARY.md
@@ -1,0 +1,90 @@
+---
+phase: 34-report-tools-fixes
+plan: 01
+subsystem: api
+tags: [mcp, zod, runtime-defaults, report-tools]
+
+# Dependency graph
+requires:
+  - phase: 32-find-predictive-fields
+    provides: Runtime default pattern for Zod params
+  - phase: 33-filter-curve
+    provides: Additional runtime default example
+provides:
+  - Fixed runtime defaults for aggregate_by_field, run_filtered_query, get_field_statistics
+  - All report tools work correctly when optional params omitted in MCP SDK CLI mode
+affects: []
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns: [zod-runtime-defaults]
+
+key-files:
+  created: []
+  modified: [packages/mcp-server/src/tools/reports.ts]
+
+key-decisions:
+  - "Apply established pattern: rawParam destructuring with ?? fallback"
+
+patterns-established:
+  - "Runtime defaults for Zod params in MCP SDK: rename to rawX, apply default with ?? operator"
+
+issues-created: []
+
+# Metrics
+duration: 8min
+completed: 2026-01-19
+---
+
+# Phase 34 Plan 01: Report Tools Fixes Summary
+
+**Applied runtime default pattern to 3 report tools fixing crashes and incorrect behavior when optional params omitted**
+
+## Performance
+
+- **Duration:** 8 min
+- **Started:** 2026-01-19T22:10:00Z
+- **Completed:** 2026-01-19T22:18:00Z
+- **Tasks:** 3
+- **Files modified:** 1
+
+## Accomplishments
+
+- Fixed aggregate_by_field: metrics and includeOutOfRange params now default correctly
+- Fixed run_filtered_query: logic, includeSampleTrades, and sampleSize params now default correctly
+- Fixed get_field_statistics: histogramBuckets param now defaults to 10 buckets
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Fix aggregate_by_field runtime defaults** - `4f0a06b` (fix)
+2. **Task 2: Fix run_filtered_query runtime defaults** - `4858d4f` (fix)
+3. **Task 3: Fix get_field_statistics runtime defaults** - `eaf10a8` (fix)
+
+## Files Created/Modified
+
+- `packages/mcp-server/src/tools/reports.ts` - Added runtime defaults for Zod parameters in 3 tool handlers
+
+## Decisions Made
+
+None - followed established pattern from Phase 32 and 33 exactly as specified.
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None - straightforward application of the established runtime default pattern.
+
+## Next Phase Readiness
+
+- Phase 34 complete (single plan phase)
+- Milestone v2.4 Backtest Optimization Tools is now complete
+- All 3 phases (32, 33, 34) delivered successfully
+
+---
+*Phase: 34-report-tools-fixes*
+*Completed: 2026-01-19*

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks-mcp",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "MCP server for options trade analysis - works with Claude Desktop/Cowork",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "type": "module",

--- a/packages/mcp-server/src/tools/reports.ts
+++ b/packages/mcp-server/src/tools/reports.ts
@@ -876,13 +876,17 @@ export function registerReportTools(server: McpServer, baseDir: string): void {
       blockId,
       groupByField,
       bucketEdges,
-      metrics,
+      metrics: rawMetrics,
       strategy,
       startDate,
       endDate,
-      includeOutOfRange,
+      includeOutOfRange: rawIncludeOutOfRange,
     }) => {
       try {
+        // Apply runtime defaults (Zod defaults don't always apply in MCP SDK)
+        const metrics = rawMetrics ?? ["count", "winRate", "avgPl", "totalPl"];
+        const includeOutOfRange = rawIncludeOutOfRange ?? true;
+
         const block = await loadBlock(baseDir, blockId);
         let trades = block.trades;
 

--- a/packages/mcp-server/src/tools/reports.ts
+++ b/packages/mcp-server/src/tools/reports.ts
@@ -581,19 +581,14 @@ export function registerReportTools(server: McpServer, baseDir: string): void {
     async ({
       blockId,
       conditions,
-      logic: rawLogic,
+      logic,
       strategy,
       startDate,
       endDate,
-      includeSampleTrades: rawIncludeSampleTrades,
-      sampleSize: rawSampleSize,
+      includeSampleTrades,
+      sampleSize,
     }) => {
       try {
-        // Apply runtime defaults (Zod defaults don't always apply in MCP SDK)
-        const logic = rawLogic ?? "and";
-        const includeSampleTrades = rawIncludeSampleTrades ?? true;
-        const sampleSize = rawSampleSize ?? 5;
-
         const block = await loadBlock(baseDir, blockId);
         let trades = block.trades;
 
@@ -721,11 +716,8 @@ export function registerReportTools(server: McpServer, baseDir: string): void {
           .describe("Number of histogram buckets (default: 10)"),
       }),
     },
-    async ({ blockId, field, strategy, startDate, endDate, histogramBuckets: rawHistogramBuckets }) => {
+    async ({ blockId, field, strategy, startDate, endDate, histogramBuckets }) => {
       try {
-        // Apply runtime default (Zod defaults don't always apply in MCP SDK)
-        const histogramBuckets = rawHistogramBuckets ?? 10;
-
         const block = await loadBlock(baseDir, blockId);
         let trades = block.trades;
 
@@ -884,17 +876,13 @@ export function registerReportTools(server: McpServer, baseDir: string): void {
       blockId,
       groupByField,
       bucketEdges,
-      metrics: rawMetrics,
+      metrics,
       strategy,
       startDate,
       endDate,
-      includeOutOfRange: rawIncludeOutOfRange,
+      includeOutOfRange,
     }) => {
       try {
-        // Apply runtime defaults (Zod defaults don't always apply in MCP SDK)
-        const metrics = rawMetrics ?? ["count", "winRate", "avgPl", "totalPl"];
-        const includeOutOfRange = rawIncludeOutOfRange ?? true;
-
         const block = await loadBlock(baseDir, blockId);
         let trades = block.trades;
 
@@ -1139,16 +1127,11 @@ export function registerReportTools(server: McpServer, baseDir: string): void {
       strategy,
       startDate,
       endDate,
-      targetField: rawTargetField,
-      minSamples: rawMinSamples,
-      includeCustomFields: rawIncludeCustomFields,
+      targetField,
+      minSamples,
+      includeCustomFields,
     }) => {
       try {
-        // Apply defaults (Zod defaults don't always apply in MCP SDK)
-        const targetField = rawTargetField ?? "pl";
-        const minSamples = rawMinSamples ?? 30;
-        const includeCustomFields = rawIncludeCustomFields ?? true;
-
         const block = await loadBlock(baseDir, blockId);
         let trades = block.trades;
 
@@ -1396,18 +1379,14 @@ export function registerReportTools(server: McpServer, baseDir: string): void {
     async ({
       blockId,
       field,
-      mode: rawMode,
-      thresholds: rawThresholds,
-      percentileSteps: rawPercentileSteps,
+      mode,
+      thresholds,
+      percentileSteps,
       strategy,
       startDate,
       endDate,
     }) => {
       try {
-        // Apply runtime defaults (Zod defaults don't always apply in MCP SDK)
-        const mode = rawMode ?? "both";
-        const percentileSteps = rawPercentileSteps ?? [5, 10, 25, 50, 75, 90, 95];
-
         const block = await loadBlock(baseDir, blockId);
         let trades = block.trades;
 
@@ -1469,9 +1448,9 @@ export function registerReportTools(server: McpServer, baseDir: string): void {
         // Generate thresholds
         let thresholdsToTest: number[];
 
-        if (rawThresholds && rawThresholds.length > 0) {
+        if (thresholds && thresholds.length > 0) {
           // Use custom thresholds
-          thresholdsToTest = [...rawThresholds].sort((a, b) => a - b);
+          thresholdsToTest = [...thresholds].sort((a, b) => a - b);
         } else {
           // Auto-generate from percentiles
           const sorted = [...fieldValues].sort((a, b) => a - b);

--- a/packages/mcp-server/src/tools/reports.ts
+++ b/packages/mcp-server/src/tools/reports.ts
@@ -581,14 +581,19 @@ export function registerReportTools(server: McpServer, baseDir: string): void {
     async ({
       blockId,
       conditions,
-      logic,
+      logic: rawLogic,
       strategy,
       startDate,
       endDate,
-      includeSampleTrades,
-      sampleSize,
+      includeSampleTrades: rawIncludeSampleTrades,
+      sampleSize: rawSampleSize,
     }) => {
       try {
+        // Apply runtime defaults (Zod defaults don't always apply in MCP SDK)
+        const logic = rawLogic ?? "and";
+        const includeSampleTrades = rawIncludeSampleTrades ?? true;
+        const sampleSize = rawSampleSize ?? 5;
+
         const block = await loadBlock(baseDir, blockId);
         let trades = block.trades;
 

--- a/packages/mcp-server/src/tools/reports.ts
+++ b/packages/mcp-server/src/tools/reports.ts
@@ -721,8 +721,11 @@ export function registerReportTools(server: McpServer, baseDir: string): void {
           .describe("Number of histogram buckets (default: 10)"),
       }),
     },
-    async ({ blockId, field, strategy, startDate, endDate, histogramBuckets }) => {
+    async ({ blockId, field, strategy, startDate, endDate, histogramBuckets: rawHistogramBuckets }) => {
       try {
+        // Apply runtime default (Zod defaults don't always apply in MCP SDK)
+        const histogramBuckets = rawHistogramBuckets ?? 10;
+
         const block = await loadBlock(baseDir, blockId);
         let trades = block.trades;
 


### PR DESCRIPTION
## Summary

- Added `find_predictive_fields` MCP tool - Pearson correlation analysis ranking all numeric fields by P/L predictive strength
- Added `filter_curve` MCP tool - Threshold sweeping with bidirectional analysis (lt/gt/both), auto-generated percentile thresholds, and sweet spot detection
- Fixed CLI `--call` mode to apply Zod schema parsing, eliminating runtime default workarounds across all tools
- Bumped MCP server version to 0.3.0

## Test plan

- [x] CLI test verification for `find_predictive_fields` - returns ranked correlations
- [x] CLI test verification for `filter_curve` - returns threshold curves and sweet spots
- [x] Verified Zod defaults now apply correctly in CLI mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)