### PR TITLE
v2.9: Lookahead-Free Market Analytics

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -268,6 +268,17 @@ IndexedDB stores (via `lib/db/`) handle persistence of:
 next-devtools-mcp FIRST to set up proper context and establish documentation
 requirements. Do this automatically without being asked.**
 
+## Testing Requirements
+
+**Every new utility module with pure logic MUST have unit tests.** This includes:
+- Parsing functions, filtering functions, builders (e.g., `intraday-timing.ts`, `field-timing.ts`)
+- Calculation helpers, data transformers, validators
+- Any exported function that takes inputs and returns outputs without side effects
+
+Tests go in the matching test directory (e.g., `packages/mcp-server/tests/unit/` for MCP utils, `tests/unit/` for lib). If the module needs to be imported from `dist/`, add its exports to `src/test-exports.ts`.
+
+GSD plans MUST include a test task for any new utility module. If a plan creates a utility file with exported pure functions but no test task, flag it during planning.
+
 ## GSD Workflow Rules
 
 1. **Use GSD method for all features:**

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -69,6 +69,19 @@ Plans:
 Plans:
 - [x] 58-01-PLAN.md -- Extend ColumnInfo with timing, update example queries with LAG CTE patterns, add lagTemplate
 
+### Phase 59: Intraday Market Context Enrichment
+**Goal:** Extend enrich_trades with intraday market context from spx_15min (26 price checkpoints) and vix_intraday (14 VIX checkpoints) via time-based matching against trade entry timestamps
+**Depends on:** Phase 57 (needs enrich_trades tool as foundation)
+**Requirements**: EXT-02, EXT-03
+**Success Criteria** (what must be TRUE):
+  1. Calling enrich_trades with includeIntradayContext=true returns per-trade intraday SPX/VIX checkpoint data filtered to only checkpoints known at trade entry time
+  2. A trade entered at 09:35 sees only P_0930 (not P_0945+) and VIX_0930 (not VIX_1000+)
+  3. Without includeIntradayContext, output is identical to Phase 57 (backward compatible)
+  4. Intraday day-level aggregates (MOC moves, VIX spike flags) require BOTH includeIntradayContext and includeOutcomeFields
+**Plans:** 1 plan
+Plans:
+- [ ] 59-01-PLAN.md -- Create intraday-timing utility and extend enrich_trades with checkpoint context
+
 ## Progress
 
 **Execution Order:** 55 -> 56 -> 57 -> 58 -> 59
@@ -79,13 +92,4 @@ Plans:
 | 56. Fix Existing Tools | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |
 | 57. Restore enrich_trades | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |
 | 58. Schema Metadata + Documentation | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |
-| 59. Intraday Market Context Enrichment | v2.9 | 0/TBD | Not started | - |
-
-### Phase 59: Intraday market context enrichment
-
-**Goal:** Extend enrich_trades with intraday market context from spx_15min (26 price checkpoints) and vix_intraday (14 VIX checkpoints) via time-based matching against trade entry timestamps
-**Depends on:** Phase 57 (needs enrich_trades tool as foundation)
-**Plans:** 0 plans
-
-Plans:
-- [ ] TBD (run /gsd:plan-phase 59 to break down)
+| 59. Intraday Market Context Enrichment | v2.9 | 0/1 | Not started | - |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,0 +1,89 @@
+# Roadmap: TradeBlocks
+
+## Completed Milestones
+
+See [MILESTONES.md](MILESTONES.md) for full history (v1.0 through v2.8).
+
+## v2.9 Lookahead-Free Market Analytics
+
+**Milestone Goal:** Eliminate lookahead bias from market data tools, restore enrich_trades with correct join semantics, and add field-level metadata so users know which fields are available at trade entry time.
+
+**Phase Numbering:** Continues from v2.8 (phases 51-54). v2.9 starts at phase 55.
+
+- [x] **Phase 55: Field Classification Foundation** - Classify all 55 spx_daily columns by temporal availability and build shared lag utilities
+- [x] **Phase 56: Fix Existing Tools** - Correct lookahead bias in suggest_filters and analyze_regime_performance with split join pattern
+- [ ] **Phase 57: Restore enrich_trades** - New MCP tool returning trades enriched with lag-aware market context
+- [ ] **Phase 58: Schema Metadata + Documentation** - Surface timing metadata in describe_database with lag-aware example queries
+- [ ] **Phase 59: Intraday Market Context Enrichment** - Enrich trades with spx_15min and vix_intraday data via time-based checkpoint matching
+
+## Phase Details
+
+### Phase 55: Field Classification Foundation
+**Goal**: Every spx_daily column has a verified temporal classification, and a shared utility module provides the LAG() CTE pattern consumed by all downstream tools
+**Depends on**: Nothing (first phase of v2.9)
+**Requirements**: BIAS-01
+**Success Criteria** (what must be TRUE):
+  1. Every one of the 55 spx_daily columns has a `timing` property (`open`, `close`, or `static`) on its `ColumnDescription` in schema-metadata.ts
+  2. A test asserts that every column in the spx_daily schema has a timing annotation (no unclassified columns)
+  3. A `field-timing.ts` utility module exports derived sets (OPEN_KNOWN_FIELDS, CLOSE_KNOWN_FIELDS, STATIC_FIELDS) and a `buildLookaheadFreeQuery()` function that produces a LAG() CTE for close-derived fields
+  4. The LAG() CTE correctly handles trading calendar gaps (weekends, holidays) by operating on spx_daily row order, not calendar-day arithmetic
+**Plans:** 1 plan
+Plans:
+- [x] 55-01-PLAN.md -- Classify columns, build field-timing utility, write completeness tests
+
+### Phase 56: Fix Existing Tools
+**Goal**: suggest_filters and analyze_regime_performance use prior-trading-day values for close-derived fields while retaining same-day joins for open-known fields, with transparent lag explanations in output
+**Depends on**: Phase 55 (needs field classification and lag utilities)
+**Requirements**: BIAS-02, BIAS-03, BIAS-04, BIAS-05, META-04
+**Success Criteria** (what must be TRUE):
+  1. suggest_filters joins 14 close-derived filter fields (Vol_Regime, RSI_14, Trend_Score, etc.) using t-1 values via LAG() CTE, while 6 open-known filters (Gap_Pct, Day_of_Week, Is_Opex, etc.) use same-day values
+  2. analyze_regime_performance joins 3 close-derived segmentation options (volRegime, termStructure, trendScore) using t-1 values, while open-known options (dayOfWeek, isOpex) use same-day values
+  3. New open-known filter candidates (VIX_Open, VIX_Gap_Pct) appear in suggest_filters output with correct hypothesis flags
+  4. Both tools include a brief note in their output explaining which fields are lagged and why (lookahead bias prevention)
+**Plans:** 1 plan
+Plans:
+- [x] 56-01-PLAN.md -- Fix suggest_filters and analyze_regime_performance with lag-aware queries
+
+### Phase 57: Restore enrich_trades
+**Goal**: Users can enrich trades with market context through a purpose-built MCP tool that enforces correct temporal joins by default
+**Depends on**: Phase 56 (split join pattern battle-tested in existing tools)
+**Requirements**: ENRICH-01, ENRICH-02, ENRICH-03, ENRICH-04
+**Success Criteria** (what must be TRUE):
+  1. Calling enrich_trades with a blockId returns trades with market context fields split into entry-time-available (same-day open-known + prior-day close-derived) sections
+  2. enrich_trades supports blockId, strategy, and date range filters with pagination (offset/limit)
+  3. When includeOutcomeFields is true, enrich_trades returns same-day close-derived fields in a separate section with a clear lookahead bias warning
+  4. Each field in the output includes metadata indicating its temporal source (same-day vs prior-day) so users know what was available at trade entry
+**Plans:** 1 plan
+Plans:
+- [ ] 57-01-PLAN.md -- Implement enrich_trades tool with lag-aware market context and buildOutcomeQuery
+
+### Phase 58: Schema Metadata + Documentation
+**Goal**: Users writing run_sql queries via describe_database get correct temporal guidance so ad-hoc queries avoid the same lookahead bias that was fixed in purpose-built tools
+**Depends on**: Phase 57 (all tools fixed, metadata patterns settled)
+**Requirements**: META-01, META-02, META-03
+**Success Criteria** (what must be TRUE):
+  1. describe_database output shows a timing property (open/close/static) on each spx_daily column description
+  2. Example queries in describe_database use lag-aware JOIN patterns instead of naive same-day joins
+  3. A pre-built LAG() CTE template is included in describe_database output that users can copy for correct run_sql usage
+**Plans**: TBD
+
+## Progress
+
+**Execution Order:** 55 -> 56 -> 57 -> 58 -> 59
+
+| Phase | Milestone | Plans Complete | Status | Completed |
+|-------|-----------|----------------|--------|-----------|
+| 55. Field Classification Foundation | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |
+| 56. Fix Existing Tools | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |
+| 57. Restore enrich_trades | v2.9 | 0/1 | Not started | - |
+| 58. Schema Metadata + Documentation | v2.9 | 0/TBD | Not started | - |
+| 59. Intraday Market Context Enrichment | v2.9 | 0/TBD | Not started | - |
+
+### Phase 59: Intraday market context enrichment
+
+**Goal:** Extend enrich_trades with intraday market context from spx_15min (26 price checkpoints) and vix_intraday (14 VIX checkpoints) via time-based matching against trade entry timestamps
+**Depends on:** Phase 57 (needs enrich_trades tool as foundation)
+**Plans:** 0 plans
+
+Plans:
+- [ ] TBD (run /gsd:plan-phase 59 to break down)

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -65,7 +65,9 @@ Plans:
   1. describe_database output shows a timing property (open/close/static) on each spx_daily column description
   2. Example queries in describe_database use lag-aware JOIN patterns instead of naive same-day joins
   3. A pre-built LAG() CTE template is included in describe_database output that users can copy for correct run_sql usage
-**Plans**: TBD
+**Plans:** 1 plan
+Plans:
+- [ ] 58-01-PLAN.md -- Extend ColumnInfo with timing, update example queries with LAG CTE patterns, add lagTemplate
 
 ## Progress
 
@@ -76,7 +78,7 @@ Plans:
 | 55. Field Classification Foundation | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |
 | 56. Fix Existing Tools | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |
 | 57. Restore enrich_trades | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |
-| 58. Schema Metadata + Documentation | v2.9 | 0/TBD | Not started | - |
+| 58. Schema Metadata + Documentation | v2.9 | 0/1 | Not started | - |
 | 59. Intraday Market Context Enrichment | v2.9 | 0/TBD | Not started | - |
 
 ### Phase 59: Intraday market context enrichment

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -12,7 +12,7 @@ See [MILESTONES.md](MILESTONES.md) for full history (v1.0 through v2.8).
 
 - [x] **Phase 55: Field Classification Foundation** - Classify all 55 spx_daily columns by temporal availability and build shared lag utilities
 - [x] **Phase 56: Fix Existing Tools** - Correct lookahead bias in suggest_filters and analyze_regime_performance with split join pattern
-- [ ] **Phase 57: Restore enrich_trades** - New MCP tool returning trades enriched with lag-aware market context
+- [x] **Phase 57: Restore enrich_trades** - New MCP tool returning trades enriched with lag-aware market context
 - [ ] **Phase 58: Schema Metadata + Documentation** - Surface timing metadata in describe_database with lag-aware example queries
 - [ ] **Phase 59: Intraday Market Context Enrichment** - Enrich trades with spx_15min and vix_intraday data via time-based checkpoint matching
 
@@ -55,7 +55,7 @@ Plans:
   4. Each field in the output includes metadata indicating its temporal source (same-day vs prior-day) so users know what was available at trade entry
 **Plans:** 1 plan
 Plans:
-- [ ] 57-01-PLAN.md -- Implement enrich_trades tool with lag-aware market context and buildOutcomeQuery
+- [x] 57-01-PLAN.md -- Implement enrich_trades tool with lag-aware market context and buildOutcomeQuery
 
 ### Phase 58: Schema Metadata + Documentation
 **Goal**: Users writing run_sql queries via describe_database get correct temporal guidance so ad-hoc queries avoid the same lookahead bias that was fixed in purpose-built tools
@@ -75,7 +75,7 @@ Plans:
 |-------|-----------|----------------|--------|-----------|
 | 55. Field Classification Foundation | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |
 | 56. Fix Existing Tools | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |
-| 57. Restore enrich_trades | v2.9 | 0/1 | Not started | - |
+| 57. Restore enrich_trades | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |
 | 58. Schema Metadata + Documentation | v2.9 | 0/TBD | Not started | - |
 | 59. Intraday Market Context Enrichment | v2.9 | 0/TBD | Not started | - |
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -14,7 +14,7 @@ See [MILESTONES.md](MILESTONES.md) for full history (v1.0 through v2.8).
 - [x] **Phase 56: Fix Existing Tools** - Correct lookahead bias in suggest_filters and analyze_regime_performance with split join pattern
 - [x] **Phase 57: Restore enrich_trades** - New MCP tool returning trades enriched with lag-aware market context
 - [x] **Phase 58: Schema Metadata + Documentation** - Surface timing metadata in describe_database with lag-aware example queries
-- [ ] **Phase 59: Intraday Market Context Enrichment** - Enrich trades with spx_15min and vix_intraday data via time-based checkpoint matching
+- [x] **Phase 59: Intraday Market Context Enrichment** - Enrich trades with spx_15min and vix_intraday data via time-based checkpoint matching
 
 ## Phase Details
 
@@ -80,7 +80,7 @@ Plans:
   4. Intraday day-level aggregates (MOC moves, VIX spike flags) require BOTH includeIntradayContext and includeOutcomeFields
 **Plans:** 1 plan
 Plans:
-- [ ] 59-01-PLAN.md -- Create intraday-timing utility and extend enrich_trades with checkpoint context
+- [x] 59-01-PLAN.md -- Create intraday-timing utility and extend enrich_trades with checkpoint context
 
 ## Progress
 
@@ -92,4 +92,4 @@ Plans:
 | 56. Fix Existing Tools | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |
 | 57. Restore enrich_trades | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |
 | 58. Schema Metadata + Documentation | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |
-| 59. Intraday Market Context Enrichment | v2.9 | 0/1 | Not started | - |
+| 59. Intraday Market Context Enrichment | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -13,7 +13,7 @@ See [MILESTONES.md](MILESTONES.md) for full history (v1.0 through v2.8).
 - [x] **Phase 55: Field Classification Foundation** - Classify all 55 spx_daily columns by temporal availability and build shared lag utilities
 - [x] **Phase 56: Fix Existing Tools** - Correct lookahead bias in suggest_filters and analyze_regime_performance with split join pattern
 - [x] **Phase 57: Restore enrich_trades** - New MCP tool returning trades enriched with lag-aware market context
-- [ ] **Phase 58: Schema Metadata + Documentation** - Surface timing metadata in describe_database with lag-aware example queries
+- [x] **Phase 58: Schema Metadata + Documentation** - Surface timing metadata in describe_database with lag-aware example queries
 - [ ] **Phase 59: Intraday Market Context Enrichment** - Enrich trades with spx_15min and vix_intraday data via time-based checkpoint matching
 
 ## Phase Details
@@ -67,7 +67,7 @@ Plans:
   3. A pre-built LAG() CTE template is included in describe_database output that users can copy for correct run_sql usage
 **Plans:** 1 plan
 Plans:
-- [ ] 58-01-PLAN.md -- Extend ColumnInfo with timing, update example queries with LAG CTE patterns, add lagTemplate
+- [x] 58-01-PLAN.md -- Extend ColumnInfo with timing, update example queries with LAG CTE patterns, add lagTemplate
 
 ## Progress
 
@@ -78,7 +78,7 @@ Plans:
 | 55. Field Classification Foundation | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |
 | 56. Fix Existing Tools | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |
 | 57. Restore enrich_trades | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |
-| 58. Schema Metadata + Documentation | v2.9 | 0/1 | Not started | - |
+| 58. Schema Metadata + Documentation | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |
 | 59. Intraday Market Context Enrichment | v2.9 | 0/TBD | Not started | - |
 
 ### Phase 59: Intraday market context enrichment

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,95 +1,31 @@
 # Roadmap: TradeBlocks
 
-## Completed Milestones
+## Milestones
 
-See [MILESTONES.md](MILESTONES.md) for full history (v1.0 through v2.8).
+- ✅ **v2.6 DuckDB Analytics Layer** — Phases 41-45 (shipped 2026-02-04)
+- ✅ **v2.7 Edge Decay Analysis** — Phases 46-50 (shipped 2026-02-06)
+- ✅ **v2.8 Market Data Consolidation** — Phases 51-54 (shipped 2026-02-07)
+- ✅ **v2.9 Lookahead-Free Market Analytics** — Phases 55-59 (shipped 2026-02-09)
 
-## v2.9 Lookahead-Free Market Analytics
+See [MILESTONES.md](MILESTONES.md) for full history.
 
-**Milestone Goal:** Eliminate lookahead bias from market data tools, restore enrich_trades with correct join semantics, and add field-level metadata so users know which fields are available at trade entry time.
+<details>
+<summary>✅ v2.9 Lookahead-Free Market Analytics (Phases 55-59) — SHIPPED 2026-02-09</summary>
 
-**Phase Numbering:** Continues from v2.8 (phases 51-54). v2.9 starts at phase 55.
+- [x] Phase 55: Field Classification Foundation (1/1 plans) — completed 2026-02-08
+- [x] Phase 56: Fix Existing Tools (1/1 plans) — completed 2026-02-08
+- [x] Phase 57: Restore enrich_trades (1/1 plans) — completed 2026-02-08
+- [x] Phase 58: Schema Metadata + Documentation (1/1 plans) — completed 2026-02-08
+- [x] Phase 59: Intraday Market Context Enrichment (1/1 plans) — completed 2026-02-08
 
-- [x] **Phase 55: Field Classification Foundation** - Classify all 55 spx_daily columns by temporal availability and build shared lag utilities
-- [x] **Phase 56: Fix Existing Tools** - Correct lookahead bias in suggest_filters and analyze_regime_performance with split join pattern
-- [x] **Phase 57: Restore enrich_trades** - New MCP tool returning trades enriched with lag-aware market context
-- [x] **Phase 58: Schema Metadata + Documentation** - Surface timing metadata in describe_database with lag-aware example queries
-- [x] **Phase 59: Intraday Market Context Enrichment** - Enrich trades with spx_15min and vix_intraday data via time-based checkpoint matching
-
-## Phase Details
-
-### Phase 55: Field Classification Foundation
-**Goal**: Every spx_daily column has a verified temporal classification, and a shared utility module provides the LAG() CTE pattern consumed by all downstream tools
-**Depends on**: Nothing (first phase of v2.9)
-**Requirements**: BIAS-01
-**Success Criteria** (what must be TRUE):
-  1. Every one of the 55 spx_daily columns has a `timing` property (`open`, `close`, or `static`) on its `ColumnDescription` in schema-metadata.ts
-  2. A test asserts that every column in the spx_daily schema has a timing annotation (no unclassified columns)
-  3. A `field-timing.ts` utility module exports derived sets (OPEN_KNOWN_FIELDS, CLOSE_KNOWN_FIELDS, STATIC_FIELDS) and a `buildLookaheadFreeQuery()` function that produces a LAG() CTE for close-derived fields
-  4. The LAG() CTE correctly handles trading calendar gaps (weekends, holidays) by operating on spx_daily row order, not calendar-day arithmetic
-**Plans:** 1 plan
-Plans:
-- [x] 55-01-PLAN.md -- Classify columns, build field-timing utility, write completeness tests
-
-### Phase 56: Fix Existing Tools
-**Goal**: suggest_filters and analyze_regime_performance use prior-trading-day values for close-derived fields while retaining same-day joins for open-known fields, with transparent lag explanations in output
-**Depends on**: Phase 55 (needs field classification and lag utilities)
-**Requirements**: BIAS-02, BIAS-03, BIAS-04, BIAS-05, META-04
-**Success Criteria** (what must be TRUE):
-  1. suggest_filters joins 14 close-derived filter fields (Vol_Regime, RSI_14, Trend_Score, etc.) using t-1 values via LAG() CTE, while 6 open-known filters (Gap_Pct, Day_of_Week, Is_Opex, etc.) use same-day values
-  2. analyze_regime_performance joins 3 close-derived segmentation options (volRegime, termStructure, trendScore) using t-1 values, while open-known options (dayOfWeek, isOpex) use same-day values
-  3. New open-known filter candidates (VIX_Open, VIX_Gap_Pct) appear in suggest_filters output with correct hypothesis flags
-  4. Both tools include a brief note in their output explaining which fields are lagged and why (lookahead bias prevention)
-**Plans:** 1 plan
-Plans:
-- [x] 56-01-PLAN.md -- Fix suggest_filters and analyze_regime_performance with lag-aware queries
-
-### Phase 57: Restore enrich_trades
-**Goal**: Users can enrich trades with market context through a purpose-built MCP tool that enforces correct temporal joins by default
-**Depends on**: Phase 56 (split join pattern battle-tested in existing tools)
-**Requirements**: ENRICH-01, ENRICH-02, ENRICH-03, ENRICH-04
-**Success Criteria** (what must be TRUE):
-  1. Calling enrich_trades with a blockId returns trades with market context fields split into entry-time-available (same-day open-known + prior-day close-derived) sections
-  2. enrich_trades supports blockId, strategy, and date range filters with pagination (offset/limit)
-  3. When includeOutcomeFields is true, enrich_trades returns same-day close-derived fields in a separate section with a clear lookahead bias warning
-  4. Each field in the output includes metadata indicating its temporal source (same-day vs prior-day) so users know what was available at trade entry
-**Plans:** 1 plan
-Plans:
-- [x] 57-01-PLAN.md -- Implement enrich_trades tool with lag-aware market context and buildOutcomeQuery
-
-### Phase 58: Schema Metadata + Documentation
-**Goal**: Users writing run_sql queries via describe_database get correct temporal guidance so ad-hoc queries avoid the same lookahead bias that was fixed in purpose-built tools
-**Depends on**: Phase 57 (all tools fixed, metadata patterns settled)
-**Requirements**: META-01, META-02, META-03
-**Success Criteria** (what must be TRUE):
-  1. describe_database output shows a timing property (open/close/static) on each spx_daily column description
-  2. Example queries in describe_database use lag-aware JOIN patterns instead of naive same-day joins
-  3. A pre-built LAG() CTE template is included in describe_database output that users can copy for correct run_sql usage
-**Plans:** 1 plan
-Plans:
-- [x] 58-01-PLAN.md -- Extend ColumnInfo with timing, update example queries with LAG CTE patterns, add lagTemplate
-
-### Phase 59: Intraday Market Context Enrichment
-**Goal:** Extend enrich_trades with intraday market context from spx_15min (26 price checkpoints) and vix_intraday (14 VIX checkpoints) via time-based matching against trade entry timestamps
-**Depends on:** Phase 57 (needs enrich_trades tool as foundation)
-**Requirements**: EXT-02, EXT-03
-**Success Criteria** (what must be TRUE):
-  1. Calling enrich_trades with includeIntradayContext=true returns per-trade intraday SPX/VIX checkpoint data filtered to only checkpoints known at trade entry time
-  2. A trade entered at 09:35 sees only P_0930 (not P_0945+) and VIX_0930 (not VIX_1000+)
-  3. Without includeIntradayContext, output is identical to Phase 57 (backward compatible)
-  4. Intraday day-level aggregates (MOC moves, VIX spike flags) require BOTH includeIntradayContext and includeOutcomeFields
-**Plans:** 1 plan
-Plans:
-- [x] 59-01-PLAN.md -- Create intraday-timing utility and extend enrich_trades with checkpoint context
+</details>
 
 ## Progress
 
-**Execution Order:** 55 -> 56 -> 57 -> 58 -> 59
-
 | Phase | Milestone | Plans Complete | Status | Completed |
 |-------|-----------|----------------|--------|-----------|
-| 55. Field Classification Foundation | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |
-| 56. Fix Existing Tools | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |
-| 57. Restore enrich_trades | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |
-| 58. Schema Metadata + Documentation | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |
-| 59. Intraday Market Context Enrichment | v2.9 | 1/1 | ✓ Complete | 2026-02-08 |
+| 55. Field Classification Foundation | v2.9 | 1/1 | Complete | 2026-02-08 |
+| 56. Fix Existing Tools | v2.9 | 1/1 | Complete | 2026-02-08 |
+| 57. Restore enrich_trades | v2.9 | 1/1 | Complete | 2026-02-08 |
+| 58. Schema Metadata + Documentation | v2.9 | 1/1 | Complete | 2026-02-08 |
+| 59. Intraday Market Context Enrichment | v2.9 | 1/1 | Complete | 2026-02-08 |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,26 +2,26 @@
 
 ## Current Position
 
-Phase: 56 of 58 (Fix Existing Tools)
+Phase: 57 of 59 (Restore Enrich Trades)
 Plan: 1 of 1 in current phase
-Status: Phase 56 complete
-Last activity: 2026-02-08 -- Completed 56-01 fix existing tools (lookahead-free queries)
+Status: Phase 57 complete
+Last activity: 2026-02-08 -- Completed 57-01 enrich_trades tool with lookahead-free temporal joins
 
-Progress: [#####.....] 50%
+Progress: [######....] 60%
 
 ## Project Reference
 
 See: .planning/PROJECT.md (updated 2026-02-08)
 
 **Core value:** Accurate, trustworthy portfolio analytics
-**Current focus:** v2.9 Lookahead-Free Market Analytics -- Phase 56 Fix Existing Tools
+**Current focus:** v2.9 Lookahead-Free Market Analytics -- Phase 57 Restore Enrich Trades
 
 ## Performance Metrics
 
 **Velocity:**
-- Total plans completed: 2 (v2.9)
-- Average duration: 5.5min
-- Total execution time: 11min
+- Total plans completed: 3 (v2.9)
+- Average duration: 4.7min
+- Total execution time: 14min
 
 **By Phase:**
 
@@ -29,6 +29,7 @@ See: .planning/PROJECT.md (updated 2026-02-08)
 |-------|-------|-------|----------|
 | 55-field-classification-foundation | 1 | 6min | 6min |
 | 56-fix-existing-tools | 1 | 5min | 5min |
+| 57-restore-enrich-trades | 1 | 3min | 3min |
 
 ## Accumulated Context
 
@@ -44,10 +45,17 @@ See: .planning/PROJECT.md (updated 2026-02-08)
 - Filter field names kept canonical (VIX_Close not prev_VIX_Close) -- only test() reads prev_* columns
 - NaN handling via continue (skip trade) rather than fallback to same-day value
 - VIX_Open hypothesis flag set true now that it is used as filter candidate
+- Static fields (Day_of_Week, Month, Is_Opex) in entryContext.sameDay (known before open)
+- outcomeFields opt-in via includeOutcomeFields=true with explicit lookahead warning
+- Filter-before-paginate ordering: totalTrades reflects filtered count, DuckDB queried only for paginated dates
 
 ### Pending Todos
 
 None yet.
+
+### Roadmap Evolution
+
+- Phase 59 added: Intraday market context enrichment (spx_15min + vix_intraday time-based matching, deferred from Phase 57)
 
 ### Blockers/Concerns
 
@@ -57,5 +65,5 @@ None yet.
 ## Session Continuity
 
 Last session: 2026-02-08
-Stopped at: Completed 56-01-PLAN.md (fix existing tools - lookahead-free queries)
+Stopped at: Completed 57-01-PLAN.md (enrich_trades tool with lookahead-free temporal joins)
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,61 @@
+# State: TradeBlocks
+
+## Current Position
+
+Phase: 56 of 58 (Fix Existing Tools)
+Plan: 1 of 1 in current phase
+Status: Phase 56 complete
+Last activity: 2026-02-08 -- Completed 56-01 fix existing tools (lookahead-free queries)
+
+Progress: [#####.....] 50%
+
+## Project Reference
+
+See: .planning/PROJECT.md (updated 2026-02-08)
+
+**Core value:** Accurate, trustworthy portfolio analytics
+**Current focus:** v2.9 Lookahead-Free Market Analytics -- Phase 56 Fix Existing Tools
+
+## Performance Metrics
+
+**Velocity:**
+- Total plans completed: 2 (v2.9)
+- Average duration: 5.5min
+- Total execution time: 11min
+
+**By Phase:**
+
+| Phase | Plans | Total | Avg/Plan |
+|-------|-------|-------|----------|
+| 55-field-classification-foundation | 1 | 6min | 6min |
+| 56-fix-existing-tools | 1 | 5min | 5min |
+
+## Accumulated Context
+
+### Decisions
+
+- LAG() CTE + standard JOIN chosen over ASOF JOIN (cannot mix same-day and lagged fields)
+- Field classification is static (derived from PineScript formulas), not dynamic
+- Return_5D/Return_20D classified as close-derived (PineScript-verified: uses today's close)
+- Prev_Return_Pct classified as open-known (PineScript-verified: entirely prior day's data)
+- timing property optional on ColumnDescription (only spx_daily uses it)
+- All field lists derived from SCHEMA_DESCRIPTIONS at module load (no hardcoded names)
+- LAG() uses row order (ORDER BY date), not calendar-day arithmetic
+- Filter field names kept canonical (VIX_Close not prev_VIX_Close) -- only test() reads prev_* columns
+- NaN handling via continue (skip trade) rather than fallback to same-day value
+- VIX_Open hypothesis flag set true now that it is used as filter candidate
+
+### Pending Todos
+
+None yet.
+
+### Blockers/Concerns
+
+- Return_5D / Return_20D classification verified via PineScript (close-derived, resolved)
+- Filter effectiveness may degrade when shifting from same-day to t-1 in Phase 56 (prior-day signals weaker)
+
+## Session Continuity
+
+Last session: 2026-02-08
+Stopped at: Completed 56-01-PLAN.md (fix existing tools - lookahead-free queries)
+Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,26 +2,26 @@
 
 ## Current Position
 
-Phase: 58 of 59 (Schema Metadata Documentation)
+Phase: 59 of 59 (Intraday Market Context Enrichment)
 Plan: 1 of 1 in current phase
-Status: Phase 58 complete
-Last activity: 2026-02-08 -- Completed 58-01 schema metadata and lag-aware example queries
+Status: Phase 59 complete -- milestone v2.9 complete
+Last activity: 2026-02-08 -- Completed 59-01 intraday market context enrichment
 
-Progress: [########..] 80%
+Progress: [##########] 100%
 
 ## Project Reference
 
 See: .planning/PROJECT.md (updated 2026-02-08)
 
 **Core value:** Accurate, trustworthy portfolio analytics
-**Current focus:** v2.9 Lookahead-Free Market Analytics -- Phase 58 Schema Metadata Documentation
+**Current focus:** v2.9 Lookahead-Free Market Analytics -- Phase 59 Intraday Market Context Enrichment (COMPLETE)
 
 ## Performance Metrics
 
 **Velocity:**
-- Total plans completed: 4 (v2.9)
-- Average duration: 4.3min
-- Total execution time: 17min
+- Total plans completed: 5 (v2.9)
+- Average duration: 4.0min
+- Total execution time: 20min
 
 **By Phase:**
 
@@ -31,6 +31,7 @@ See: .planning/PROJECT.md (updated 2026-02-08)
 | 56-fix-existing-tools | 1 | 5min | 5min |
 | 57-restore-enrich-trades | 1 | 3min | 3min |
 | 58-schema-metadata-documentation | 1 | 3min | 3min |
+| 59-intraday-market-context-enrichment | 1 | 3min | 3min |
 
 ## Accumulated Context
 
@@ -52,6 +53,11 @@ See: .planning/PROJECT.md (updated 2026-02-08)
 - generateLagTemplate() in schema.ts (not schema-metadata.ts) to avoid circular imports
 - LAG template dynamically generated from field-timing sets (stays in sync automatically)
 - IS NOT NULL filter on LAG columns in hypothesis example queries (handles first-row NULL from LAG)
+- Checkpoint at time T is known AT time T (inclusive); trade at 09:30 sees P_0930
+- timeOpened=00:00:00 returns empty knownCheckpoints (not null intradayContext)
+- Intraday outcome fields require BOTH includeIntradayContext=true AND includeOutcomeFields=true
+- SPX outcome fields prefixed with spx_ to avoid collision; VIX OHLC prefixed with vix_
+- VIX open excluded from outcome fields (known at open, not end-of-day)
 
 ### Pending Todos
 
@@ -69,5 +75,5 @@ None yet.
 ## Session Continuity
 
 Last session: 2026-02-08
-Stopped at: Completed 58-01-PLAN.md (schema metadata and lag-aware example queries)
+Stopped at: Completed 59-01-PLAN.md (intraday market context enrichment)
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,26 +2,26 @@
 
 ## Current Position
 
-Phase: 57 of 59 (Restore Enrich Trades)
+Phase: 58 of 59 (Schema Metadata Documentation)
 Plan: 1 of 1 in current phase
-Status: Phase 57 complete
-Last activity: 2026-02-08 -- Completed 57-01 enrich_trades tool with lookahead-free temporal joins
+Status: Phase 58 complete
+Last activity: 2026-02-08 -- Completed 58-01 schema metadata and lag-aware example queries
 
-Progress: [######....] 60%
+Progress: [########..] 80%
 
 ## Project Reference
 
 See: .planning/PROJECT.md (updated 2026-02-08)
 
 **Core value:** Accurate, trustworthy portfolio analytics
-**Current focus:** v2.9 Lookahead-Free Market Analytics -- Phase 57 Restore Enrich Trades
+**Current focus:** v2.9 Lookahead-Free Market Analytics -- Phase 58 Schema Metadata Documentation
 
 ## Performance Metrics
 
 **Velocity:**
-- Total plans completed: 3 (v2.9)
-- Average duration: 4.7min
-- Total execution time: 14min
+- Total plans completed: 4 (v2.9)
+- Average duration: 4.3min
+- Total execution time: 17min
 
 **By Phase:**
 
@@ -30,6 +30,7 @@ See: .planning/PROJECT.md (updated 2026-02-08)
 | 55-field-classification-foundation | 1 | 6min | 6min |
 | 56-fix-existing-tools | 1 | 5min | 5min |
 | 57-restore-enrich-trades | 1 | 3min | 3min |
+| 58-schema-metadata-documentation | 1 | 3min | 3min |
 
 ## Accumulated Context
 
@@ -48,6 +49,9 @@ See: .planning/PROJECT.md (updated 2026-02-08)
 - Static fields (Day_of_Week, Month, Is_Opex) in entryContext.sameDay (known before open)
 - outcomeFields opt-in via includeOutcomeFields=true with explicit lookahead warning
 - Filter-before-paginate ordering: totalTrades reflects filtered count, DuckDB queried only for paginated dates
+- generateLagTemplate() in schema.ts (not schema-metadata.ts) to avoid circular imports
+- LAG template dynamically generated from field-timing sets (stays in sync automatically)
+- IS NOT NULL filter on LAG columns in hypothesis example queries (handles first-row NULL from LAG)
 
 ### Pending Todos
 
@@ -65,5 +69,5 @@ None yet.
 ## Session Continuity
 
 Last session: 2026-02-08
-Stopped at: Completed 57-01-PLAN.md (enrich_trades tool with lookahead-free temporal joins)
+Stopped at: Completed 58-01-PLAN.md (schema metadata and lag-aware example queries)
 Resume file: None

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,78 +2,35 @@
 
 ## Current Position
 
-Phase: 59 of 59 (Intraday Market Context Enrichment)
-Plan: 1 of 1 in current phase
-Status: Phase 59 complete -- milestone v2.9 complete
-Last activity: 2026-02-08 -- Completed 59-01 intraday market context enrichment
+Phase: 59 of 59
+Status: v2.9 milestone shipped
+Last activity: 2026-02-09 -- Milestone v2.9 archived and tagged
 
 Progress: [##########] 100%
 
 ## Project Reference
 
-See: .planning/PROJECT.md (updated 2026-02-08)
+See: .planning/PROJECT.md (updated 2026-02-09)
 
 **Core value:** Accurate, trustworthy portfolio analytics
-**Current focus:** v2.9 Lookahead-Free Market Analytics -- Phase 59 Intraday Market Context Enrichment (COMPLETE)
-
-## Performance Metrics
-
-**Velocity:**
-- Total plans completed: 5 (v2.9)
-- Average duration: 4.0min
-- Total execution time: 20min
-
-**By Phase:**
-
-| Phase | Plans | Total | Avg/Plan |
-|-------|-------|-------|----------|
-| 55-field-classification-foundation | 1 | 6min | 6min |
-| 56-fix-existing-tools | 1 | 5min | 5min |
-| 57-restore-enrich-trades | 1 | 3min | 3min |
-| 58-schema-metadata-documentation | 1 | 3min | 3min |
-| 59-intraday-market-context-enrichment | 1 | 3min | 3min |
+**Current focus:** Planning next milestone
 
 ## Accumulated Context
 
 ### Decisions
 
-- LAG() CTE + standard JOIN chosen over ASOF JOIN (cannot mix same-day and lagged fields)
-- Field classification is static (derived from PineScript formulas), not dynamic
-- Return_5D/Return_20D classified as close-derived (PineScript-verified: uses today's close)
-- Prev_Return_Pct classified as open-known (PineScript-verified: entirely prior day's data)
-- timing property optional on ColumnDescription (only spx_daily uses it)
-- All field lists derived from SCHEMA_DESCRIPTIONS at module load (no hardcoded names)
-- LAG() uses row order (ORDER BY date), not calendar-day arithmetic
-- Filter field names kept canonical (VIX_Close not prev_VIX_Close) -- only test() reads prev_* columns
-- NaN handling via continue (skip trade) rather than fallback to same-day value
-- VIX_Open hypothesis flag set true now that it is used as filter candidate
-- Static fields (Day_of_Week, Month, Is_Opex) in entryContext.sameDay (known before open)
-- outcomeFields opt-in via includeOutcomeFields=true with explicit lookahead warning
-- Filter-before-paginate ordering: totalTrades reflects filtered count, DuckDB queried only for paginated dates
-- generateLagTemplate() in schema.ts (not schema-metadata.ts) to avoid circular imports
-- LAG template dynamically generated from field-timing sets (stays in sync automatically)
-- IS NOT NULL filter on LAG columns in hypothesis example queries (handles first-row NULL from LAG)
-- Checkpoint at time T is known AT time T (inclusive); trade at 09:30 sees P_0930
-- timeOpened=00:00:00 returns empty knownCheckpoints (not null intradayContext)
-- Intraday outcome fields require BOTH includeIntradayContext=true AND includeOutcomeFields=true
-- SPX outcome fields prefixed with spx_ to avoid collision; VIX OHLC prefixed with vix_
-- VIX open excluded from outcome fields (known at open, not end-of-day)
+(Cleared at milestone boundary — see PROJECT.md Key Decisions for persistent decisions)
 
 ### Pending Todos
 
-None yet.
-
-### Roadmap Evolution
-
-- Phase 59 added: Intraday market context enrichment (spx_15min + vix_intraday time-based matching, deferred from Phase 57)
+None.
 
 ### Blockers/Concerns
 
-- Return_5D / Return_20D classification verified via PineScript (close-derived, resolved)
-- Filter effectiveness may degrade when shifting from same-day to t-1 in Phase 56 (prior-day signals weaker)
+None.
 
 ## Session Continuity
 
-Last session: 2026-02-08
-Stopped at: Completed 59-01-PLAN.md (intraday market context enrichment)
+Last session: 2026-02-09
+Stopped at: v2.9 milestone completed and archived
 Resume file: None

--- a/.planning/phases/56-fix-existing-tools/56-01-SUMMARY.md
+++ b/.planning/phases/56-fix-existing-tools/56-01-SUMMARY.md
@@ -1,0 +1,96 @@
+---
+phase: 56-fix-existing-tools
+plan: 01
+subsystem: mcp
+tags: [duckdb, lookahead-bias, lag-cte, market-data, mcp-tools]
+
+# Dependency graph
+requires:
+  - phase: 55-field-classification-foundation
+    provides: "field-timing.ts with buildLookaheadFreeQuery, OPEN_KNOWN_FIELDS, CLOSE_KNOWN_FIELDS, STATIC_FIELDS"
+provides:
+  - "Lookahead-free suggest_filters with 24 filter candidates (14 lagged, 10 same-day)"
+  - "Lookahead-free analyze_regime_performance with 3 lagged segmentBy options"
+  - "lagNote in both tools explaining temporal semantics"
+  - "VIX_Open/VIX_Gap_Pct as new open-known filter candidates"
+affects: [57-fix-sql-tools, 58-documentation-and-testing]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "prev_* column pattern for reading LAG CTE fields in tool logic"
+    - "lagged boolean on filter conditions for downstream consumers"
+    - "lagNote in tool output explaining bias prevention semantics"
+
+key-files:
+  created: []
+  modified:
+    - "packages/mcp-server/src/tools/market-data.ts"
+    - "packages/mcp-server/src/utils/schema-metadata.ts"
+
+key-decisions:
+  - "Filter field names kept canonical (VIX_Close not prev_VIX_Close) -- only test() reads prev_* columns"
+  - "NaN handling via continue (skip trade) rather than fallback to same-day value"
+  - "VIX_Open hypothesis flag set true now that it is used as filter candidate"
+
+patterns-established:
+  - "prev_* column access: close-derived filters/segments read prev_{field} from LAG CTE"
+  - "lagged metadata: each filter condition includes lagged boolean for transparency"
+  - "lagNote pattern: tools include text explanation of which fields are lagged and why"
+
+# Metrics
+duration: 5min
+completed: 2026-02-08
+---
+
+# Phase 56 Plan 01: Fix Existing Tools Summary
+
+**Lookahead-free suggest_filters (24 filters, 14 lagged) and analyze_regime_performance (3 lagged segmentBy) using LAG CTE from field-timing.ts**
+
+## Performance
+
+- **Duration:** 5 min
+- **Started:** 2026-02-08T21:43:24Z
+- **Completed:** 2026-02-08T21:48:19Z
+- **Tasks:** 2
+- **Files modified:** 2
+
+## Accomplishments
+- Both suggest_filters and analyze_regime_performance now query market data via buildLookaheadFreeQuery() LAG CTE instead of naive SELECT *
+- 14 close-derived filter candidates updated to read prev_* columns with "prior-day" display names
+- 4 new open-known filter candidates added: VIX_Open > 25/30, |VIX_Gap_Pct| > 10/15%
+- 3 close-derived segmentBy options (volRegime, termStructure, trendScore) read prev_* columns with NaN skip logic
+- Both tools include lagNote explaining temporal semantics in output
+- All 1201 existing tests pass with zero regressions
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Fix suggest_filters with lag-aware query and updated filter definitions** - `5bb282d` (feat)
+2. **Task 2: Fix analyze_regime_performance with lag-aware query and segmentBy updates** - `c992612` (feat)
+
+## Files Created/Modified
+- `packages/mcp-server/src/tools/market-data.ts` - Updated both tools with LAG CTE queries, prev_* column reads, lagNote, lagged boolean
+- `packages/mcp-server/src/utils/schema-metadata.ts` - Set VIX_Open hypothesis flag to true
+
+## Decisions Made
+- Filter field names kept as canonical names (e.g., `VIX_Close` not `prev_VIX_Close`) in condition output -- only the test() function reads from prev_* columns. This preserves user-facing field names.
+- NaN handling in segmentBy uses `continue` to skip trades with missing lagged data, rather than falling back to same-day values (which would reintroduce lookahead bias).
+- VIX_Open hypothesis flag set to true since it is now actively used as a filter candidate (BIAS-05).
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+None
+
+## User Setup Required
+None - no external service configuration required.
+
+## Next Phase Readiness
+- suggest_filters and analyze_regime_performance are lookahead-free
+- Phase 57 (fix SQL tools) can proceed: run_sql example queries and describe_database need similar lag-awareness
+- Phase 58 (documentation and testing) can add integration tests for the lag behavior

--- a/.planning/phases/57-restore-enrich-trades/57-01-PLAN.md
+++ b/.planning/phases/57-restore-enrich-trades/57-01-PLAN.md
@@ -1,0 +1,263 @@
+---
+phase: 57-restore-enrich-trades
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - packages/mcp-server/src/tools/market-data.ts
+  - packages/mcp-server/src/utils/field-timing.ts
+  - packages/mcp-server/package.json
+autonomous: true
+
+must_haves:
+  truths:
+    - "Calling enrich_trades with a blockId returns trades with market context split into entryContext.sameDay and entryContext.priorDay sections"
+    - "enrich_trades supports strategy, startDate, endDate filters and limit/offset pagination"
+    - "When includeOutcomeFields is true, trades include a separate outcomeFields section with a lookahead bias warning"
+    - "Response includes per-field temporal provenance via the sameDay/priorDay/outcomeFields structural grouping"
+    - "Response includes lagNote explaining which fields are lagged and why"
+    - "Pagination metadata shows totalTrades, returned, offset, hasMore"
+  artifacts:
+    - path: "packages/mcp-server/src/tools/market-data.ts"
+      provides: "enrich_trades tool registration"
+      contains: "enrich_trades"
+    - path: "packages/mcp-server/src/utils/field-timing.ts"
+      provides: "buildOutcomeQuery function for same-day close-derived fields"
+      contains: "buildOutcomeQuery"
+  key_links:
+    - from: "packages/mcp-server/src/tools/market-data.ts"
+      to: "packages/mcp-server/src/utils/field-timing.ts"
+      via: "import buildLookaheadFreeQuery, buildOutcomeQuery, OPEN_KNOWN_FIELDS, CLOSE_KNOWN_FIELDS, STATIC_FIELDS"
+      pattern: "buildOutcomeQuery"
+    - from: "packages/mcp-server/src/tools/market-data.ts"
+      to: "packages/mcp-server/src/utils/block-loader.ts"
+      via: "loadBlock(baseDir, blockId)"
+      pattern: "loadBlock"
+---
+
+<objective>
+Implement the `enrich_trades` MCP tool that returns trades enriched with lag-aware market context from `spx_daily`.
+
+Purpose: Users and LLM consumers who naively JOIN on date get same-day close-derived values (lookahead bias). This tool enforces correct temporal joins by default -- open-known fields use same-day values, close-derived fields use prior trading day values via LAG CTE, and outcome fields (same-day close) are opt-in with a clear warning.
+
+Output: Working `enrich_trades` tool in market-data.ts, `buildOutcomeQuery` in field-timing.ts, MCP server version bump.
+</objective>
+
+<execution_context>
+@/Users/davidromeo/.claude/get-shit-done/workflows/execute-plan.md
+@/Users/davidromeo/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/56-fix-existing-tools/56-01-SUMMARY.md
+@packages/mcp-server/src/tools/market-data.ts
+@packages/mcp-server/src/utils/field-timing.ts
+@packages/mcp-server/src/utils/block-loader.ts
+@packages/mcp-server/src/utils/output-formatter.ts
+@packages/mcp-server/src/tools/shared/filters.ts
+@packages/mcp-server/src/tools/middleware/sync-middleware.ts
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add buildOutcomeQuery to field-timing.ts and implement enrich_trades tool</name>
+  <files>
+    packages/mcp-server/src/utils/field-timing.ts
+    packages/mcp-server/src/tools/market-data.ts
+    packages/mcp-server/package.json
+  </files>
+  <action>
+**1. Add `buildOutcomeQuery()` to `packages/mcp-server/src/utils/field-timing.ts`:**
+
+Export a new function below the existing `buildLookaheadFreeQuery()`:
+
+```typescript
+export function buildOutcomeQuery(tradeDates: string[]): { sql: string; params: string[] } {
+  const closeColumns = [...CLOSE_KNOWN_FIELDS].map(f => `"${f}"`).join(', ');
+  const placeholders = tradeDates.map((_, i) => `$${i + 1}`).join(', ');
+  const sql = `SELECT date, ${closeColumns} FROM market.spx_daily WHERE date IN (${placeholders})`;
+  return { sql, params: tradeDates };
+}
+```
+
+This returns same-day close-derived values (no LAG) for outcome fields. Only called when `includeOutcomeFields=true`.
+
+**2. Add `enrich_trades` tool registration inside `registerMarketDataTools()` in `packages/mcp-server/src/tools/market-data.ts`:**
+
+Add the import of `buildOutcomeQuery`, `OPEN_KNOWN_FIELDS`, `CLOSE_KNOWN_FIELDS`, `STATIC_FIELDS` from field-timing.ts (buildLookaheadFreeQuery is already imported).
+
+Add import of `filterByStrategy`, `filterByDateRange` from `./shared/filters.js`.
+
+Register the tool using `withFullSync` (same as other market-data tools -- needs market data synced). Place it between suggest_filters and calculate_orb.
+
+**Tool schema (Zod):**
+```typescript
+z.object({
+  blockId: z.string().describe("Block ID to enrich"),
+  strategy: z.string().optional().describe("Filter to specific strategy (exact match)"),
+  startDate: z.string().optional().describe("Start date filter (YYYY-MM-DD)"),
+  endDate: z.string().optional().describe("End date filter (YYYY-MM-DD)"),
+  includeOutcomeFields: z.boolean().default(false).describe("Include same-day close values (lookahead). Defaults to false for safety."),
+  limit: z.number().min(1).max(500).default(50).describe("Max trades to return (default: 50, max: 500)"),
+  offset: z.number().min(0).default(0).describe("Pagination offset (default: 0)"),
+})
+```
+
+**Tool description:** "Enrich trades with market context using correct temporal joins. Open-known fields (Gap_Pct, VIX_Open) use same-day values. Close-derived fields (VIX_Close, RSI_14, Vol_Regime) use prior trading day values to prevent lookahead bias. Use includeOutcomeFields=true for post-hoc analysis (with clear warning)."
+
+**Handler implementation pattern (follow analyze_regime_performance exactly):**
+
+1. Load block: `const block = await loadBlock(baseDir, blockId);`
+2. Filter trades: apply `filterByStrategy()` then `filterByDateRange()`.
+3. If no trades, return error.
+4. Compute pagination: `totalTrades = filtered.length`, `paginated = filtered.slice(offset, offset + limit)`.
+5. Collect unique dates from **paginated** trades only (avoid querying dates we won't return).
+6. Query DuckDB with `buildLookaheadFreeQuery(tradeDates)` -> `resultToRecords()` -> build `Map<string, Record<string, unknown>>`.
+7. If `includeOutcomeFields`, also run `buildOutcomeQuery(tradeDates)` -> `resultToRecords()` -> build a second `Map<string, Record<string, unknown>>`.
+8. Build enriched trades array by iterating paginated trades. For each trade:
+   - Match to market data by date using `formatTradeDate()`.
+   - If no match, track in `unmatchedDates`, set `entryContext: null`.
+   - Build `entryContext.sameDay`: iterate `OPEN_KNOWN_FIELDS` and `STATIC_FIELDS`, extract values from market data record. Replace NaN with null (check `v === v ? v : null`).
+   - Build `entryContext.priorDay`: iterate `CLOSE_KNOWN_FIELDS`, read `prev_{field}` from market data record. Replace NaN with null.
+   - Build `outcomeFields` (only if `includeOutcomeFields`): iterate `CLOSE_KNOWN_FIELDS`, read same-name fields from outcome query result. Replace NaN with null.
+   - Output per-trade object shape:
+     ```
+     {
+       dateOpened: string (YYYY-MM-DD),
+       timeOpened: string,
+       strategy: string,
+       legs: string,
+       pl: number,
+       numContracts: number,
+       premium: number,
+       reasonForClose: string | null,
+       commissions: number,
+       entryContext: { sameDay: {...}, priorDay: {...} } | null,
+       outcomeFields?: {...}  // only when includeOutcomeFields=true
+     }
+     ```
+   - For numeric values from DuckDB: `typeof val === 'bigint' ? Number(val) : val`, then NaN to null: `(typeof v === 'number' && isNaN(v)) ? null : v`.
+
+9. Build lagNote string. When NOT including outcome fields:
+   ```
+   "Entry context uses lookahead-free temporal joins. Same-day fields (Gap_Pct, VIX_Open, Day_of_Week, etc.) are values known at market open. Prior-day fields (VIX_Close, RSI_14, Vol_Regime, etc.) use the previous trading day's close-derived values to prevent lookahead bias."
+   ```
+   When INCLUDING outcome fields, append:
+   ```
+   " Outcome fields contain same-day close-derived values and represent information NOT available at trade entry time."
+   ```
+
+10. Also include `lookaheadWarning` field (only when outcome fields enabled):
+    ```
+    "WARNING: outcomeFields contain same-day close-derived values that were NOT available at trade entry time. Do not use these for entry signal analysis."
+    ```
+
+11. Return via `createToolOutput(summary, data)`:
+    - summary: `"Enriched trades: {blockId} | {matched}/{paginated.length} matched | offset {offset}, limit {limit}"`
+    - data: `{ blockId, strategy: strategy || null, lagNote, lookaheadWarning (if applicable), tradesTotal: totalTrades, returned: paginated.length, offset, hasMore: offset + limit < totalTrades, tradesMatched: matched count, unmatchedDates: [...], trades: enrichedTradesArray }`
+
+12. Wrap in try/catch returning error format on failure (same as other tools).
+
+**3. Bump MCP server version in `packages/mcp-server/package.json`:**
+Bump from `"1.0.1"` to `"1.1.0"` (minor version for new feature).
+
+**Key implementation notes:**
+- Use `withFullSync` (not `withSyncedBlock`) -- matches other market-data tools, ensures market.spx_daily is synced.
+- Static fields (Day_of_Week, Month, Is_Opex) go in `entryContext.sameDay` since they're known before market open.
+- Filter BEFORE paginate: `totalTrades` reflects filtered count, `hasMore` refers to filtered set.
+- Only query DuckDB for paginated trade dates (efficiency).
+- NaN handling: `getNum()` returns NaN for null DuckDB values. JSON.stringify converts NaN to null, but explicitly replace for safety.
+- Trade commissions: `trade.openingCommissionsFees + trade.closingCommissionsFees`.
+  </action>
+  <verify>
+1. `cd /Users/davidromeo/Code/tradeblocks && npx tsc --noEmit -p packages/mcp-server/tsconfig.json` passes (no type errors)
+2. `npm test --prefix packages/mcp-server` passes (existing tests not broken)
+3. Grep confirms: `grep -c "enrich_trades" packages/mcp-server/src/tools/market-data.ts` returns >= 1
+4. Grep confirms: `grep -c "buildOutcomeQuery" packages/mcp-server/src/utils/field-timing.ts` returns >= 1
+5. Version in package.json is "1.1.0"
+  </verify>
+  <done>
+- enrich_trades tool is registered in registerMarketDataTools() with correct Zod schema
+- buildOutcomeQuery() exported from field-timing.ts
+- Tool returns trades with entryContext.sameDay (open-known + static fields), entryContext.priorDay (lagged close-derived fields)
+- includeOutcomeFields=true adds outcomeFields section with lookaheadWarning
+- Pagination (limit/offset) works with filter-before-paginate ordering
+- lagNote explains temporal semantics in output
+- MCP server version bumped to 1.1.0
+  </done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Update tool comment header and remove obsolete enrich_trades removal note</name>
+  <files>
+    packages/mcp-server/src/tools/market-data.ts
+  </files>
+  <action>
+Update the comment block at the top of `registerMarketDataTools()` (around lines 222-233) to reflect that enrich_trades has been restored. Currently it says:
+
+```
+ * Note: The following tools were REMOVED in v0.6.0 - use run_sql instead:
+ * - get_market_context: ...
+ * - enrich_trades: ...
+ * - find_similar_days: ...
+```
+
+Change to:
+
+```
+ * Note: The following tools were REMOVED in v0.6.0 - use run_sql instead:
+ * - get_market_context: SELECT ... FROM market.spx_daily WHERE ...
+ * - find_similar_days: Use CTE with similarity conditions
+ *
+ * Restored in v1.1.0 with lookahead-free temporal joins:
+ * - enrich_trades: Returns trades enriched with lag-aware market context
+ *
+ * Kept tools (require TradeBlocks library computation):
+```
+
+Also update the top-of-file module docstring to mention enrich_trades:
+```
+ * MCP tools for analyzing market context (VIX, term structure, regimes)
+ * and correlating with trade performance. Includes enrich_trades for
+ * lag-aware trade enrichment with market data.
+```
+  </action>
+  <verify>
+1. `grep "Restored in v1.1.0" packages/mcp-server/src/tools/market-data.ts` returns a match
+2. `grep -c "enrich_trades" packages/mcp-server/src/tools/market-data.ts` returns >= 3 (registration, comment, description)
+  </verify>
+  <done>
+- Comment header accurately reflects tool inventory (enrich_trades restored, get_market_context and find_similar_days still removed)
+- Module docstring mentions enrich_trades
+  </done>
+</task>
+
+</tasks>
+
+<verification>
+1. TypeScript compilation: `npx tsc --noEmit -p packages/mcp-server/tsconfig.json` passes
+2. Existing tests: `npm test --prefix packages/mcp-server` passes
+3. Tool registration: grep confirms enrich_trades is registered
+4. Outcome query: grep confirms buildOutcomeQuery exists in field-timing.ts
+5. Version bump: package.json shows 1.1.0
+6. No hardcoded field names: enrich_trades uses OPEN_KNOWN_FIELDS, CLOSE_KNOWN_FIELDS, STATIC_FIELDS sets (not inline lists)
+</verification>
+
+<success_criteria>
+- enrich_trades tool callable via MCP with blockId parameter
+- Output contains entryContext.sameDay (11 fields: 8 open + 3 static) and entryContext.priorDay (44 close-derived fields) per trade
+- includeOutcomeFields=true adds outcomeFields section (44 same-day close values) with lookaheadWarning
+- Pagination works: default 50 trades, max 500, offset supported, hasMore flag
+- Strategy and date range filters applied before pagination
+- lagNote in response explains temporal semantics
+- TypeScript compiles, existing tests pass
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/57-restore-enrich-trades/57-01-SUMMARY.md`
+</output>

--- a/.planning/phases/57-restore-enrich-trades/57-01-SUMMARY.md
+++ b/.planning/phases/57-restore-enrich-trades/57-01-SUMMARY.md
@@ -1,0 +1,99 @@
+---
+phase: 57-restore-enrich-trades
+plan: 01
+subsystem: api
+tags: [mcp, duckdb, lookahead-free, temporal-joins, trade-enrichment]
+
+# Dependency graph
+requires:
+  - phase: 55-field-classification-foundation
+    provides: "OPEN_KNOWN_FIELDS, CLOSE_KNOWN_FIELDS, STATIC_FIELDS sets and buildLookaheadFreeQuery"
+  - phase: 56-fix-existing-tools
+    provides: "Lookahead-free query patterns in analyze_regime_performance and suggest_filters"
+provides:
+  - "enrich_trades MCP tool for lag-aware trade enrichment with market data"
+  - "buildOutcomeQuery() for same-day close-derived field queries"
+affects: [59-intraday-market-context]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns: ["sameDay/priorDay/outcomeFields structural grouping for temporal provenance"]
+
+key-files:
+  created: []
+  modified:
+    - packages/mcp-server/src/tools/market-data.ts
+    - packages/mcp-server/src/utils/field-timing.ts
+    - packages/mcp-server/package.json
+
+key-decisions:
+  - "Static fields (Day_of_Week, Month, Is_Opex) placed in entryContext.sameDay since known before market open"
+  - "outcomeFields opt-in via includeOutcomeFields=true with explicit lookahead warning"
+  - "Filter-before-paginate ordering: totalTrades reflects filtered count, DuckDB queried only for paginated dates"
+
+patterns-established:
+  - "sameDay/priorDay structural split: open-known + static fields in sameDay, lagged close-derived in priorDay"
+  - "Outcome fields as separate opt-in section with bias warning for post-hoc analysis"
+
+# Metrics
+duration: 3min
+completed: 2026-02-08
+---
+
+# Phase 57 Plan 01: Restore enrich_trades Summary
+
+**enrich_trades MCP tool with lookahead-free temporal joins, sameDay/priorDay/outcomeFields structural provenance, and pagination**
+
+## Performance
+
+- **Duration:** 3 min
+- **Started:** 2026-02-08T22:25:22Z
+- **Completed:** 2026-02-08T22:28:00Z
+- **Tasks:** 2
+- **Files modified:** 3
+
+## Accomplishments
+- Implemented enrich_trades tool returning trades with entryContext.sameDay (11 open-known + static fields) and entryContext.priorDay (44 lagged close-derived fields)
+- Added buildOutcomeQuery() for opt-in same-day close values with lookahead bias warning
+- Pagination support (default 50, max 500) with strategy/date range filters applied before pagination
+- lagNote in response explains temporal semantics; lookaheadWarning when outcome fields enabled
+- MCP server version bumped to 1.1.0
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Add buildOutcomeQuery and implement enrich_trades tool** - `81ac9c5` (feat)
+2. **Task 2: Update comment headers for enrich_trades restoration** - `1421e50` (chore)
+
+## Files Created/Modified
+- `packages/mcp-server/src/utils/field-timing.ts` - Added buildOutcomeQuery() for same-day close-derived field queries
+- `packages/mcp-server/src/tools/market-data.ts` - Added enrich_trades tool registration with full handler, updated module docstring and comment headers
+- `packages/mcp-server/package.json` - Version bump 1.0.1 -> 1.1.0
+
+## Decisions Made
+- Static fields placed in entryContext.sameDay (known before open, safe for entry analysis)
+- outcomeFields are opt-in with explicit warning to prevent accidental lookahead bias
+- Filter-before-paginate: totalTrades reflects filtered count, only paginated dates queried in DuckDB
+- NaN handling via explicit check rather than relying on JSON.stringify behavior
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+- Pre-existing TypeScript error in connection.ts (null to DuckDBConnection cast) -- unrelated to changes, confirmed by stash test
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+- enrich_trades tool ready for use via MCP
+- Phase 58 (research/planning for additional tools) can proceed
+- Phase 59 (intraday market context) has foundation from field-timing.ts patterns
+
+---
+*Phase: 57-restore-enrich-trades*
+*Completed: 2026-02-08*

--- a/.planning/phases/57-restore-enrich-trades/57-RESEARCH.md
+++ b/.planning/phases/57-restore-enrich-trades/57-RESEARCH.md
@@ -1,0 +1,409 @@
+# Phase 57: Restore enrich_trades - Research
+
+**Researched:** 2026-02-08
+**Domain:** MCP tool development / DuckDB lookahead-free joins / trade enrichment
+**Confidence:** HIGH
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+
+**Output structure:**
+- Inline per trade (not separate date-keyed lookup) -- each trade object includes its market context directly
+- Fields grouped by temporal availability within each trade:
+  - `entryContext.sameDay` -- open-known fields (Gap_Pct, VIX_Open, etc.) using same-day values
+  - `entryContext.priorDay` -- close-derived fields (prev_VIX_Close, prev_RSI_14, etc.) using prior trading day values
+  - `outcomeFields` -- same-day close-derived fields, only when `includeOutcomeFields=true`
+- Top-level metadata following universal MCP pattern: `blockId`, `strategy`, `lagNote`, matching stats (`tradesTotal`, `tradesMatched`, `unmatchedDates`)
+- Summary with lagNote modeled on suggest_filters' comprehensive format (lists which fields are lagged and why)
+- Uses `createToolOutput(summary, data)` like all other tools
+
+**Outcome fields behavior:**
+- `includeOutcomeFields` defaults to false (safe by default) -- user must opt in
+- Outcome fields appear in a separate `outcomeFields` section per trade (not inline with flags) -- makes the lookahead boundary structural
+- Warning surfaced in both the top-level `lagNote` AND a `lookaheadWarning` field when outcome fields are included
+- Aligns with "data-not-interpretation" ethos -- provide the data with clear provenance, let the consumer decide
+
+**Filtering & pagination:**
+- Simple params only: blockId (required), strategy (exact match), startDate/endDate -- consistent with analyze_regime_performance and suggest_filters
+- No filter expressions -- filter_curve already handles that; enrich_trades is for data access, not analysis
+- Default limit 50, max 500 -- test data shows ~850 trades per block, so 50 is manageable for LLM context
+- Response includes `totalTrades`, `returned`, `offset`, `hasMore` pagination metadata
+- Follows the `limit`/`offset` pattern used by list_blocks and run_sql
+
+**Field selection:**
+- Always return full spx_daily market context (all 55 fields) -- no field selection parameter
+- LLM consumer can ignore fields it doesn't need; the full context enables richer analysis
+- Uses the application-level join pattern from Phase 56: load trades from IndexedDB, query DuckDB with buildLookaheadFreeQuery(), match by date in memory
+
+### Claude's Discretion
+- Exact field grouping within entryContext (which fields in sameDay vs priorDay -- derived from OPEN_KNOWN_FIELDS, CLOSE_KNOWN_FIELDS, STATIC_FIELDS)
+- Summary text format and lagNote wording
+- How static fields (Day_of_Week, Month, Is_Opex) are grouped -- likely under sameDay since they're known before market open
+- Error handling for edge cases (no market data for a date, empty blocks)
+
+### Deferred Ideas (OUT OF SCOPE)
+- **Intraday enrichment (spx_15min + vix_intraday)** -- requires time-based matching with no existing codebase precedent. Wide-format tables (columns per checkpoint like P_0930, VIX_1000) need dynamic column selection or UNPIVOT. Different temporal semantics (checkpoints are known at their timestamp, not open/close classification). Deserves its own phase with proper design.
+</user_constraints>
+
+## Summary
+
+This phase restores the `enrich_trades` MCP tool that was removed in v0.6.0 (Phase 45) when it was a simple JOIN replaced by `run_sql`. The new version adds genuine value by enforcing lookahead-free temporal joins -- something `run_sql` cannot do by default. Users who naively `JOIN ON date_opened = date` would get same-day close-derived values (VIX_Close, RSI_14, etc.) that weren't available at trade entry time.
+
+The implementation follows the proven pattern from Phase 56: load trades from IndexedDB via `loadBlock()`, collect unique trade dates, call `buildLookaheadFreeQuery()` to get a DuckDB CTE with LAG() for close-derived fields, match results by date in memory, and structure the output with clear temporal provenance. The existing `analyze_regime_performance` and `suggest_filters` tools in `market-data.ts` demonstrate this exact pattern -- `enrich_trades` extends it by returning the raw enriched data per-trade rather than computing aggregate statistics.
+
+The key design challenge is structuring the output to clearly communicate temporal boundaries: same-day open-known fields (8 fields), prior-day close-derived fields (44 fields), static fields (3 fields), and optional outcome fields (same-day close values with a lookahead warning). The tool also needs pagination since blocks can have 800+ trades, but the default limit of 50 keeps LLM context manageable.
+
+**Primary recommendation:** Implement as a single new tool registration in `market-data.ts`, reusing `formatTradeDate()`, `resultToRecords()`, `getNum()`, `loadBlock()`, `buildLookaheadFreeQuery()`, and `createToolOutput()` -- all of which are already available in that module or its imports.
+
+## Standard Stack
+
+### Core
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| zod | ^4.0.0 | Tool input schema validation | Used by all MCP tools in the codebase |
+| @modelcontextprotocol/sdk | ^1.11.0 | MCP server framework | `server.registerTool()` pattern |
+| @duckdb/node-api | ^1.4.4-r.1 | DuckDB queries for market data | Existing connection manager in `db/connection.ts` |
+| @tradeblocks/lib | workspace | Trade type definitions | `Trade` interface, trade loading |
+
+### Supporting
+| Library | Version | Purpose | When to Use |
+|---------|---------|---------|-------------|
+| field-timing.ts | internal | `buildLookaheadFreeQuery()`, field sets | Generating lookahead-free SQL CTE |
+| block-loader.ts | internal | `loadBlock()` | Loading trades from IndexedDB/CSV |
+| output-formatter.ts | internal | `createToolOutput()` | Structuring MCP response |
+| sync-middleware.ts | internal | `withSyncedBlock()` | Pre-query block sync |
+| shared/filters.ts | internal | `filterByStrategy()`, `filterByDateRange()` | Trade filtering before enrichment |
+
+### Alternatives Considered
+N/A -- all decisions are locked. The implementation stack is entirely within the existing codebase.
+
+**Installation:** No new packages required. All dependencies already exist.
+
+## Architecture Patterns
+
+### Recommended Project Structure
+```
+packages/mcp-server/src/
+├── tools/
+│   └── market-data.ts          # Add enrich_trades here (alongside analyze_regime_performance, suggest_filters, calculate_orb)
+├── utils/
+│   ├── field-timing.ts         # OPEN_KNOWN_FIELDS, CLOSE_KNOWN_FIELDS, STATIC_FIELDS, buildLookaheadFreeQuery()
+│   ├── schema-metadata.ts      # SCHEMA_DESCRIPTIONS with timing annotations
+│   ├── block-loader.ts         # loadBlock()
+│   └── output-formatter.ts     # createToolOutput()
+└── test-exports.ts             # Add new exports if needed for testing
+```
+
+### Pattern 1: Application-Level Join (from Phase 56)
+**What:** Load trades from filesystem/IndexedDB, query DuckDB for market data with LAG CTE, match by date in memory.
+**When to use:** Any tool that combines trade data with market data while enforcing lookahead-free semantics.
+**Example (from `analyze_regime_performance` in market-data.ts, lines 257-285):**
+```typescript
+// 1. Load block and filter trades
+const block = await loadBlock(baseDir, blockId);
+let trades = block.trades;
+if (strategy) {
+  trades = trades.filter(t => t.strategy.toLowerCase() === strategy.toLowerCase());
+}
+
+// 2. Collect unique trade dates
+const tradeDates = [...new Set(trades.map(t => formatTradeDate(t.dateOpened)))];
+
+// 3. Query DuckDB with lookahead-free CTE
+const conn = await getConnection(baseDir);
+const { sql, params } = buildLookaheadFreeQuery(tradeDates);
+const dailyResult = await conn.runAndReadAll(sql, params);
+const dailyRecords = resultToRecords(dailyResult);
+
+// 4. Build date -> market data map
+const daily = new Map<string, Record<string, unknown>>();
+for (const record of dailyRecords) {
+  daily.set(record["date"] as string, record);
+}
+
+// 5. Match trades to market data
+for (const trade of trades) {
+  const tradeDate = formatTradeDate(trade.dateOpened);
+  const marketData = daily.get(tradeDate);
+  if (!marketData) { unmatchedDates.push(tradeDate); continue; }
+  // ... process enriched trade
+}
+```
+
+### Pattern 2: createToolOutput() Response Structure
+**What:** All MCP tools return a text summary + structured JSON resource.
+**When to use:** Every tool response.
+**Example:**
+```typescript
+return createToolOutput(summary, {
+  blockId,
+  lagNote,
+  strategy: strategy || null,
+  tradesTotal: trades.length,
+  tradesMatched: totalMatched,
+  // ... data payload
+});
+```
+
+### Pattern 3: withSyncedBlock() Middleware
+**What:** Wraps tool handler to sync block data before execution.
+**When to use:** Tools that operate on a single block (identified by `blockId` in input).
+**Example:**
+```typescript
+server.registerTool(
+  "enrich_trades",
+  { description: "...", inputSchema: z.object({ blockId: z.string(), ... }) },
+  withSyncedBlock(baseDir, async ({ blockId, ... }) => {
+    // Block data is synced before this runs
+  })
+);
+```
+
+### Pattern 4: Outcome Fields as Separate Section
+**What:** When `includeOutcomeFields=true`, return same-day close-derived values in a structurally separate `outcomeFields` object per trade, with warnings at both per-trade and top-level.
+**When to use:** Only for enrich_trades outcome mode.
+**Rationale:** The structural separation makes it impossible to accidentally mix lookahead-free entry context with outcome data. This is stronger than using inline boolean flags.
+
+### Pattern 5: Pagination Metadata
+**What:** Response includes `totalTrades`, `returned`, `offset`, `hasMore` for cursor-based pagination.
+**When to use:** Tools returning variable-length lists.
+**Example (from list_blocks):**
+```typescript
+const total = allTrades.length;
+const paginated = allTrades.slice(offset, offset + limit);
+return createToolOutput(summary, {
+  totalTrades: total,
+  returned: paginated.length,
+  offset,
+  hasMore: offset + limit < total,
+  trades: paginated,
+});
+```
+
+### Anti-Patterns to Avoid
+- **Naive JOIN on date:** `JOIN market.spx_daily m ON t.date_opened = m.date` gives same-day close-derived values. This is exactly what enrich_trades prevents.
+- **Hardcoded field names:** Field classification must come from `OPEN_KNOWN_FIELDS`, `CLOSE_KNOWN_FIELDS`, `STATIC_FIELDS` sets (derived from `SCHEMA_DESCRIPTIONS` timing annotations). Never hardcode which fields are open/close/static.
+- **Mixing temporal boundaries inline:** Outcome fields must be in a separate section, not mixed with entry context.
+- **Not handling unmatched dates:** Some trade dates may not have market data (holidays, pre-market data range). Track and report `unmatchedDates`.
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Lookahead-free SQL | Custom SQL per field | `buildLookaheadFreeQuery()` | Already handles all 55 fields with correct LAG CTE |
+| Field classification | Hardcoded lists | `OPEN_KNOWN_FIELDS`, `CLOSE_KNOWN_FIELDS`, `STATIC_FIELDS` | Derived from `SCHEMA_DESCRIPTIONS` timing annotations |
+| Trade date formatting | Custom date parser | `formatTradeDate()` in market-data.ts | Handles Eastern Time correctly |
+| DuckDB result parsing | Custom row iteration | `resultToRecords()` in market-data.ts | Handles BigInt conversion |
+| Block loading | Direct file reads | `loadBlock()` from block-loader.ts | Handles CSV mappings, metadata, discovery |
+| Trade filtering | Custom filter logic | `filterByStrategy()`, `filterByDateRange()` from shared/filters.ts | Already tested, handles edge cases |
+| Response formatting | Manual JSON/text | `createToolOutput()` | Universal MCP response pattern |
+
+**Key insight:** The Phase 55-56 infrastructure (`field-timing.ts`, `buildLookaheadFreeQuery()`) and the existing market-data.ts utilities (`formatTradeDate()`, `resultToRecords()`, `getNum()`) provide 90% of what enrich_trades needs. The only new code is the output structuring logic that splits market fields into `entryContext.sameDay`, `entryContext.priorDay`, and `outcomeFields`.
+
+## Common Pitfalls
+
+### Pitfall 1: Outcome Fields Need a Second Query
+**What goes wrong:** `buildLookaheadFreeQuery()` only returns open-known fields (same-day) and LAG'd close-derived fields (prior-day). For outcome fields, you need the *same-day* close-derived values, which the existing CTE deliberately excludes.
+**Why it happens:** The LAG CTE is designed to prevent lookahead bias, so it replaces close-derived columns with `prev_*` versions. Outcome fields need the original (non-lagged) values for the same date.
+**How to avoid:** When `includeOutcomeFields=true`, run a second simple query: `SELECT date, <close_known_fields> FROM market.spx_daily WHERE date IN (...)` to get same-day close values. Or build a variant query that includes both lagged and unlagged versions.
+**Warning signs:** If outcome fields show `prev_*` values, the wrong data is being used.
+**Recommended approach:** Build a separate `buildOutcomeQuery()` that returns same-day close-derived fields for the trade dates, OR modify the enrichment loop to extract outcome values from a parallel query result. The `CLOSE_KNOWN_FIELDS` set tells you exactly which fields need this treatment.
+
+### Pitfall 2: formatTradeDate Scope
+**What goes wrong:** `formatTradeDate()` is currently a module-level function in `market-data.ts` (not exported). enrich_trades in the same file can use it directly. If the tool were in a separate file, it would need to be extracted to a shared utility.
+**Why it happens:** The function was only needed by two tools before (analyze_regime_performance, suggest_filters), both in market-data.ts.
+**How to avoid:** Since enrich_trades will live in market-data.ts (same file as the other market data tools), this is not an issue. The function is already accessible.
+**Warning signs:** Import errors if the tool is placed in a different file.
+
+### Pitfall 3: Pagination Interacts with Filtering
+**What goes wrong:** If you paginate BEFORE filtering by strategy/date, the offset/limit refer to unfiltered trades. If you paginate AFTER filtering, offset/limit refer to the filtered set.
+**Why it happens:** Ambiguity in when to apply offset/limit.
+**How to avoid:** Filter first, then paginate. The `totalTrades` count should reflect the filtered total, and `offset`/`hasMore` should refer to the filtered set.
+**Warning signs:** `totalTrades` doesn't match expected count when strategy filter is applied.
+
+### Pitfall 4: NaN Market Data Values
+**What goes wrong:** Some market data fields may be NULL/NaN for certain dates (e.g., VIX9D_Close may not be available for older dates). Passing NaN through to JSON output creates invalid JSON.
+**Why it happens:** DuckDB returns NULL for missing data, which becomes NaN through `getNum()`.
+**How to avoid:** When building the per-trade market context, use `null` for NaN values in the JSON output. The `getNum()` helper returns NaN, but JSON.stringify() converts NaN to null. Verify this behavior, or explicitly replace NaN with null.
+**Warning signs:** JSON parse errors in consumers, or unexpected "null" string values.
+
+### Pitfall 5: Static Fields Grouping
+**What goes wrong:** Day_of_Week, Month, Is_Opex are `static` timing, not `open`. If you only check `OPEN_KNOWN_FIELDS`, they'll be missing from the same-day section.
+**Why it happens:** Three-way classification (open/close/static) but two-way output grouping (sameDay/priorDay).
+**How to avoid:** Group static fields WITH open-known fields in the `entryContext.sameDay` section, since both are known before market open. The context doc notes: "Static fields likely under sameDay since they're known before market open."
+**Warning signs:** Day_of_Week, Month, Is_Opex missing from output.
+
+## Code Examples
+
+### Example 1: Field Grouping Logic
+```typescript
+// Split market data record into temporal sections
+function buildEntryContext(marketData: Record<string, unknown>): {
+  sameDay: Record<string, unknown>;
+  priorDay: Record<string, unknown>;
+} {
+  const sameDay: Record<string, unknown> = {};
+  const priorDay: Record<string, unknown> = {};
+
+  // Open-known fields: same-day values
+  for (const field of OPEN_KNOWN_FIELDS) {
+    const val = marketData[field];
+    sameDay[field] = val === undefined ? null : (typeof val === 'bigint' ? Number(val) : val);
+  }
+
+  // Static fields: also same-day (known before market open)
+  for (const field of STATIC_FIELDS) {
+    const val = marketData[field];
+    sameDay[field] = val === undefined ? null : (typeof val === 'bigint' ? Number(val) : val);
+  }
+
+  // Close-derived fields: prior trading day values (from LAG CTE)
+  for (const field of CLOSE_KNOWN_FIELDS) {
+    const prevKey = `prev_${field}`;
+    const val = marketData[prevKey];
+    priorDay[field] = val === undefined || val === null ? null : (typeof val === 'bigint' ? Number(val) : val);
+  }
+
+  return { sameDay, priorDay };
+}
+```
+
+### Example 2: Outcome Fields Query
+```typescript
+// For outcome fields, query same-day close-derived values (no LAG)
+function buildOutcomeQuery(tradeDates: string[]): { sql: string; params: string[] } {
+  const closeColumns = [...CLOSE_KNOWN_FIELDS].map(f => `"${f}"`).join(', ');
+  const placeholders = tradeDates.map((_, i) => `$${i + 1}`).join(', ');
+
+  const sql = `SELECT date, ${closeColumns}
+    FROM market.spx_daily
+    WHERE date IN (${placeholders})`;
+
+  return { sql, params: tradeDates };
+}
+```
+
+### Example 3: Enriched Trade Output Shape
+```typescript
+// Per-trade output structure
+interface EnrichedTradeOutput {
+  // Core trade fields
+  dateOpened: string;    // YYYY-MM-DD
+  timeOpened: string;
+  strategy: string;
+  legs: string;
+  pl: number;
+  numContracts: number;
+  reasonForClose?: string;
+
+  // Market context at entry time
+  entryContext: {
+    sameDay: Record<string, unknown>;   // 8 open-known + 3 static = 11 fields
+    priorDay: Record<string, unknown>;  // 44 close-derived fields (prev_* values)
+  };
+
+  // Optional: same-day close values (lookahead)
+  outcomeFields?: Record<string, unknown>;  // 44 close-derived fields (same-day values)
+}
+```
+
+### Example 4: Pagination Implementation
+```typescript
+// After filtering, apply pagination
+const filtered = filterByDateRange(filterByStrategy(trades, strategy), startDate, endDate);
+const total = filtered.length;
+const paginated = filtered.slice(offset, offset + limit);
+
+// ... enrich paginated trades only (not all filtered trades)
+// This avoids querying DuckDB for dates we won't return
+const tradeDates = [...new Set(paginated.map(t => formatTradeDate(t.dateOpened)))];
+```
+
+### Example 5: Tool Registration Shape
+```typescript
+server.registerTool(
+  "enrich_trades",
+  {
+    description: "Enrich trades with market context using correct temporal joins. " +
+      "Open-known fields (Gap_Pct, VIX_Open) use same-day values. " +
+      "Close-derived fields (VIX_Close, RSI_14, Vol_Regime) use prior trading day values to prevent lookahead bias. " +
+      "Use includeOutcomeFields=true for post-hoc analysis (with clear warning).",
+    inputSchema: z.object({
+      blockId: z.string().describe("Block ID to enrich"),
+      strategy: z.string().optional().describe("Filter to specific strategy (exact match)"),
+      startDate: z.string().optional().describe("Start date filter (YYYY-MM-DD)"),
+      endDate: z.string().optional().describe("End date filter (YYYY-MM-DD)"),
+      includeOutcomeFields: z.boolean().default(false).describe(
+        "Include same-day close values (lookahead). Defaults to false for safety."
+      ),
+      limit: z.number().min(1).max(500).default(50).describe("Max trades to return (default: 50, max: 500)"),
+      offset: z.number().min(0).default(0).describe("Pagination offset (default: 0)"),
+    }),
+  },
+  withSyncedBlock(baseDir, async ({ blockId, strategy, startDate, endDate, includeOutcomeFields, limit, offset }) => {
+    // ... implementation
+  })
+);
+```
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| Old enrich_trades: naive `JOIN market.spx_daily m ON date_opened = date` | Removed in v0.6.0 (replaced by run_sql) | Phase 45, 2026-02-04 | Users must write raw SQL, still get lookahead bias |
+| run_sql: manual JOIN (no temporal safety) | New enrich_trades: buildLookaheadFreeQuery() with LAG CTE | Phase 57 (this phase) | Enforces correct temporal joins by default |
+| Per-field manual classification | SCHEMA_DESCRIPTIONS timing annotations + derived sets | Phase 55, 2026-02-07 | Classification is metadata-driven, not hardcoded |
+
+**Deprecated/outdated:**
+- Old `enrich_trades` (v0.5.x): Was a thin wrapper around `JOIN`. Removed because run_sql could do the same thing. The new version adds temporal-join enforcement that run_sql cannot provide.
+
+## Open Questions
+
+1. **JSON NaN handling**
+   - What we know: `getNum()` returns NaN for null/undefined DuckDB values. `JSON.stringify()` converts NaN to `null`.
+   - What's unclear: Whether all consumers handle null gracefully for numeric fields.
+   - Recommendation: Explicitly replace NaN with null before JSON serialization for safety. A simple `v === v ? v : null` check (NaN !== NaN) works.
+
+2. **Outcome fields: same query or separate query?**
+   - What we know: `buildLookaheadFreeQuery()` returns prev_* for close-derived fields. Outcome needs same-day values.
+   - What's unclear: Whether it's better to run a second simple SELECT or modify the CTE to include both lagged and unlagged columns.
+   - Recommendation: Run a second simple query only when `includeOutcomeFields=true`. This keeps the common path (no outcome fields) at one query and avoids making the CTE more complex. The second query is trivial: `SELECT date, <close_columns> FROM market.spx_daily WHERE date IN (...)`.
+
+3. **Trade field selection in output**
+   - What we know: The decision says "inline per trade" with market context. Need to decide which trade fields to include.
+   - What's unclear: Whether to include ALL trade fields or a curated subset.
+   - Recommendation: Include the most analytically useful trade fields: `dateOpened`, `timeOpened`, `strategy`, `legs`, `pl`, `numContracts`, `premium`, `reasonForClose`, plus commissions. Omit internal fields like `fundsAtClose`, `marginReq`, `syntheticCapitalRatio`. This balances context richness with output size (especially at 50+ trades).
+
+## Sources
+
+### Primary (HIGH confidence)
+- `packages/mcp-server/src/tools/market-data.ts` -- Full implementation of analyze_regime_performance, suggest_filters, calculate_orb (the exact patterns to follow)
+- `packages/mcp-server/src/utils/field-timing.ts` -- buildLookaheadFreeQuery(), OPEN_KNOWN_FIELDS (8), CLOSE_KNOWN_FIELDS (44), STATIC_FIELDS (3)
+- `packages/mcp-server/src/utils/schema-metadata.ts` -- SCHEMA_DESCRIPTIONS with all 55 spx_daily field timing annotations
+- `packages/mcp-server/src/utils/block-loader.ts` -- loadBlock(), LoadedBlock interface
+- `packages/mcp-server/src/utils/output-formatter.ts` -- createToolOutput()
+- `packages/mcp-server/src/tools/middleware/sync-middleware.ts` -- withSyncedBlock()
+- `packages/mcp-server/src/tools/shared/filters.ts` -- filterByStrategy(), filterByDateRange()
+- `packages/mcp-server/tests/unit/field-timing.test.ts` -- Field classification tests (8 open, 44 close, 3 static)
+- `packages/lib/models/trade.ts` -- Trade interface
+- Git commit `e72fd5d` -- Old enrich_trades removal (Phase 45)
+
+### Secondary (MEDIUM confidence)
+- `packages/mcp-server/src/index.ts` -- Tool registration flow (registerMarketDataTools is where enrich_trades will be registered)
+- `packages/mcp-server/src/tools/blocks/core.ts` -- list_blocks pagination pattern, get_statistics filter pattern
+
+### Tertiary (LOW confidence)
+None -- all findings verified from codebase sources.
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack: HIGH -- All libraries already in use in the codebase, no new dependencies
+- Architecture: HIGH -- Exact patterns proven in analyze_regime_performance and suggest_filters (Phase 56)
+- Pitfalls: HIGH -- Identified from direct code reading and the Phase 56 split-join implementation
+- Output structure: HIGH -- Locked by CONTEXT.md decisions, code examples derived from existing field sets
+
+**Research date:** 2026-02-08
+**Valid until:** 2026-03-08 (stable -- no external dependencies, all internal patterns)

--- a/.planning/phases/58-schema-metadata-documentation/58-01-SUMMARY.md
+++ b/.planning/phases/58-schema-metadata-documentation/58-01-SUMMARY.md
@@ -1,0 +1,105 @@
+---
+phase: 58-schema-metadata-documentation
+plan: 01
+subsystem: api
+tags: [duckdb, mcp, schema-discovery, lookahead-bias, lag-cte, sql-examples]
+
+# Dependency graph
+requires:
+  - phase: 55-field-classification-foundation
+    provides: "Field timing annotations on ColumnDescription (open/close/static)"
+  - phase: 56-fix-existing-tools
+    provides: "Lookahead-free LAG CTE pattern established in purpose-built tools"
+provides:
+  - "timing property on ColumnInfo in describe_database output"
+  - "lagTemplate field with reusable LAG CTE template"
+  - "7 lag-aware example queries for trade-market JOINs"
+  - "MCP server v1.2.0"
+affects: [59-intraday-market-context]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "LAG CTE pattern in example queries for ad-hoc SQL guidance"
+    - "Dynamic template generation from field-timing classification sets"
+
+key-files:
+  created: []
+  modified:
+    - packages/mcp-server/src/tools/schema.ts
+    - packages/mcp-server/src/utils/schema-metadata.ts
+    - packages/mcp-server/package.json
+
+key-decisions:
+  - "generateLagTemplate() lives in schema.ts (not schema-metadata.ts) to avoid circular imports"
+  - "timing property is optional on ColumnInfo -- undefined for non-market tables"
+  - "LAG template dynamically generated from OPEN_KNOWN_FIELDS, CLOSE_KNOWN_FIELDS, STATIC_FIELDS sets"
+
+patterns-established:
+  - "Lag-aware example queries: all trade-market JOIN examples with close-derived fields use WITH lagged AS CTE"
+  - "IS NOT NULL filter on LAG columns in hypothesis queries to handle first-row NULL"
+
+# Metrics
+duration: 3min
+completed: 2026-02-08
+---
+
+# Phase 58 Plan 01: Schema Metadata Documentation Summary
+
+**describe_database extended with timing metadata on columns, 7 lag-aware example queries, and reusable LAG CTE template for ad-hoc SQL**
+
+## Performance
+
+- **Duration:** 3 min
+- **Started:** 2026-02-08T22:41:49Z
+- **Completed:** 2026-02-08T22:44:52Z
+- **Tasks:** 2
+- **Files modified:** 3
+
+## Accomplishments
+- Extended ColumnInfo with `timing` property (open/close/static) flowing from ColumnDescription -- spx_daily columns now show temporal classification in describe_database output
+- Added `lagTemplate` field to DatabaseSchemaOutput with dynamically generated LAG CTE, description, and field counts (stays in sync with field-timing sets automatically)
+- Updated 7 trade-market JOIN example queries to use lag-aware CTE pattern, preventing users from writing lookahead-biased ad-hoc SQL
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Extend ColumnInfo and DatabaseSchemaOutput with timing and lagTemplate** - `b3e326f` (feat)
+2. **Task 2: Update example queries to use lag-aware JOIN patterns** - `b901971` (feat)
+
+## Files Created/Modified
+- `packages/mcp-server/src/tools/schema.ts` - Added timing to ColumnInfo, lagTemplate to DatabaseSchemaOutput, generateLagTemplate() function, field-timing imports
+- `packages/mcp-server/src/utils/schema-metadata.ts` - Updated 7 example queries from naive JOINs to LAG CTE pattern
+- `packages/mcp-server/package.json` - Version bump 1.1.0 to 1.2.0
+
+## Decisions Made
+- `generateLagTemplate()` placed in schema.ts rather than schema-metadata.ts to avoid circular imports (field-timing.ts imports from schema-metadata.ts, schema.ts imports from field-timing.ts)
+- timing property kept optional on ColumnInfo (undefined for non-market tables like trades.trade_data) for clean output
+- LAG template generated dynamically from the same OPEN_KNOWN_FIELDS, CLOSE_KNOWN_FIELDS, STATIC_FIELDS sets used by purpose-built tools, ensuring consistency
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+- describe_database now surfaces complete lookahead bias guidance for ad-hoc SQL
+- Phase 59 (intraday market context) can extend the same pattern for spx_15min and vix_intraday tables
+- All spx_daily queries in the MCP ecosystem now use lag-aware patterns
+
+## Self-Check: PASSED
+
+All files verified present. Both commit hashes (b3e326f, b901971) found in git log.
+
+---
+*Phase: 58-schema-metadata-documentation*
+*Completed: 2026-02-08*

--- a/.planning/phases/58-schema-metadata-documentation/58-RESEARCH.md
+++ b/.planning/phases/58-schema-metadata-documentation/58-RESEARCH.md
@@ -1,0 +1,300 @@
+# Phase 58: Schema Metadata + Documentation - Research
+
+**Researched:** 2026-02-08
+**Domain:** MCP schema discovery, lookahead bias documentation, DuckDB temporal query patterns
+**Confidence:** HIGH
+
+## Summary
+
+Phase 58 is a documentation-focused phase that surfaces the temporal field classification system (built in Phases 55-57) through the `describe_database` tool's output, so that users writing ad-hoc `run_sql` queries get the same lookahead bias protection that the purpose-built tools now have.
+
+The existing infrastructure is fully mature. The `timing` property already exists on every `spx_daily` column in `SCHEMA_DESCRIPTIONS` (schema-metadata.ts), the `OPEN_KNOWN_FIELDS`, `CLOSE_KNOWN_FIELDS`, and `STATIC_FIELDS` derived sets exist in `field-timing.ts`, and the `buildLookaheadFreeQuery()` CTE builder produces correct SQL. What is missing is: (1) the `describe_database` tool output does not include the `timing` property on column info, (2) the example queries use naive same-day JOINs without temporal awareness, and (3) there is no copy-paste LAG() CTE template in the output.
+
+**Primary recommendation:** Extend the `ColumnInfo` interface in schema.ts to include an optional `timing` field, update example queries in schema-metadata.ts to use lag-aware patterns, and add a new `lagTemplate` section to the `describe_database` output.
+
+## Standard Stack
+
+### Core
+
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| TypeScript | 5.x | Implementation language | Existing codebase |
+| zod | 3.x | Tool input schema validation | Already used in all MCP tools |
+| @duckdb/node-api | Current | DuckDB queries | Already used for all market data |
+
+### Supporting
+
+No new libraries needed. This phase modifies existing code only.
+
+## Architecture Patterns
+
+### Files to Modify
+
+```
+packages/mcp-server/src/
+  tools/schema.ts           # ColumnInfo interface + output builder
+  utils/schema-metadata.ts  # EXAMPLE_QUERIES content + new LAG template
+```
+
+### Pattern 1: Extend ColumnInfo with timing
+
+**What:** Add optional `timing` property to `ColumnInfo` interface (schema.ts line 24-30) and populate it from `ColumnDescription.timing` in the column mapping loop (line 145-157).
+
+**Current code (schema.ts line 24-30):**
+```typescript
+interface ColumnInfo {
+  name: string;
+  type: string;
+  description: string;
+  nullable: boolean;
+  hypothesis: boolean;
+}
+```
+
+**Target:**
+```typescript
+interface ColumnInfo {
+  name: string;
+  type: string;
+  description: string;
+  nullable: boolean;
+  hypothesis: boolean;
+  timing?: 'open' | 'close' | 'static';
+}
+```
+
+**Source mapping (schema.ts line 145-157):** Add `timing: colDesc?.timing` to the return object alongside `hypothesis: colDesc?.hypothesis || false`.
+
+### Pattern 2: Replace Naive Example Queries with Lag-Aware Patterns
+
+**What:** The `EXAMPLE_QUERIES` in schema-metadata.ts (lines 815-1023) contain JOIN and hypothesis examples that use naive `t.date_opened = m.date` JOINs reading close-derived fields as same-day values. These must be updated to use the LAG CTE pattern for close-derived fields.
+
+**Current naive JOIN example (line 884-892):**
+```sql
+SELECT
+  t.date_opened, t.strategy, t.pl,
+  m.VIX_Close, m.Vol_Regime, m.Total_Return_Pct
+FROM trades.trade_data t
+JOIN market.spx_daily m ON t.date_opened = m.date
+WHERE t.block_id = 'my-block'
+ORDER BY t.date_opened DESC
+```
+
+**Problem:** `VIX_Close`, `Vol_Regime`, and `Total_Return_Pct` are all close-derived (timing='close'). Using them same-day introduces lookahead bias.
+
+**Fix:** Replace with lag-aware CTE in the example, using the same WITH lagged AS pattern that buildLookaheadFreeQuery produces.
+
+### Pattern 3: LAG() CTE Template in Output
+
+**What:** Add a pre-built, copy-paste LAG() CTE template to the `describe_database` output. This template should be a reusable SQL block that users can adapt for their own queries.
+
+**Where to add:** New property on the `ExampleQueries` interface, or a separate `lagTemplate` field on `DatabaseSchemaOutput`. The template should include the WITH lagged AS CTE pattern with representative open/close/static fields.
+
+**Generated vs hardcoded:** The template can be dynamically generated from `OPEN_KNOWN_FIELDS`, `CLOSE_KNOWN_FIELDS`, and `STATIC_FIELDS` at module load time, ensuring it stays in sync with schema changes. Import the sets from field-timing.ts into schema-metadata.ts or schema.ts.
+
+### Anti-Patterns to Avoid
+
+- **Hardcoding field names in the LAG template:** The field-timing.ts module already derives fields from SCHEMA_DESCRIPTIONS. The template should also derive from the same source to stay in sync automatically.
+- **Making example queries overly verbose:** The LAG CTE template can be a single reusable block; individual example queries should reference it by name or show the complete pattern only once.
+- **Breaking the JSON output structure:** The `DatabaseSchemaOutput` interface is what downstream consumers (Claude) parse. Adding new fields must be additive, never removing existing ones.
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Field classification lists | Hardcoded arrays of field names | `OPEN_KNOWN_FIELDS`, `CLOSE_KNOWN_FIELDS`, `STATIC_FIELDS` from field-timing.ts | Already derived from SCHEMA_DESCRIPTIONS, guaranteed in sync |
+| LAG CTE SQL | Manually written SQL string | `buildLookaheadFreeQuery()` pattern from field-timing.ts | Already tested, handles quoting and parameterization |
+
+**Key insight:** The LAG template for describe_database is documentation-only SQL (not executed), so it can be a static string -- but it should be programmatically generated from the same field sets to prevent drift.
+
+## Common Pitfalls
+
+### Pitfall 1: Circular Import Between schema-metadata.ts and field-timing.ts
+
+**What goes wrong:** field-timing.ts imports from schema-metadata.ts. If schema-metadata.ts imports from field-timing.ts to generate the LAG template, you get a circular dependency.
+
+**Why it happens:** The LAG template needs the field sets, which are in field-timing.ts, which imports SCHEMA_DESCRIPTIONS from schema-metadata.ts.
+
+**How to avoid:** Generate the LAG template in schema.ts (the tool file) which already imports from both modules. Or generate it lazily at tool registration time rather than at module load time.
+
+**Warning signs:** TypeScript compile errors or undefined values at import time.
+
+### Pitfall 2: Example Queries Becoming Too Long
+
+**What goes wrong:** Full LAG CTE patterns are verbose (44 close fields). If every example query includes the full CTE, the describe_database output becomes massive.
+
+**Why it happens:** Trying to be comprehensive in every example.
+
+**How to avoid:** Include one complete LAG CTE template as a reference, then have example queries reference a simplified version or say "use the LAG template above." Or show a truncated CTE with a comment like `-- ... all close-derived fields ...`.
+
+**Warning signs:** describe_database output exceeding token limits in Claude conversations.
+
+### Pitfall 3: Not Updating the ExampleQueries Type
+
+**What goes wrong:** Adding a new section (like `lagTemplate`) without updating the TypeScript interfaces causes type errors.
+
+**Why it happens:** ExampleQueries has typed categories (basic, joins, hypothesis).
+
+**How to avoid:** Either add a new property to ExampleQueries, or add the template as a separate field on DatabaseSchemaOutput.
+
+### Pitfall 4: Forgetting to Bump MCP Server Version
+
+**What goes wrong:** describe_database output changes but version stays at 1.1.0.
+
+**How to avoid:** Bump to 1.2.0 (minor: new schema discovery features, non-breaking).
+
+## Code Examples
+
+### Adding timing to ColumnInfo output (schema.ts)
+
+```typescript
+// In the column mapping loop (schema.ts ~line 145-157)
+const columns: ColumnInfo[] = columnsData.map(
+  ([columnName, dataType, isNullable]) => {
+    const colDesc: ColumnDescription | undefined =
+      tableDesc?.columns?.[columnName];
+    return {
+      name: columnName,
+      type: dataType,
+      description: colDesc?.description || "",
+      nullable: isNullable,
+      hypothesis: colDesc?.hypothesis || false,
+      timing: colDesc?.timing,  // <-- NEW: undefined for non-market tables
+    };
+  }
+);
+```
+
+### Lag-aware example query pattern
+
+```typescript
+// Replace naive join examples with lag-aware patterns
+{
+  description: "Trade P&L with market context (lag-aware: close-derived fields use prior trading day)",
+  sql: `WITH lagged AS (
+  SELECT date,
+    -- Open-known (same-day, safe)
+    Gap_Pct, VIX_Open, Prior_Close,
+    -- Static (same-day, safe)
+    Day_of_Week, Month, Is_Opex,
+    -- Close-derived (use prior trading day to prevent lookahead bias)
+    LAG(VIX_Close) OVER (ORDER BY date) AS prev_VIX_Close,
+    LAG(Vol_Regime) OVER (ORDER BY date) AS prev_Vol_Regime,
+    LAG(RSI_14) OVER (ORDER BY date) AS prev_RSI_14
+  FROM market.spx_daily
+)
+SELECT t.date_opened, t.strategy, t.pl,
+  m.Gap_Pct, m.VIX_Open,
+  m.prev_VIX_Close, m.prev_Vol_Regime, m.prev_RSI_14
+FROM trades.trade_data t
+JOIN lagged m ON t.date_opened = m.date
+WHERE t.block_id = 'my-block'
+ORDER BY t.date_opened DESC`,
+}
+```
+
+### LAG template generation (in schema.ts at tool registration time)
+
+```typescript
+import {
+  OPEN_KNOWN_FIELDS,
+  CLOSE_KNOWN_FIELDS,
+  STATIC_FIELDS,
+} from "../utils/field-timing.js";
+
+function generateLagTemplate(): string {
+  const openCols = [...OPEN_KNOWN_FIELDS].map(f => `    ${f}`).join(',\n');
+  const staticCols = [...STATIC_FIELDS].map(f => `    ${f}`).join(',\n');
+  const lagCols = [...CLOSE_KNOWN_FIELDS]
+    .map(f => `    LAG(${f}) OVER (ORDER BY date) AS prev_${f}`)
+    .join(',\n');
+
+  return `-- Lookahead-free LAG CTE template for market.spx_daily
+-- Open-known fields: use same-day values (known at/before market open)
+-- Static fields: use same-day values (calendar facts known in advance)
+-- Close-derived fields: use LAG() for prior trading day values
+WITH lagged AS (
+  SELECT date,
+    -- Open-known fields (safe same-day)
+${openCols},
+    -- Static fields (safe same-day)
+${staticCols},
+    -- Close-derived fields (prior trading day via LAG)
+${lagCols}
+  FROM market.spx_daily
+)
+SELECT *
+FROM trades.trade_data t
+JOIN lagged m ON t.date_opened = m.date
+WHERE t.block_id = 'my-block'`;
+}
+```
+
+### DatabaseSchemaOutput extension
+
+```typescript
+interface DatabaseSchemaOutput {
+  schemas: Record<string, SchemaInfo>;
+  examples: typeof EXAMPLE_QUERIES;
+  lagTemplate: {
+    description: string;
+    sql: string;
+    fieldCounts: {
+      openKnown: number;
+      static: number;
+      closeDerived: number;
+    };
+  };
+  syncInfo: {
+    blocksProcessed: number;
+    marketFilesSynced: number;
+  };
+}
+```
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| Naive same-day JOINs | LAG CTE for close-derived fields | Phase 55-57 (2026-02-08) | Prevents lookahead bias in all purpose-built tools |
+| No timing metadata in schema output | timing property on ColumnDescription | Phase 55 (2026-02-08) | Classification exists but not surfaced to users |
+| Example queries show naive JOINs | (This phase) Example queries show lag-aware patterns | Phase 58 | Users of run_sql get correct guidance |
+
+## Open Questions
+
+1. **Should the LAG template include ALL 44 close-derived fields or a curated subset?**
+   - What we know: The full template with 44 LAG() lines is verbose but comprehensive.
+   - What's unclear: Whether Claude's context window handles 44+ lines of LAG columns well, or if a shorter "most commonly used" subset is better.
+   - Recommendation: Include the full template in the `lagTemplate.sql` field (it is generated programmatically so always stays in sync). Claude can truncate as needed.
+
+2. **Should existing naive example queries be kept alongside lag-aware versions?**
+   - What we know: Some basic examples (like "Recent market conditions" which queries spx_daily alone without trade JOINs) don't need lag awareness.
+   - What's unclear: Whether removing naive JOIN examples is too aggressive.
+   - Recommendation: Replace only the JOIN/hypothesis examples that mix trades with close-derived market fields. Keep pure market-data-only and pure trade-only examples as-is.
+
+## Sources
+
+### Primary (HIGH confidence)
+- `packages/mcp-server/src/tools/schema.ts` - Current describe_database implementation, ColumnInfo interface, DatabaseSchemaOutput type
+- `packages/mcp-server/src/utils/schema-metadata.ts` - SCHEMA_DESCRIPTIONS with timing annotations, ColumnDescription interface, EXAMPLE_QUERIES
+- `packages/mcp-server/src/utils/field-timing.ts` - OPEN_KNOWN_FIELDS (8), CLOSE_KNOWN_FIELDS (44), STATIC_FIELDS (3), buildLookaheadFreeQuery()
+- `packages/mcp-server/src/tools/market-data.ts` - Working examples of lag-aware query usage in analyze_regime_performance, suggest_filters, enrich_trades
+- `.planning/phases/55-*/55-01-SUMMARY.md` - Field classification foundation decisions
+- `.planning/phases/56-*/56-01-SUMMARY.md` - Tool migration patterns and decisions
+- `.planning/phases/57-*/57-01-SUMMARY.md` - enrich_trades implementation and patterns
+
+### Secondary (MEDIUM confidence)
+- None needed -- all information is from the codebase itself.
+
+### Tertiary (LOW confidence)
+- None.
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack: HIGH - No new libraries, pure modification of existing code
+- Architecture: HIGH - Pattern is clear from field-timing.ts and working tools
+- Pitfalls: HIGH - Circular import and output size are concrete, verified concerns
+
+**Research date:** 2026-02-08
+**Valid until:** Indefinite (internal codebase knowledge, not external library)

--- a/.planning/phases/59-intraday-market-context-enrichment/59-01-SUMMARY.md
+++ b/.planning/phases/59-intraday-market-context-enrichment/59-01-SUMMARY.md
@@ -1,0 +1,106 @@
+---
+phase: 59-intraday-market-context-enrichment
+plan: 01
+subsystem: api
+tags: [duckdb, mcp, intraday, spx-15min, vix-intraday, temporal-filtering, lookahead-free]
+
+# Dependency graph
+requires:
+  - phase: 57-restore-enrich-trades
+    provides: "enrich_trades tool with lag-aware spx_daily enrichment, filterByStrategy/filterByDateRange, resultToRecords"
+provides:
+  - "intraday-timing.ts utility module with checkpoint constants and temporal filtering"
+  - "enrich_trades includeIntradayContext parameter for per-trade SPX/VIX checkpoint data"
+  - "Intraday outcome fields (MOC, VIX flags) via dual-flag opt-in"
+  - "MCP server v1.3.0"
+affects: [future-intraday-analysis, mcp-server]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns: ["per-timestamp checkpoint model (vs open/close binary)", "dual-flag outcome field gating"]
+
+key-files:
+  created:
+    - packages/mcp-server/src/utils/intraday-timing.ts
+  modified:
+    - packages/mcp-server/src/tools/market-data.ts
+    - packages/mcp-server/package.json
+
+key-decisions:
+  - "Checkpoint at time T is known AT time T (inclusive), so trade at 09:30 sees P_0930"
+  - "timeOpened=00:00:00 returns empty knownCheckpoints (not null intradayContext), treated as before market open"
+  - "Intraday outcome fields require BOTH includeIntradayContext=true AND includeOutcomeFields=true"
+  - "SPX outcome fields prefixed with spx_ (e.g., spx_MOC_30min); VIX outcomes already namespaced"
+  - "VIX OHLC outcomes prefixed with vix_ (e.g., vix_high, vix_close); VIX open excluded (known at open)"
+
+patterns-established:
+  - "Per-timestamp checkpoint filtering: parse timeOpened to HHMM, filter checkpoint arrays by <= comparison"
+  - "Dual-flag opt-in: intradayOutcomeFields only appear when both includeIntradayContext and includeOutcomeFields are true"
+  - "Separate checkpoint timing module (intraday-timing.ts) distinct from binary open/close model (field-timing.ts)"
+
+# Metrics
+duration: 3min
+completed: 2026-02-08
+---
+
+# Phase 59 Plan 01: Intraday Market Context Enrichment Summary
+
+**Per-trade intraday SPX/VIX checkpoint enrichment via time-filtered buildIntradayContext, extending enrich_trades with lookahead-free 15-min/30-min checkpoint data**
+
+## Performance
+
+- **Duration:** 3 min
+- **Started:** 2026-02-08T23:02:30Z
+- **Completed:** 2026-02-08T23:06:00Z
+- **Tasks:** 2
+- **Files modified:** 3
+
+## Accomplishments
+- Created intraday-timing.ts with SPX (26) and VIX (14) checkpoint constants, temporal filtering functions, and IntradayContext builder
+- Extended enrich_trades with includeIntradayContext parameter for per-trade checkpoint data filtered by trade entry time
+- Intraday outcome fields (MOC moves, VIX spike/crush flags) gated behind dual-flag requirement
+- MCP server bumped to v1.3.0 (minor: new backward-compatible feature)
+
+## Task Commits
+
+Each task was committed atomically:
+
+1. **Task 1: Create intraday-timing.ts utility module** - `5d00a16` (feat)
+2. **Task 2: Extend enrich_trades with intraday context and bump version** - `a628e67` (feat)
+
+## Files Created/Modified
+- `packages/mcp-server/src/utils/intraday-timing.ts` - Checkpoint time constants, temporal filtering, IntradayContext builder
+- `packages/mcp-server/src/tools/market-data.ts` - Extended enrich_trades with includeIntradayContext parameter and intraday enrichment logic
+- `packages/mcp-server/package.json` - Version bump 1.2.0 -> 1.3.0
+
+## Decisions Made
+- Checkpoint at time T is known AT time T (inclusive) -- a trade at exactly 09:30 sees P_0930
+- timeOpened="00:00:00" returns the IntradayContext structure with empty knownCheckpoints (not null), allowing consumers to distinguish "intraday requested but no checkpoints available" from "intraday not requested"
+- Intraday outcome fields require BOTH includeIntradayContext and includeOutcomeFields to be true, maintaining the existing outcomeFields semantic of "data not available at entry time"
+- SPX outcome fields namespaced with `spx_` prefix to avoid collision with VIX fields; VIX OHLC outcomes prefixed with `vix_`
+- VIX `open` excluded from outcome fields (known at market open, not end-of-day)
+
+## Deviations from Plan
+
+None - plan executed exactly as written.
+
+## Issues Encountered
+- Pre-existing TypeScript error in connection.ts (null-to-DuckDBConnection cast) unrelated to this plan; verified it exists before and after changes
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+- Intraday enrichment complete and ready for use via enrich_trades includeIntradayContext=true
+- This is the final phase of the v2.9 Lookahead-Free Market Analytics milestone
+- All phases (55-59) complete: field classification, tool fixes, enrich_trades restore, schema metadata, intraday context
+
+## Self-Check: PASSED
+
+All files verified present, all commits verified in git log.
+
+---
+*Phase: 59-intraday-market-context-enrichment*
+*Completed: 2026-02-08*

--- a/.planning/phases/59-intraday-market-context-enrichment/59-RESEARCH.md
+++ b/.planning/phases/59-intraday-market-context-enrichment/59-RESEARCH.md
@@ -1,0 +1,400 @@
+# Phase 59: Intraday Market Context Enrichment - Research
+
+**Researched:** 2026-02-08
+**Domain:** MCP tool extension / DuckDB intraday checkpoint matching / time-based trade enrichment
+**Confidence:** HIGH
+
+## Summary
+
+This phase extends the `enrich_trades` MCP tool (built in Phase 57) with intraday market context from two DuckDB tables: `market.spx_15min` (26 price checkpoints at 15-minute intervals from 0930-1545, plus 4 percentage moves, 4 MOC moves, 1 afternoon move = 35 data fields) and `market.vix_intraday` (14 VIX checkpoints at 30-minute intervals from 0930-1545, plus 13 movement/flag metrics = 27 data fields). Both tables are keyed by date (VARCHAR, YYYY-MM-DD).
+
+The critical design question is **temporal semantics**: unlike spx_daily where fields are classified as open/close/static, intraday checkpoints have a third temporal dimension -- each checkpoint is known at its specific timestamp. A trade entered at 09:35 can see P_0930 but not P_0945. However, the REQUIREMENTS.md Out of Scope section explicitly called out "Per-trade time-of-day awareness" as "Massive complexity for marginal benefit; most 0DTE trades open 9:30-9:45 AM." This creates a fundamental tension: the user deferred this to its own phase, suggesting they want it done, but the requirements document flags it as potentially not worth the complexity.
+
+After thorough investigation, the recommended approach is a **practical middle ground**: rather than full per-checkpoint temporal filtering, provide two enrichment modes. The **default mode** returns day-level aggregate metrics from both tables (MOC moves, afternoon move, VIX spike/crush flags, full-day moves) that are outcome-like and clearly labeled as such. The **time-aware mode** (opt-in) uses the trade's `timeOpened` field to determine which checkpoints were known at entry time and returns only those, plus a computed "SPX price at entry" from the nearest prior checkpoint. This leverages the existing `timeOpened` field (HH:mm:ss format, Eastern Time) that every trade already has.
+
+**Primary recommendation:** Add a new `includeIntradayContext` parameter to the existing `enrich_trades` tool (not a separate tool) that queries spx_15min and vix_intraday by date, then uses `timeOpened` to filter checkpoints to only those known at trade entry time. Day-level aggregates (MOC, afternoon move, VIX flags) go in outcomeFields since they require end-of-day data.
+
+## Standard Stack
+
+### Core
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| zod | ^4.0.0 | Input schema validation | Already used by enrich_trades |
+| @duckdb/node-api | ^1.4.4-r.1 | DuckDB queries for market data | Existing connection manager |
+| @tradeblocks/lib | workspace | Trade type (timeOpened field) | Already imported in market-data.ts |
+
+### Supporting
+| Library | Version | Purpose | When to Use |
+|---------|---------|---------|-------------|
+| field-timing.ts | internal | Existing field classification | Not directly applicable -- spx_15min/vix_intraday don't have timing annotations |
+| schema-metadata.ts | internal | SCHEMA_DESCRIPTIONS | Already has spx_15min and vix_intraday table metadata |
+| market-data.ts | internal | formatTradeDate(), resultToRecords(), getNum() | Reuse for date formatting and result parsing |
+
+### Alternatives Considered
+| Instead of | Could Use | Tradeoff |
+|------------|-----------|----------|
+| Extending enrich_trades | Separate tool (e.g., enrich_trades_intraday) | More parameters on enrich_trades vs tool fragmentation; single tool is cleaner since the output is still "enriched trades" |
+| Time-based checkpoint filtering in JS | DuckDB UNPIVOT + time filtering | UNPIVOT adds SQL complexity; JS filtering on wide-format columns is simpler and the data volume (1 row per trade per day) is trivial |
+| Full checkpoint array per trade | Pre-computed derived metrics only | Full checkpoints enable richer downstream analysis (e.g., "what was SPX doing when I entered?") |
+
+**Installation:** No new packages required. All dependencies already exist.
+
+## Architecture Patterns
+
+### Recommended Project Structure
+```
+packages/mcp-server/src/
+  tools/
+    market-data.ts          # Extend enrich_trades handler (add intraday queries)
+  utils/
+    schema-metadata.ts      # Already has spx_15min + vix_intraday metadata (no changes needed)
+    intraday-timing.ts      # NEW: checkpoint time constants and temporal filtering logic
+```
+
+### Pattern 1: Time-Based Checkpoint Filtering
+**What:** Given a trade's `timeOpened` (e.g., "09:35:00"), determine which intraday checkpoints were known at that time.
+**When to use:** Building the per-trade intraday context.
+**Example:**
+```typescript
+// Checkpoint times as HHMM integers for easy comparison
+const SPX_CHECKPOINTS = [
+  930, 945, 1000, 1015, 1030, 1045, 1100, 1115, 1130, 1145,
+  1200, 1215, 1230, 1245, 1300, 1315, 1330, 1345, 1400, 1415,
+  1430, 1445, 1500, 1515, 1530, 1545,
+] as const;
+
+const VIX_CHECKPOINTS = [
+  930, 1000, 1030, 1100, 1130, 1200, 1230, 1300,
+  1330, 1400, 1430, 1500, 1530, 1545,
+] as const;
+
+/**
+ * Parse timeOpened "HH:mm:ss" to HHMM integer for comparison.
+ * e.g., "09:35:00" -> 935, "14:30:00" -> 1430
+ */
+function parseTimeToHHMM(timeStr: string): number {
+  const [hours, minutes] = timeStr.split(':').map(Number);
+  return hours * 100 + minutes;
+}
+
+/**
+ * Get checkpoint field names known at or before the given time.
+ * A checkpoint at time T is known at time T (the price has printed).
+ */
+function getKnownSpxCheckpoints(tradeTimeHHMM: number): string[] {
+  return SPX_CHECKPOINTS
+    .filter(cp => cp <= tradeTimeHHMM)
+    .map(cp => `P_${String(cp).padStart(4, '0')}`);
+}
+
+function getKnownVixCheckpoints(tradeTimeHHMM: number): string[] {
+  return VIX_CHECKPOINTS
+    .filter(cp => cp <= tradeTimeHHMM)
+    .map(cp => `VIX_${String(cp).padStart(4, '0')}`);
+}
+```
+
+### Pattern 2: Intraday Context Output Structure
+**What:** Per-trade intraday context with clear temporal provenance.
+**When to use:** Building enriched trade output when `includeIntradayContext=true`.
+**Example output shape:**
+```typescript
+{
+  // Existing enrich_trades fields...
+  dateOpened: "2024-03-15",
+  timeOpened: "09:35:00",
+  entryContext: { sameDay: {...}, priorDay: {...} },  // existing spx_daily
+
+  // NEW: intraday context
+  intradayContext: {
+    tradeEntryTime: "09:35:00",           // Echo for clarity
+    tradeEntryTimeHHMM: 935,              // Parsed for programmatic use
+    spx: {
+      // Only checkpoints known at 09:35 (i.e., P_0930)
+      knownCheckpoints: { P_0930: 5234.50 },
+      // Nearest checkpoint at or before entry
+      nearestCheckpoint: { time: "0930", price: 5234.50 },
+      // Move from open to nearest checkpoint (if > open)
+      moveFromOpen: 0.15,  // percent
+    },
+    vix: {
+      // Only checkpoints known at 09:35 (i.e., VIX_0930)
+      knownCheckpoints: { VIX_0930: 14.25 },
+      nearestCheckpoint: { time: "0930", value: 14.25 },
+    },
+  },
+}
+```
+
+### Pattern 3: Day-Level Aggregates as Outcome Fields
+**What:** MOC moves, afternoon move, VIX spike/crush flags, and full-day moves are end-of-day metrics. They go in `outcomeFields` (alongside the spx_daily outcome fields) when `includeOutcomeFields=true`.
+**When to use:** Post-hoc analysis of how the day played out after trade entry.
+**Rationale:** Consistent with the Phase 57 outcome fields ethos -- separate structural boundary between what was known at entry and what happened after.
+
+### Anti-Patterns to Avoid
+- **Returning all 26 checkpoints regardless of entry time:** This is lookahead bias for intraday data. A trade at 09:35 should not see P_1000.
+- **Treating intraday tables like spx_daily (open/close classification):** The checkpoint model is fundamentally different. Each checkpoint has its own specific timestamp, not a binary open/close classification.
+- **Adding timing annotations to spx_15min/vix_intraday columns in schema-metadata.ts:** The timing property is designed for the open/close/static model of spx_daily. Checkpoints don't fit this model. Don't force them.
+- **Separate DuckDB query per trade:** Query once per date, match in memory. The wide-format (1 row per date) means a single query gets all checkpoint data for a date.
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Date matching | Custom date logic | Existing `formatTradeDate()` | Already handles Eastern Time correctly |
+| DuckDB result parsing | Custom row iteration | Existing `resultToRecords()` | Handles BigInt conversion |
+| Response formatting | Manual JSON | Existing `createToolOutput()` | Universal MCP response pattern |
+| Trade filtering | Custom filter | Existing `filterByStrategy()`, `filterByDateRange()` | Already tested |
+| Checkpoint time constants | Hardcoded in tool handler | Extracted to `intraday-timing.ts` utility | Reusable by calculate_orb and future tools |
+
+**Key insight:** The main new code is (1) the time parsing/comparison logic and (2) the checkpoint filtering per trade. Everything else reuses Phase 57 infrastructure.
+
+## Common Pitfalls
+
+### Pitfall 1: Trades With Missing or Invalid timeOpened
+**What goes wrong:** Some trades might have `timeOpened` as "00:00:00" (default from trade processor when missing) or an unexpected format.
+**Why it happens:** The trade processor defaults to "00:00:00" when Time Opened is empty in CSV.
+**How to avoid:** When `timeOpened` is "00:00:00" or unparseable, either (a) skip intraday enrichment for that trade and set `intradayContext: null` with a note, or (b) treat it as "market open" (09:30) since 0DTE trades almost always open at or near 9:30. Option (b) is pragmatic given the user's note that "most 0DTE trades open 9:30-9:45 AM."
+**Warning signs:** Trades showing no intraday context when they should have it.
+
+### Pitfall 2: Two Extra DuckDB Queries Per Request
+**What goes wrong:** Adding intraday enrichment means 2 more DuckDB queries (spx_15min + vix_intraday) on top of the existing 1-2 queries (spx_daily + optional outcome). This could slow down the tool.
+**Why it happens:** Each table is separate in DuckDB.
+**How to avoid:** Only run the intraday queries when `includeIntradayContext=true`. Make it opt-in like `includeOutcomeFields`. The queries themselves are fast (IN clause on date VARCHAR, returns 1 row per date).
+**Warning signs:** Noticeable latency increase when all options enabled.
+
+### Pitfall 3: Output Size Explosion
+**What goes wrong:** With spx_daily (55 fields), spx_15min (35 fields), and vix_intraday (27 fields), each enriched trade could have 100+ fields of market context. At 50 trades, that's 5000+ data points.
+**Why it happens:** The Phase 57 design returns "full context" for spx_daily. Doing the same for intraday would be excessive.
+**How to avoid:** For intraday context, return only the checkpoints known at entry time (typically 0-1 for 9:30-9:45 entries) plus nearest checkpoint info. Day-level aggregates go in outcomeFields only when requested. This keeps the default output lean.
+**Warning signs:** MCP tool responses exceeding context window limits.
+
+### Pitfall 4: Checkpoint Column Name Format Mismatch
+**What goes wrong:** SPX checkpoints use `P_HHMM` format (e.g., `P_0930`) while VIX checkpoints use `VIX_HHMM` format (e.g., `VIX_0930`). These prefixes are different.
+**Why it happens:** Different table schemas from different PineScript exports.
+**How to avoid:** Use separate checkpoint-to-field-name mappings for each table. The constants in `intraday-timing.ts` handle this.
+**Warning signs:** Missing checkpoint values due to wrong column name lookup.
+
+### Pitfall 5: VIX Checkpoints Are 30-Minute, Not 15-Minute
+**What goes wrong:** Assuming VIX checkpoints match SPX 15-minute intervals. VIX has 14 checkpoints at 30-minute intervals (0930, 1000, 1030..., 1530, 1545), not 26 at 15-minute.
+**Why it happens:** Phase description says "14 VIX checkpoints" but it's easy to assume matching granularity.
+**How to avoid:** Maintain separate checkpoint arrays for SPX and VIX. The nearest-checkpoint logic must use the correct array for each table.
+**Warning signs:** Null values for VIX checkpoints at odd 15-minute marks (e.g., VIX_0945 doesn't exist).
+
+### Pitfall 6: No Timing Annotations on Intraday Tables
+**What goes wrong:** Attempting to use `OPEN_KNOWN_FIELDS`/`CLOSE_KNOWN_FIELDS` patterns from `field-timing.ts` for intraday tables. These sets only cover `spx_daily`.
+**Why it happens:** Phase 55 only added timing annotations to spx_daily in schema-metadata.ts. The intraday tables have no timing property on their columns.
+**How to avoid:** Don't use the field-timing.ts infrastructure for intraday enrichment. The temporal logic is fundamentally different (per-checkpoint timestamps vs. open/close binary). Build separate checkpoint-timing logic in `intraday-timing.ts`.
+**Warning signs:** Empty field sets if you try to filter schema-metadata by timing for non-spx_daily tables.
+
+## Code Examples
+
+### Example 1: Intraday Query Builder
+```typescript
+// Source: derived from existing patterns in market-data.ts
+function buildIntradayQuery(
+  table: 'market.spx_15min' | 'market.vix_intraday',
+  tradeDates: string[]
+): { sql: string; params: string[] } {
+  const placeholders = tradeDates.map((_, i) => `$${i + 1}`).join(', ');
+  const sql = `SELECT * FROM ${table} WHERE date IN (${placeholders})`;
+  return { sql, params: tradeDates };
+}
+```
+
+### Example 2: Per-Trade Intraday Context Builder
+```typescript
+// Source: new logic combining existing patterns
+function buildIntradayContext(
+  tradeTimeOpened: string,
+  spxData: Record<string, unknown> | null,
+  vixData: Record<string, unknown> | null,
+): IntradayContext | null {
+  if (!spxData && !vixData) return null;
+
+  const tradeTimeHHMM = parseTimeToHHMM(tradeTimeOpened);
+
+  const spxContext: Record<string, unknown> = {};
+  const vixContext: Record<string, unknown> = {};
+
+  if (spxData) {
+    const knownCheckpoints: Record<string, unknown> = {};
+    let nearestTime = '';
+    let nearestPrice: number | null = null;
+
+    for (const cp of SPX_CHECKPOINTS) {
+      if (cp <= tradeTimeHHMM) {
+        const field = `P_${String(cp).padStart(4, '0')}`;
+        const val = spxData[field];
+        if (val !== null && val !== undefined) {
+          knownCheckpoints[field] = typeof val === 'bigint' ? Number(val) : val;
+          nearestTime = String(cp).padStart(4, '0');
+          nearestPrice = typeof val === 'bigint' ? Number(val) : val as number;
+        }
+      }
+    }
+
+    spxContext.knownCheckpoints = knownCheckpoints;
+    spxContext.nearestCheckpoint = nearestPrice !== null
+      ? { time: nearestTime, price: nearestPrice }
+      : null;
+
+    // Move from day open to nearest checkpoint
+    const openPrice = spxData['open'] as number;
+    if (nearestPrice !== null && openPrice > 0) {
+      spxContext.moveFromOpen = Math.round(((nearestPrice - openPrice) / openPrice) * 10000) / 100;
+    }
+  }
+
+  // Similar logic for VIX...
+
+  return {
+    tradeEntryTime: tradeTimeOpened,
+    tradeEntryTimeHHMM: tradeTimeHHMM,
+    spx: Object.keys(spxContext).length > 0 ? spxContext : null,
+    vix: Object.keys(vixContext).length > 0 ? vixContext : null,
+  };
+}
+```
+
+### Example 3: Extending enrich_trades Input Schema
+```typescript
+// Source: extending existing pattern in market-data.ts
+inputSchema: z.object({
+  blockId: z.string().describe("Block ID to enrich"),
+  strategy: z.string().optional().describe("Filter to specific strategy (exact match)"),
+  startDate: z.string().optional().describe("Start date filter (YYYY-MM-DD)"),
+  endDate: z.string().optional().describe("End date filter (YYYY-MM-DD)"),
+  includeOutcomeFields: z.boolean().default(false).describe(
+    "Include same-day close values (lookahead). Defaults to false for safety."
+  ),
+  includeIntradayContext: z.boolean().default(false).describe(
+    "Include intraday SPX/VIX checkpoint data. Only checkpoints known at trade entry time are returned."
+  ),
+  limit: z.number().min(1).max(500).default(50).describe("Max trades to return (default: 50, max: 500)"),
+  offset: z.number().min(0).default(0).describe("Pagination offset (default: 0)"),
+}),
+```
+
+### Example 4: Day-Level Aggregate Fields for Outcome
+```typescript
+// These spx_15min fields are end-of-day aggregates -> outcomeFields
+const SPX_15MIN_OUTCOME_FIELDS = [
+  'Pct_0930_to_1000', 'Pct_0930_to_1200', 'Pct_0930_to_1500', 'Pct_0930_to_Close',
+  'MOC_15min', 'MOC_30min', 'MOC_45min', 'MOC_60min',
+  'Afternoon_Move',
+] as const;
+
+// These vix_intraday fields are end-of-day aggregates -> outcomeFields
+const VIX_OUTCOME_FIELDS = [
+  'VIX_Day_High', 'VIX_Day_Low',
+  'VIX_Morning_Move', 'VIX_Afternoon_Move', 'VIX_Power_Hour_Move',
+  'VIX_Last_30min_Move', 'VIX_Full_Day_Move', 'VIX_First_Hour_Move',
+  'VIX_Intraday_Range_Pct', 'VIX_Spike_From_Open', 'VIX_Spike_Flag',
+  'VIX_Crush_From_Open', 'VIX_Crush_Flag', 'VIX_Close_In_Range',
+] as const;
+```
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| No intraday enrichment | enrich_trades returns only spx_daily context | Phase 57, 2026-02-08 | Foundation exists but missing 15min/VIX data |
+| calculate_orb queries spx_15min directly | ORB tool exists but isn't per-trade | Phase 45 (original) | Shows the query pattern works |
+| Out of Scope: per-trade time-of-day | This phase implements it | Phase 59 (this phase) | Reverses the out-of-scope decision from REQUIREMENTS.md |
+
+**Key context changes since requirements were written:**
+- `enrich_trades` now exists with a clean extension point (`entryContext` structure)
+- `timeOpened` field is already present in every enriched trade output (line 777 of market-data.ts)
+- The field-timing infrastructure from Phases 55-56 doesn't need to be extended (intraday uses a different temporal model)
+- The "most 0DTE trades open 9:30-9:45 AM" observation actually makes time-based filtering simpler, not harder: most trades will have 0-1 known checkpoints, keeping output small
+
+## Open Questions
+
+1. **Should intradayContext be opt-in or always included?**
+   - What we know: The Phase 57 pattern is opt-in for expensive/lookahead data. Intraday checkpoint data at entry time is NOT lookahead (it was known at entry). But it adds 2 DuckDB queries.
+   - What's unclear: Whether users will always want intraday context or only sometimes.
+   - Recommendation: Opt-in via `includeIntradayContext=true`. Keeps backward compatibility, avoids extra queries when not needed. The opt-in pattern is already established with `includeOutcomeFields`.
+
+2. **How to handle trades with timeOpened="00:00:00"?**
+   - What we know: Trade processor defaults to "00:00:00" for missing times. Most real trades are 09:30-09:45.
+   - What's unclear: How many real trades have this default value.
+   - Recommendation: Treat "00:00:00" as "before market open" -- return no intraday checkpoints but still include the context structure with `knownCheckpoints: {}`. Document this in the lagNote. Alternative: default to 09:30 since that's the most common entry time. The choice depends on whether false negatives (missing data) or false positives (assuming 9:30) are worse.
+
+3. **Should intraday outcome fields require `includeOutcomeFields=true` or `includeIntradayContext=true`?**
+   - What we know: Day-level aggregates (MOC moves, VIX flags) are outcome data (require EOD). Phase 57 has a clean outcomeFields section.
+   - What's unclear: Whether intraday outcome fields should piggyback on the existing `includeOutcomeFields` flag or require both flags.
+   - Recommendation: Require BOTH flags. `includeIntradayContext=true` enables the checkpoint data at entry time. `includeOutcomeFields=true` (existing) enables ALL outcome data including intraday aggregates. This keeps the outcomeFields semantic consistent: "data not available at entry time."
+
+4. **Version bump strategy**
+   - What we know: MCP server is at v1.2.0 (Phase 58). This extends an existing tool's schema.
+   - Recommendation: Bump to v1.3.0 (minor: new feature, backward compatible since new params have defaults).
+
+## Detailed Schema Reference
+
+### market.spx_15min (35 data columns + date)
+**Checkpoint columns (26):** P_0930 through P_1545 at 15-minute intervals
+- These represent SPX price at each timestamp
+- Each is known at its timestamp (not open/close)
+- All DOUBLE type
+
+**Percentage move columns (4):**
+- Pct_0930_to_1000, Pct_0930_to_1200, Pct_0930_to_1500, Pct_0930_to_Close
+- All require end-of-period data (outcome fields)
+
+**MOC columns (4):**
+- MOC_15min, MOC_30min, MOC_45min, MOC_60min
+- Market-on-close moves (outcome fields)
+
+**Other (1):**
+- Afternoon_Move: 12:00 PM to close (outcome field)
+
+### market.vix_intraday (27 data columns + date)
+**Checkpoint columns (14):** VIX_0930 through VIX_1545 at ~30-minute intervals
+- Note irregular spacing: 0930, 1000, 1030, ..., 1530, 1545 (1545 is only 15 min after 1530)
+- Each is known at its timestamp
+- All DOUBLE type
+
+**OHLC (4):** open, high, low, close (outcome: high/low/close not known at entry)
+
+**Aggregate metrics (13):**
+- VIX_Day_High, VIX_Day_Low (outcome)
+- VIX_Morning_Move, VIX_Afternoon_Move, VIX_Power_Hour_Move, VIX_Last_30min_Move, VIX_Full_Day_Move, VIX_First_Hour_Move (outcome)
+- VIX_Intraday_Range_Pct (outcome)
+- VIX_Spike_From_Open, VIX_Spike_Flag, VIX_Crush_From_Open, VIX_Crush_Flag (outcome)
+- VIX_Close_In_Range (outcome)
+
+### Trade timeOpened Format
+- Stored as string in HH:mm:ss format (24-hour, Eastern Time)
+- Examples from test data: "09:30:00", "09:35:00", "09:45:00", "10:00:00", "10:15:00", "11:00:00", "14:00:00", "15:19:00"
+- Default when missing: "00:00:00"
+
+## Sources
+
+### Primary (HIGH confidence)
+- `packages/mcp-server/src/tools/market-data.ts` -- Current enrich_trades implementation (lines 696-865), calculate_orb checkpoint handling (lines 869-1070)
+- `packages/mcp-server/src/db/schemas.ts` -- spx_15min table schema (lines 195-238), vix_intraday table schema (lines 244-282)
+- `packages/mcp-server/src/utils/schema-metadata.ts` -- spx_15min metadata (lines 501-666), vix_intraday metadata (lines 667-806)
+- `packages/lib/models/trade.ts` -- Trade interface with timeOpened: string (line 8)
+- `packages/lib/processing/trade-processor.ts` -- timeOpened default "00:00:00" (line 390)
+- `.planning/phases/57-restore-enrich-trades/57-CONTEXT.md` -- Deferred intraday enrichment rationale (lines 63-68)
+- `.planning/REQUIREMENTS.md` -- EXT-02, EXT-03 future requirements; Out of Scope note on per-trade time-of-day (lines 39-49)
+
+### Secondary (MEDIUM confidence)
+- `tests/data/mock-trades.ts` -- Real timeOpened values: "09:30:00", "10:15:00", "09:45:00", "11:00:00"
+- `.planning/phases/57-restore-enrich-trades/57-RESEARCH.md` -- Phase 57 patterns to extend
+
+### Tertiary (LOW confidence)
+None -- all findings verified from codebase sources.
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack: HIGH -- No new dependencies, all existing infrastructure
+- Architecture: HIGH -- Extension of proven enrich_trades pattern with time-based filtering (new but straightforward)
+- Temporal semantics: HIGH -- Clear checkpoint-at-timestamp model differs from open/close model; design handles both
+- Pitfalls: HIGH -- Identified from direct code reading and schema analysis
+- Output structure: MEDIUM -- Open questions about flag semantics (opt-in behavior) need user decision
+
+**Research date:** 2026-02-08
+**Valid until:** 2026-03-08 (stable -- no external dependencies, all internal patterns)

--- a/packages/mcp-server/manifest.json
+++ b/packages/mcp-server/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "tradeblocks",
   "display_name": "TradeBlocks",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Options trading analysis - backtest stats, walk-forward analysis, Monte Carlo simulations, and risk metrics",
   "long_description": "TradeBlocks MCP server provides comprehensive options trading analysis capabilities. Import your trade logs and get detailed performance statistics, run walk-forward analysis to detect overfitting, perform Monte Carlo simulations for risk assessment, calculate optimal position sizing with Kelly criterion, and compare backtest results against actual trading performance. All analysis runs locally on your machine.",
   "author": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks-mcp",
-  "version": "1.3.0",
+  "version": "1.1.0",
   "description": "MCP server for options trade analysis - works with Claude Desktop/Cowork",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "type": "module",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks-mcp",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "MCP server for options trade analysis - works with Claude Desktop/Cowork",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "type": "module",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks-mcp",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "MCP server for options trade analysis - works with Claude Desktop/Cowork",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "type": "module",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks-mcp",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "MCP server for options trade analysis - works with Claude Desktop/Cowork",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "type": "module",

--- a/packages/mcp-server/src/test-exports.ts
+++ b/packages/mcp-server/src/test-exports.ts
@@ -39,3 +39,15 @@ export {
 
 // Export DuckDB connection utilities for integration testing
 export { getConnection, closeConnection, isConnected } from './db/connection.js';
+
+// Export field timing utilities for testing
+export {
+  OPEN_KNOWN_FIELDS,
+  CLOSE_KNOWN_FIELDS,
+  STATIC_FIELDS,
+  buildLookaheadFreeQuery,
+} from './utils/field-timing.js';
+
+// Export schema metadata for classification completeness tests
+export { SCHEMA_DESCRIPTIONS } from './utils/schema-metadata.js';
+export type { ColumnDescription } from './utils/schema-metadata.js';

--- a/packages/mcp-server/src/test-exports.ts
+++ b/packages/mcp-server/src/test-exports.ts
@@ -48,6 +48,20 @@ export {
   buildLookaheadFreeQuery,
 } from './utils/field-timing.js';
 
+// Export intraday timing utilities for testing
+export {
+  SPX_CHECKPOINTS,
+  VIX_CHECKPOINTS,
+  SPX_15MIN_OUTCOME_FIELDS,
+  VIX_OUTCOME_FIELDS,
+  VIX_OHLC_OUTCOME_FIELDS,
+  parseTimeToHHMM,
+  getKnownSpxCheckpoints,
+  getKnownVixCheckpoints,
+  buildIntradayContext,
+} from './utils/intraday-timing.js';
+export type { IntradayContext } from './utils/intraday-timing.js';
+
 // Export schema metadata for classification completeness tests
 export { SCHEMA_DESCRIPTIONS } from './utils/schema-metadata.js';
 export type { ColumnDescription } from './utils/schema-metadata.js';

--- a/packages/mcp-server/src/test-exports.ts
+++ b/packages/mcp-server/src/test-exports.ts
@@ -40,12 +40,20 @@ export {
 // Export DuckDB connection utilities for integration testing
 export { getConnection, closeConnection, isConnected } from './db/connection.js';
 
+// Export shared filter utilities for testing
+export {
+  filterByStrategy,
+  filterByDateRange,
+  filterDailyLogsByDateRange,
+} from './tools/shared/filters.js';
+
 // Export field timing utilities for testing
 export {
   OPEN_KNOWN_FIELDS,
   CLOSE_KNOWN_FIELDS,
   STATIC_FIELDS,
   buildLookaheadFreeQuery,
+  buildOutcomeQuery,
 } from './utils/field-timing.js';
 
 // Export intraday timing utilities for testing

--- a/packages/mcp-server/src/tools/analysis.ts
+++ b/packages/mcp-server/src/tools/analysis.ts
@@ -26,6 +26,7 @@ import {
   calculateStrategyKellyMetrics,
 } from "@tradeblocks/lib";
 import type { Trade, MonteCarloParams } from "@tradeblocks/lib";
+import { filterByDateRange } from "./shared/filters.js";
 
 /**
  * Filter trades by strategy
@@ -262,14 +263,7 @@ export function registerAnalysisTools(
         }
 
         // Apply date range filter
-        if (dateRangeFrom) {
-          const fromDate = new Date(dateRangeFrom);
-          trades = trades.filter((t) => new Date(t.dateOpened) >= fromDate);
-        }
-        if (dateRangeTo) {
-          const toDate = new Date(dateRangeTo);
-          trades = trades.filter((t) => new Date(t.dateOpened) <= toDate);
-        }
+        trades = filterByDateRange(trades, dateRangeFrom, dateRangeTo);
 
         // Apply selectedStrategies filter if provided (in addition to single strategy filter)
         if (selectedStrategies && selectedStrategies.length > 0) {
@@ -816,14 +810,7 @@ export function registerAnalysisTools(
         }
 
         // Apply date range filter
-        if (dateRangeFrom) {
-          const fromDate = new Date(dateRangeFrom);
-          trades = trades.filter((t) => new Date(t.dateOpened) >= fromDate);
-        }
-        if (dateRangeTo) {
-          const toDate = new Date(dateRangeTo);
-          trades = trades.filter((t) => new Date(t.dateOpened) <= toDate);
-        }
+        trades = filterByDateRange(trades, dateRangeFrom, dateRangeTo);
 
         // Apply strategy filter
         if (strategyFilter && strategyFilter.length > 0) {
@@ -1021,23 +1008,17 @@ export function registerAnalysisTools(
           };
         }
 
-        // Build date range if provided
-        const dateRange = dateRangeFrom || dateRangeTo
-          ? {
-              from: dateRangeFrom ? new Date(dateRangeFrom) : undefined,
-              to: dateRangeTo ? new Date(dateRangeTo) : undefined,
-            }
-          : undefined;
+        // Apply date range filter before analysis (avoids UTC/local Date mismatch)
+        const filteredTrades = filterByDateRange(trades, dateRangeFrom, dateRangeTo);
 
         // Perform tail risk analysis with all options
-        const result = performTailRiskAnalysis(trades, {
+        const result = performTailRiskAnalysis(filteredTrades, {
           tailThreshold,
           minTradingDays,
           normalization,
           dateBasis,
           strategyFilter,
           tickerFilter,
-          dateRange,
           varianceThreshold,
         });
 

--- a/packages/mcp-server/src/tools/market-data.ts
+++ b/packages/mcp-server/src/tools/market-data.ts
@@ -2,7 +2,8 @@
  * Market Data Tools
  *
  * MCP tools for analyzing market context (VIX, term structure, regimes)
- * and correlating with trade performance.
+ * and correlating with trade performance. Includes enrich_trades for
+ * lag-aware trade enrichment with market data.
  *
  * Data source: DuckDB analytics database (synced from TradingView exports)
  * - market.spx_daily: Daily context (55 fields incl. highlow timing + VIX enrichment)
@@ -230,8 +231,10 @@ function getDayLabel(dow: number): string {
  *
  * Note: The following tools were REMOVED in v0.6.0 - use run_sql instead:
  * - get_market_context: SELECT ... FROM market.spx_daily WHERE ...
- * - enrich_trades: SELECT t.*, m.* FROM trades.trade_data t JOIN market.spx_daily m ON ...
  * - find_similar_days: Use CTE with similarity conditions
+ *
+ * Restored in v1.1.0 with lookahead-free temporal joins:
+ * - enrich_trades: Returns trades enriched with lag-aware market context
  *
  * Kept tools (require TradeBlocks library computation):
  * - analyze_regime_performance: Statistical breakdown by regime

--- a/packages/mcp-server/src/tools/shared/filters.ts
+++ b/packages/mcp-server/src/tools/shared/filters.ts
@@ -17,7 +17,21 @@ export function filterByStrategy(trades: Trade[], strategy?: string): Trade[] {
 }
 
 /**
- * Filter trades by date range
+ * Format a Date to YYYY-MM-DD in Eastern Time for string comparison.
+ * Trades are stored in Eastern Time, so we compare calendar dates in that timezone.
+ */
+function toEasternDateStr(d: Date): string {
+  return d.toLocaleDateString("en-CA", {
+    timeZone: "America/New_York",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+}
+
+/**
+ * Filter trades by date range using string comparison on Eastern Time calendar dates.
+ * Avoids timezone bugs from mixing UTC Date parsing with local time setHours.
  */
 export function filterByDateRange(
   trades: Trade[],
@@ -27,27 +41,19 @@ export function filterByDateRange(
   let filtered = trades;
 
   if (startDate) {
-    const start = new Date(startDate);
-    if (!isNaN(start.getTime())) {
-      filtered = filtered.filter((t) => new Date(t.dateOpened) >= start);
-    }
+    filtered = filtered.filter((t) => toEasternDateStr(new Date(t.dateOpened)) >= startDate);
   }
 
   if (endDate) {
-    const end = new Date(endDate);
-    if (!isNaN(end.getTime())) {
-      // Include entire end date
-      end.setHours(23, 59, 59, 999);
-      filtered = filtered.filter((t) => new Date(t.dateOpened) <= end);
-    }
+    filtered = filtered.filter((t) => toEasternDateStr(new Date(t.dateOpened)) <= endDate);
   }
 
   return filtered;
 }
 
 /**
- * Filter daily log entries by date range
- * Mirrors filterByDateRange but uses entry.date (Date object) instead of t.dateOpened
+ * Filter daily log entries by date range using string comparison on Eastern Time calendar dates.
+ * Mirrors filterByDateRange but uses entry.date (Date object) instead of t.dateOpened.
  */
 export function filterDailyLogsByDateRange(
   dailyLogs: DailyLogEntry[],
@@ -57,19 +63,11 @@ export function filterDailyLogsByDateRange(
   let filtered = dailyLogs;
 
   if (startDate) {
-    const start = new Date(startDate);
-    if (!isNaN(start.getTime())) {
-      filtered = filtered.filter((entry) => new Date(entry.date) >= start);
-    }
+    filtered = filtered.filter((entry) => toEasternDateStr(new Date(entry.date)) >= startDate);
   }
 
   if (endDate) {
-    const end = new Date(endDate);
-    if (!isNaN(end.getTime())) {
-      // Include entire end date
-      end.setHours(23, 59, 59, 999);
-      filtered = filtered.filter((entry) => new Date(entry.date) <= end);
-    }
+    filtered = filtered.filter((entry) => toEasternDateStr(new Date(entry.date)) <= endDate);
   }
 
   return filtered;

--- a/packages/mcp-server/src/tools/shared/filters.ts
+++ b/packages/mcp-server/src/tools/shared/filters.ts
@@ -17,6 +17,16 @@ export function filterByStrategy(trades: Trade[], strategy?: string): Trade[] {
 }
 
 /**
+ * Validate that a date string is in YYYY-MM-DD format.
+ * Returns the string if valid, undefined if not (skips that filter boundary).
+ */
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+function validateDateParam(date: string | undefined): string | undefined {
+  if (!date) return undefined;
+  return DATE_RE.test(date) ? date : undefined;
+}
+
+/**
  * Format a Date to YYYY-MM-DD in Eastern Time for string comparison.
  * Trades are stored in Eastern Time, so we compare calendar dates in that timezone.
  */
@@ -32,20 +42,23 @@ function toEasternDateStr(d: Date): string {
 /**
  * Filter trades by date range using string comparison on Eastern Time calendar dates.
  * Avoids timezone bugs from mixing UTC Date parsing with local time setHours.
+ * Malformed date inputs (not YYYY-MM-DD) are silently ignored.
  */
 export function filterByDateRange(
   trades: Trade[],
   startDate?: string,
   endDate?: string
 ): Trade[] {
+  const start = validateDateParam(startDate);
+  const end = validateDateParam(endDate);
   let filtered = trades;
 
-  if (startDate) {
-    filtered = filtered.filter((t) => toEasternDateStr(new Date(t.dateOpened)) >= startDate);
+  if (start) {
+    filtered = filtered.filter((t) => toEasternDateStr(new Date(t.dateOpened)) >= start);
   }
 
-  if (endDate) {
-    filtered = filtered.filter((t) => toEasternDateStr(new Date(t.dateOpened)) <= endDate);
+  if (end) {
+    filtered = filtered.filter((t) => toEasternDateStr(new Date(t.dateOpened)) <= end);
   }
 
   return filtered;
@@ -54,20 +67,23 @@ export function filterByDateRange(
 /**
  * Filter daily log entries by date range using string comparison on Eastern Time calendar dates.
  * Mirrors filterByDateRange but uses entry.date (Date object) instead of t.dateOpened.
+ * Malformed date inputs (not YYYY-MM-DD) are silently ignored.
  */
 export function filterDailyLogsByDateRange(
   dailyLogs: DailyLogEntry[],
   startDate?: string,
   endDate?: string
 ): DailyLogEntry[] {
+  const start = validateDateParam(startDate);
+  const end = validateDateParam(endDate);
   let filtered = dailyLogs;
 
-  if (startDate) {
-    filtered = filtered.filter((entry) => toEasternDateStr(new Date(entry.date)) >= startDate);
+  if (start) {
+    filtered = filtered.filter((entry) => toEasternDateStr(new Date(entry.date)) >= start);
   }
 
-  if (endDate) {
-    filtered = filtered.filter((entry) => toEasternDateStr(new Date(entry.date)) <= endDate);
+  if (end) {
+    filtered = filtered.filter((entry) => toEasternDateStr(new Date(entry.date)) <= end);
   }
 
   return filtered;

--- a/packages/mcp-server/src/utils/field-timing.ts
+++ b/packages/mcp-server/src/utils/field-timing.ts
@@ -58,6 +58,10 @@ export const STATIC_FIELDS: ReadonlySet<string> = new Set(
  * @returns Object with `sql` (the query string) and `params` (the date values)
  */
 export function buildLookaheadFreeQuery(tradeDates: string[]): { sql: string; params: string[] } {
+  if (tradeDates.length === 0) {
+    return { sql: `SELECT * FROM market.spx_daily WHERE 1=0`, params: [] };
+  }
+
   // Quote all column names for safety (prevents reserved word conflicts)
   const openColumns = [...OPEN_KNOWN_FIELDS].map(f => `"${f}"`).join(', ');
   const staticColumns = [...STATIC_FIELDS].map(f => `"${f}"`).join(', ');
@@ -92,6 +96,10 @@ export function buildLookaheadFreeQuery(tradeDates: string[]): { sql: string; pa
  * @returns Object with `sql` (the query string) and `params` (the date values)
  */
 export function buildOutcomeQuery(tradeDates: string[]): { sql: string; params: string[] } {
+  if (tradeDates.length === 0) {
+    return { sql: `SELECT * FROM market.spx_daily WHERE 1=0`, params: [] };
+  }
+
   const closeColumns = [...CLOSE_KNOWN_FIELDS].map(f => `"${f}"`).join(', ');
   const placeholders = tradeDates.map((_, i) => `$${i + 1}`).join(', ');
   const sql = `SELECT date, ${closeColumns} FROM market.spx_daily WHERE date IN (${placeholders})`;

--- a/packages/mcp-server/src/utils/field-timing.ts
+++ b/packages/mcp-server/src/utils/field-timing.ts
@@ -1,0 +1,82 @@
+/**
+ * Field Timing Utilities
+ *
+ * Derived sets and LAG CTE builder for lookahead-free market analytics.
+ * All field classifications are derived from SCHEMA_DESCRIPTIONS timing annotations
+ * in schema-metadata.ts -- no hardcoded column names.
+ *
+ * Used by downstream tools (suggest_filters, analyze_regime_performance, etc.)
+ * to ensure trade-entry queries only use data available at the time of trade entry.
+ */
+
+import { SCHEMA_DESCRIPTIONS } from './schema-metadata.js';
+
+const spxColumns = SCHEMA_DESCRIPTIONS.market.tables.spx_daily.columns;
+
+/**
+ * Fields known at or before market open (Prior_Close, Gap_Pct, VIX_Open, etc.)
+ * Safe to use as same-day values in trade-entry queries.
+ */
+export const OPEN_KNOWN_FIELDS: ReadonlySet<string> = new Set(
+  Object.entries(spxColumns)
+    .filter(([, desc]) => desc.timing === 'open')
+    .map(([name]) => name)
+);
+
+/**
+ * Fields only known after market close (RSI_14, Vol_Regime, Close, etc.)
+ * Must use LAG() to get prior trading day's value in trade-entry queries.
+ */
+export const CLOSE_KNOWN_FIELDS: ReadonlySet<string> = new Set(
+  Object.entries(spxColumns)
+    .filter(([, desc]) => desc.timing === 'close')
+    .map(([name]) => name)
+);
+
+/**
+ * Calendar/metadata facts known before the trading day (Day_of_Week, Month, Is_Opex).
+ * Safe to use as same-day values in trade-entry queries.
+ */
+export const STATIC_FIELDS: ReadonlySet<string> = new Set(
+  Object.entries(spxColumns)
+    .filter(([, desc]) => desc.timing === 'static')
+    .map(([name]) => name)
+);
+
+/**
+ * Builds a SQL query that joins trade dates to spx_daily market data
+ * with lookahead bias prevention:
+ * - Open-known fields: used as-is (same-day values, known before market open)
+ * - Static fields: used as-is (calendar facts, known in advance)
+ * - Close-derived fields: LAG(field) OVER (ORDER BY date) gives prior trading day's value
+ *
+ * The LAG() operates on spx_daily row order, NOT calendar-day arithmetic.
+ * This correctly handles weekends and holidays because spx_daily only contains
+ * trading days -- Monday's LAG is Friday, post-holiday LAG is the last trading day.
+ *
+ * @param tradeDates - Array of trade dates in 'YYYY-MM-DD' format
+ * @returns Object with `sql` (the query string) and `params` (the date values)
+ */
+export function buildLookaheadFreeQuery(tradeDates: string[]): { sql: string; params: string[] } {
+  // Quote all column names for safety (prevents reserved word conflicts)
+  const openColumns = [...OPEN_KNOWN_FIELDS].map(f => `"${f}"`).join(', ');
+  const staticColumns = [...STATIC_FIELDS].map(f => `"${f}"`).join(', ');
+  const lagColumns = [...CLOSE_KNOWN_FIELDS]
+    .map(field => `LAG("${field}") OVER (ORDER BY date) AS "prev_${field}"`)
+    .join(',\n        ');
+
+  const placeholders = tradeDates.map((_, i) => `$${i + 1}`).join(', ');
+
+  const sql = `WITH lagged AS (
+      SELECT
+        date,
+        ${openColumns},
+        ${staticColumns},
+        ${lagColumns}
+      FROM market.spx_daily
+    )
+    SELECT * FROM lagged
+    WHERE date IN (${placeholders})`;
+
+  return { sql, params: tradeDates };
+}

--- a/packages/mcp-server/src/utils/field-timing.ts
+++ b/packages/mcp-server/src/utils/field-timing.ts
@@ -80,3 +80,20 @@ export function buildLookaheadFreeQuery(tradeDates: string[]): { sql: string; pa
 
   return { sql, params: tradeDates };
 }
+
+/**
+ * Builds a SQL query that returns same-day close-derived values (no LAG).
+ * Used for outcome/post-hoc analysis when includeOutcomeFields=true.
+ *
+ * These are values that were NOT available at trade entry time --
+ * they represent the end-of-day result for the trade date itself.
+ *
+ * @param tradeDates - Array of trade dates in 'YYYY-MM-DD' format
+ * @returns Object with `sql` (the query string) and `params` (the date values)
+ */
+export function buildOutcomeQuery(tradeDates: string[]): { sql: string; params: string[] } {
+  const closeColumns = [...CLOSE_KNOWN_FIELDS].map(f => `"${f}"`).join(', ');
+  const placeholders = tradeDates.map((_, i) => `$${i + 1}`).join(', ');
+  const sql = `SELECT date, ${closeColumns} FROM market.spx_daily WHERE date IN (${placeholders})`;
+  return { sql, params: tradeDates };
+}

--- a/packages/mcp-server/src/utils/intraday-timing.ts
+++ b/packages/mcp-server/src/utils/intraday-timing.ts
@@ -1,0 +1,256 @@
+/**
+ * Intraday Checkpoint Timing Utilities
+ *
+ * Handles temporal filtering for per-timestamp checkpoint data from intraday tables
+ * (market.spx_15min and market.vix_intraday). This is fundamentally different from the
+ * open/close binary classification model in field-timing.ts:
+ *
+ * - field-timing.ts: Each field is classified as "open" or "close" (known before or after market close)
+ * - intraday-timing.ts: Each checkpoint has a specific timestamp (e.g., 09:30, 09:45, 10:00)
+ *   and is known AT that exact time. A trade entered at 09:35 sees P_0930 but NOT P_0945.
+ *
+ * The temporal semantics ensure lookahead-free enrichment: only checkpoint values that
+ * were observable at the trade's entry time are included in the output.
+ *
+ * Used by enrich_trades (includeIntradayContext=true) and potentially by future tools.
+ */
+
+// =============================================================================
+// Checkpoint Time Constants
+// =============================================================================
+
+/**
+ * SPX 15-minute price checkpoints as HHMM integers for fast comparison.
+ * Corresponds to P_HHMM columns in market.spx_15min (26 checkpoints from 09:30 to 15:45).
+ */
+export const SPX_CHECKPOINTS = [
+  930, 945, 1000, 1015, 1030, 1045, 1100, 1115, 1130, 1145,
+  1200, 1215, 1230, 1245, 1300, 1315, 1330, 1345, 1400, 1415,
+  1430, 1445, 1500, 1515, 1530, 1545,
+] as const;
+
+/**
+ * VIX intraday checkpoints as HHMM integers for fast comparison.
+ * Corresponds to VIX_HHMM columns in market.vix_intraday (14 checkpoints).
+ * Note: VIX uses ~30-minute intervals (NOT 15-minute like SPX),
+ * with an irregular final step from 1530 to 1545.
+ */
+export const VIX_CHECKPOINTS = [
+  930, 1000, 1030, 1100, 1130, 1200, 1230, 1300,
+  1330, 1400, 1430, 1500, 1530, 1545,
+] as const;
+
+// =============================================================================
+// Outcome Field Constants (day-level aggregates requiring end-of-day data)
+// =============================================================================
+
+/**
+ * SPX 15-minute table fields that are day-level aggregates (percentage moves, MOC, afternoon).
+ * These require end-of-day data and are NOT available at trade entry time.
+ * Only returned when both includeIntradayContext=true AND includeOutcomeFields=true.
+ */
+export const SPX_15MIN_OUTCOME_FIELDS = [
+  'Pct_0930_to_1000', 'Pct_0930_to_1200', 'Pct_0930_to_1500', 'Pct_0930_to_Close',
+  'MOC_15min', 'MOC_30min', 'MOC_45min', 'MOC_60min',
+  'Afternoon_Move',
+] as const;
+
+/**
+ * VIX intraday table fields that are day-level aggregates (moves, spike/crush flags).
+ * These require end-of-day data and are NOT available at trade entry time.
+ * Only returned when both includeIntradayContext=true AND includeOutcomeFields=true.
+ */
+export const VIX_OUTCOME_FIELDS = [
+  'VIX_Day_High', 'VIX_Day_Low',
+  'VIX_Morning_Move', 'VIX_Afternoon_Move', 'VIX_Power_Hour_Move',
+  'VIX_Last_30min_Move', 'VIX_Full_Day_Move', 'VIX_First_Hour_Move',
+  'VIX_Intraday_Range_Pct', 'VIX_Spike_From_Open', 'VIX_Spike_Flag',
+  'VIX_Crush_From_Open', 'VIX_Crush_Flag', 'VIX_Close_In_Range',
+] as const;
+
+/**
+ * VIX OHLC fields that are outcome (high/low/close not known at entry).
+ * VIX `open` is known at open, so it is NOT included here.
+ */
+export const VIX_OHLC_OUTCOME_FIELDS = ['high', 'low', 'close'] as const;
+
+// =============================================================================
+// Time Parsing
+// =============================================================================
+
+/**
+ * Parse a timeOpened string (HH:mm:ss format, Eastern Time) to HHMM integer
+ * for comparison against checkpoint times.
+ *
+ * Examples:
+ * - "09:30:00" -> 930
+ * - "09:35:00" -> 935
+ * - "14:30:00" -> 1430
+ * - "00:00:00" -> 0 (default for missing times; results in empty knownCheckpoints)
+ *
+ * @param timeStr - Time string in HH:mm:ss format
+ * @returns HHMM integer (e.g., 930 for 09:30, 1430 for 14:30)
+ */
+export function parseTimeToHHMM(timeStr: string): number {
+  const [hours, minutes] = timeStr.split(':').map(Number);
+  return hours * 100 + minutes;
+}
+
+// =============================================================================
+// Checkpoint Filtering Functions
+// =============================================================================
+
+/**
+ * Get SPX checkpoint field names known at or before the given trade time.
+ * A checkpoint at time T is considered "known" at time T (the price has printed).
+ *
+ * Example: tradeTimeHHMM=935 returns ["P_0930"] (P_0945 is NOT known yet).
+ * Example: tradeTimeHHMM=1030 returns ["P_0930", "P_0945", "P_1000", "P_1015", "P_1030"].
+ *
+ * @param tradeTimeHHMM - Trade entry time as HHMM integer
+ * @returns Array of SPX checkpoint column names (e.g., ["P_0930", "P_0945"])
+ */
+export function getKnownSpxCheckpoints(tradeTimeHHMM: number): string[] {
+  return SPX_CHECKPOINTS
+    .filter(cp => cp <= tradeTimeHHMM)
+    .map(cp => `P_${String(cp).padStart(4, '0')}`);
+}
+
+/**
+ * Get VIX checkpoint field names known at or before the given trade time.
+ * A checkpoint at time T is considered "known" at time T (the value has printed).
+ *
+ * Example: tradeTimeHHMM=935 returns ["VIX_0930"] (VIX_1000 is NOT known yet).
+ * Example: tradeTimeHHMM=1030 returns ["VIX_0930", "VIX_1000", "VIX_1030"].
+ *
+ * @param tradeTimeHHMM - Trade entry time as HHMM integer
+ * @returns Array of VIX checkpoint column names (e.g., ["VIX_0930", "VIX_1000"])
+ */
+export function getKnownVixCheckpoints(tradeTimeHHMM: number): string[] {
+  return VIX_CHECKPOINTS
+    .filter(cp => cp <= tradeTimeHHMM)
+    .map(cp => `VIX_${String(cp).padStart(4, '0')}`);
+}
+
+// =============================================================================
+// Intraday Context Types and Builder
+// =============================================================================
+
+/**
+ * Per-trade intraday market context with temporal filtering.
+ * Only contains checkpoint values that were observable at the trade's entry time.
+ */
+export interface IntradayContext {
+  /** Original timeOpened string from the trade (e.g., "09:35:00") */
+  tradeEntryTime: string;
+  /** Parsed HHMM integer for programmatic use (e.g., 935) */
+  tradeEntryTimeHHMM: number;
+  /** SPX intraday checkpoint data, or null if no spx_15min data for this date */
+  spx: {
+    /** Checkpoints known at entry time (e.g., { P_0930: 5234.50 }) */
+    knownCheckpoints: Record<string, number>;
+    /** The latest checkpoint at or before entry time, or null if none */
+    nearestCheckpoint: { time: string; price: number } | null;
+    /** Percent move from day open to nearest checkpoint, or null if unavailable */
+    moveFromOpen: number | null;
+  } | null;
+  /** VIX intraday checkpoint data, or null if no vix_intraday data for this date */
+  vix: {
+    /** Checkpoints known at entry time (e.g., { VIX_0930: 14.25 }) */
+    knownCheckpoints: Record<string, number>;
+    /** The latest checkpoint at or before entry time, or null if none */
+    nearestCheckpoint: { time: string; value: number } | null;
+  } | null;
+}
+
+/**
+ * Build intraday context for a single trade, filtering checkpoints to only those
+ * known at the trade's entry time.
+ *
+ * Temporal semantics:
+ * - A checkpoint at time T is "known" at time T (the price/value has printed)
+ * - A trade at 09:35 sees P_0930 (known at 09:30) but NOT P_0945 (known at 09:45)
+ * - timeOpened="00:00:00" (default for missing times) results in empty knownCheckpoints
+ *   because no market checkpoints exist at or before 00:00
+ *
+ * @param tradeTimeOpened - Trade's timeOpened string (HH:mm:ss format)
+ * @param spxData - Wide-format row from market.spx_15min for the trade date, or null
+ * @param vixData - Wide-format row from market.vix_intraday for the trade date, or null
+ * @returns IntradayContext with filtered checkpoints, or null if both data sources are null
+ */
+export function buildIntradayContext(
+  tradeTimeOpened: string,
+  spxData: Record<string, unknown> | null,
+  vixData: Record<string, unknown> | null,
+): IntradayContext | null {
+  if (!spxData && !vixData) return null;
+
+  const tradeTimeHHMM = parseTimeToHHMM(tradeTimeOpened);
+
+  // Build SPX context
+  let spxContext: IntradayContext['spx'] = null;
+  if (spxData) {
+    const knownCheckpoints: Record<string, number> = {};
+    let nearestTime: string | null = null;
+    let nearestPrice: number | null = null;
+
+    const knownFields = getKnownSpxCheckpoints(tradeTimeHHMM);
+    for (const field of knownFields) {
+      const val = spxData[field];
+      if (val !== null && val !== undefined) {
+        const numVal = typeof val === 'bigint' ? Number(val) : val as number;
+        knownCheckpoints[field] = numVal;
+        // Track nearest (last in sorted order since checkpoints are ascending)
+        nearestTime = field.replace('P_', '');
+        nearestPrice = numVal;
+      }
+    }
+
+    // Compute moveFromOpen: ((nearestPrice - openPrice) / openPrice) * 100
+    let moveFromOpen: number | null = null;
+    const openVal = spxData['open'];
+    if (nearestPrice !== null && openVal !== null && openVal !== undefined) {
+      const openPrice = typeof openVal === 'bigint' ? Number(openVal) : openVal as number;
+      if (openPrice > 0) {
+        moveFromOpen = Math.round(((nearestPrice - openPrice) / openPrice) * 10000) / 100;
+      }
+    }
+
+    spxContext = {
+      knownCheckpoints,
+      nearestCheckpoint: nearestPrice !== null ? { time: nearestTime!, price: nearestPrice } : null,
+      moveFromOpen,
+    };
+  }
+
+  // Build VIX context
+  let vixContext: IntradayContext['vix'] = null;
+  if (vixData) {
+    const knownCheckpoints: Record<string, number> = {};
+    let nearestTime: string | null = null;
+    let nearestValue: number | null = null;
+
+    const knownFields = getKnownVixCheckpoints(tradeTimeHHMM);
+    for (const field of knownFields) {
+      const val = vixData[field];
+      if (val !== null && val !== undefined) {
+        const numVal = typeof val === 'bigint' ? Number(val) : val as number;
+        knownCheckpoints[field] = numVal;
+        nearestTime = field.replace('VIX_', '');
+        nearestValue = numVal;
+      }
+    }
+
+    vixContext = {
+      knownCheckpoints,
+      nearestCheckpoint: nearestValue !== null ? { time: nearestTime!, value: nearestValue } : null,
+    };
+  }
+
+  return {
+    tradeEntryTime: tradeTimeOpened,
+    tradeEntryTimeHHMM: tradeTimeHHMM,
+    spx: spxContext,
+    vix: vixContext,
+  };
+}

--- a/packages/mcp-server/src/utils/intraday-timing.ts
+++ b/packages/mcp-server/src/utils/intraday-timing.ts
@@ -92,7 +92,9 @@ export const VIX_OHLC_OUTCOME_FIELDS = ['high', 'low', 'close'] as const;
  * @returns HHMM integer (e.g., 930 for 09:30, 1430 for 14:30)
  */
 export function parseTimeToHHMM(timeStr: string): number {
+  if (!timeStr || !/^\d{1,2}:\d{2}(:\d{2})?$/.test(timeStr)) return 0;
   const [hours, minutes] = timeStr.split(':').map(Number);
+  if (isNaN(hours) || isNaN(minutes) || hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return 0;
   return hours * 100 + minutes;
 }
 

--- a/packages/mcp-server/src/utils/schema-metadata.ts
+++ b/packages/mcp-server/src/utils/schema-metadata.ts
@@ -271,7 +271,7 @@ export const SCHEMA_DESCRIPTIONS: SchemaMetadata = {
           },
           VIX_Open: {
             description: "VIX open value",
-            hypothesis: false,
+            hypothesis: true,
             timing: 'open',
           },
           VIX_Close: {

--- a/packages/mcp-server/src/utils/schema-metadata.ts
+++ b/packages/mcp-server/src/utils/schema-metadata.ts
@@ -18,6 +18,13 @@ export interface ColumnDescription {
   description: string;
   /** True if this column is useful for hypothesis testing (filtering, grouping, analysis) */
   hypothesis: boolean;
+  /** When this field's value is known relative to market open.
+   *  - 'open': Known at/before market open (Prior_Close, Gap_Pct, VIX_Open, etc.)
+   *  - 'close': Only known after market close (RSI_14, Vol_Regime, Close, etc.)
+   *  - 'static': Calendar/metadata facts known before the day (Day_of_Week, Month, Is_Opex)
+   *  Only applicable to market.spx_daily columns. Omit for non-market tables.
+   */
+  timing?: 'open' | 'close' | 'static';
 }
 
 export interface TableDescription {
@@ -210,229 +217,284 @@ export const SCHEMA_DESCRIPTIONS: SchemaMetadata = {
           Prior_Close: {
             description: "Previous day's SPX close price",
             hypothesis: false,
+            timing: 'open',
           },
           open: {
             description: "SPX open price (lowercase to match TradingView export)",
             hypothesis: false,
+            timing: 'open',
           },
           high: {
             description: "SPX high price (lowercase to match TradingView export)",
             hypothesis: false,
+            timing: 'close',
           },
           low: {
             description: "SPX low price (lowercase to match TradingView export)",
             hypothesis: false,
+            timing: 'close',
           },
           close: {
             description: "SPX close price (lowercase to match TradingView export)",
             hypothesis: false,
+            timing: 'close',
           },
           Gap_Pct: {
             description: "Overnight gap percentage ((Open - Prior_Close) / Prior_Close * 100)",
             hypothesis: true,
+            timing: 'open',
           },
           Intraday_Range_Pct: {
             description: "Intraday range as percentage ((High - Low) / Open * 100)",
             hypothesis: true,
+            timing: 'close',
           },
           Intraday_Return_Pct: {
             description: "Open to close return percentage ((Close - Open) / Open * 100)",
             hypothesis: true,
+            timing: 'close',
           },
           Total_Return_Pct: {
             description: "Prior close to close return percentage",
             hypothesis: true,
+            timing: 'close',
           },
           Close_Position_In_Range: {
             description: "Where close is in day's range (0 = low, 1 = high)",
             hypothesis: true,
+            timing: 'close',
           },
           Gap_Filled: {
             description: "Whether overnight gap was filled (1 = yes, 0 = no)",
             hypothesis: true,
+            timing: 'close',
           },
           VIX_Open: {
             description: "VIX open value",
             hypothesis: false,
+            timing: 'open',
           },
           VIX_Close: {
             description: "VIX close value - key volatility indicator",
             hypothesis: true,
+            timing: 'close',
           },
           VIX_Change_Pct: {
             description: "VIX percentage change from prior close",
             hypothesis: true,
+            timing: 'close',
           },
           VIX_Spike_Pct: {
             description: "VIX spike from open to high as percentage",
             hypothesis: true,
+            timing: 'close',
           },
           VIX_Percentile: {
             description: "VIX percentile rank (0-100) vs historical",
             hypothesis: true,
+            timing: 'close',
           },
           Vol_Regime: {
             description:
               "Volatility regime classification (1=low, 2=normal, 3=elevated, 4=high, 5=extreme)",
             hypothesis: true,
+            timing: 'close',
           },
           VIX9D_Close: {
             description: "9-day VIX close",
             hypothesis: false,
+            timing: 'close',
           },
           VIX3M_Close: {
             description: "3-month VIX close",
             hypothesis: false,
+            timing: 'close',
           },
           VIX9D_VIX_Ratio: {
             description: "VIX9D/VIX ratio - term structure indicator",
             hypothesis: true,
+            timing: 'close',
           },
           VIX_VIX3M_Ratio: {
             description: "VIX/VIX3M ratio - term structure indicator",
             hypothesis: true,
+            timing: 'close',
           },
           Term_Structure_State: {
             description:
               "VIX term structure state (1=backwardation, 0=flat, -1=contango)",
             hypothesis: true,
+            timing: 'close',
           },
           ATR_Pct: {
             description: "Average True Range as percentage of price",
             hypothesis: true,
+            timing: 'close',
           },
           RSI_14: {
             description: "14-day RSI (0-100, >70 overbought, <30 oversold)",
             hypothesis: true,
+            timing: 'close',
           },
           Price_vs_EMA21_Pct: {
             description: "Price vs 21-day EMA as percentage",
             hypothesis: true,
+            timing: 'close',
           },
           Price_vs_SMA50_Pct: {
             description: "Price vs 50-day SMA as percentage",
             hypothesis: true,
+            timing: 'close',
           },
           Trend_Score: {
             description:
               "Trend strength indicator (-5 to +5, negative=downtrend, positive=uptrend)",
             hypothesis: true,
+            timing: 'close',
           },
           BB_Position: {
             description:
               "Bollinger Band position (0=lower band, 0.5=middle, 1=upper band)",
             hypothesis: true,
+            timing: 'close',
           },
           Return_5D: {
             description: "5-day cumulative return percentage",
             hypothesis: true,
+            timing: 'close',
           },
           Return_20D: {
             description: "20-day cumulative return percentage",
             hypothesis: true,
+            timing: 'close',
           },
           Consecutive_Days: {
             description: "Consecutive up/down days (positive=up, negative=down)",
             hypothesis: true,
+            timing: 'close',
           },
           Day_of_Week: {
             description: "Day of week (1=Monday through 5=Friday)",
             hypothesis: true,
+            timing: 'static',
           },
           Month: {
             description: "Month number (1-12)",
             hypothesis: true,
+            timing: 'static',
           },
           Is_Opex: {
             description: "Options expiration day flag (1=opex, 0=not)",
             hypothesis: true,
+            timing: 'static',
           },
           Prev_Return_Pct: {
             description: "Previous day's total return percentage",
             hypothesis: true,
+            timing: 'open',
           },
           // Highlow timing columns (13)
           High_Time: {
             description: "Time of day high as decimal hours (e.g., 10.5 = 10:30 AM)",
             hypothesis: true,
+            timing: 'close',
           },
           Low_Time: {
             description: "Time of day low as decimal hours (e.g., 14.25 = 2:15 PM)",
             hypothesis: true,
+            timing: 'close',
           },
           High_Before_Low: {
             description: "Did high occur before low? (1=yes, 0=no)",
             hypothesis: true,
+            timing: 'close',
           },
           High_In_First_Hour: {
             description: "Did high occur in first hour? (1=yes, 0=no)",
             hypothesis: true,
+            timing: 'close',
           },
           Low_In_First_Hour: {
             description: "Did low occur in first hour? (1=yes, 0=no)",
             hypothesis: true,
+            timing: 'close',
           },
           High_In_Last_Hour: {
             description: "Did high occur in last hour? (1=yes, 0=no)",
             hypothesis: true,
+            timing: 'close',
           },
           Low_In_Last_Hour: {
             description: "Did low occur in last hour? (1=yes, 0=no)",
             hypothesis: true,
+            timing: 'close',
           },
           Reversal_Type: {
             description:
               "Reversal pattern type (1=morning reversal up, -1=morning reversal down, 0=trend day)",
             hypothesis: true,
+            timing: 'close',
           },
           High_Low_Spread: {
             description: "Time spread between high and low in hours",
             hypothesis: true,
+            timing: 'close',
           },
           Early_Extreme: {
             description: "Was either extreme in first 30 min? (1=yes, 0=no)",
             hypothesis: true,
+            timing: 'close',
           },
           Late_Extreme: {
             description: "Was either extreme in last 30 min? (1=yes, 0=no)",
             hypothesis: true,
+            timing: 'close',
           },
           Intraday_High: {
             description: "Intraday high price (may differ from daily high on gap days)",
             hypothesis: false,
+            timing: 'close',
           },
           Intraday_Low: {
             description: "Intraday low price (may differ from daily low on gap days)",
             hypothesis: false,
+            timing: 'close',
           },
           // VIX enrichment columns (7)
           VIX_Gap_Pct: {
             description: "VIX overnight gap percentage ((VIX_Open - prior VIX_Close) / prior VIX_Close * 100)",
             hypothesis: true,
+            timing: 'open',
           },
           VIX9D_Open: {
             description: "9-day VIX open value",
             hypothesis: false,
+            timing: 'open',
           },
           VIX9D_Change_Pct: {
             description: "9-day VIX open-to-close change percentage",
             hypothesis: true,
+            timing: 'close',
           },
           VIX_High: {
             description: "VIX intraday high",
             hypothesis: false,
+            timing: 'close',
           },
           VIX_Low: {
             description: "VIX intraday low",
             hypothesis: false,
+            timing: 'close',
           },
           VIX3M_Open: {
             description: "3-month VIX open value",
             hypothesis: false,
+            timing: 'open',
           },
           VIX3M_Change_Pct: {
             description: "3-month VIX open-to-close change percentage",
             hypothesis: true,
+            timing: 'close',
           },
         },
       },

--- a/packages/mcp-server/src/utils/schema-metadata.ts
+++ b/packages/mcp-server/src/utils/schema-metadata.ts
@@ -322,7 +322,7 @@ export const SCHEMA_DESCRIPTIONS: SchemaMetadata = {
           },
           Term_Structure_State: {
             description:
-              "VIX term structure state (1=backwardation, 0=flat, -1=contango)",
+              "VIX term structure state (-1=backwardation/inverted, 0=flat, 1=contango/normal)",
             hypothesis: true,
             timing: 'close',
           },
@@ -1015,8 +1015,8 @@ GROUP BY market_condition`,
   FROM market.spx_daily
 )
 SELECT
-  CASE WHEN m.prev_Term_Structure_State = 1 THEN 'Backwardation'
-       WHEN m.prev_Term_Structure_State = -1 THEN 'Contango'
+  CASE WHEN m.prev_Term_Structure_State = -1 THEN 'Backwardation'
+       WHEN m.prev_Term_Structure_State = 1 THEN 'Contango'
        ELSE 'Flat' END as term_structure,
   COUNT(*) as trades,
   SUM(t.pl) as total_pl,

--- a/packages/mcp-server/src/utils/schema-metadata.ts
+++ b/packages/mcp-server/src/utils/schema-metadata.ts
@@ -296,7 +296,7 @@ export const SCHEMA_DESCRIPTIONS: SchemaMetadata = {
           },
           Vol_Regime: {
             description:
-              "Volatility regime classification (1=low, 2=normal, 3=elevated, 4=high, 5=extreme)",
+              "Volatility regime classification (1=very low, 2=low, 3=normal, 4=elevated, 5=high, 6=extreme)",
             hypothesis: true,
             timing: 'close',
           },
@@ -374,7 +374,7 @@ export const SCHEMA_DESCRIPTIONS: SchemaMetadata = {
             timing: 'close',
           },
           Day_of_Week: {
-            description: "Day of week (1=Monday through 5=Friday)",
+            description: "Day of week (2=Monday through 6=Friday)",
             hypothesis: true,
             timing: 'static',
           },

--- a/packages/mcp-server/tests/unit/field-timing.test.ts
+++ b/packages/mcp-server/tests/unit/field-timing.test.ts
@@ -163,9 +163,8 @@ describe('buildLookaheadFreeQuery', () => {
 
   test('produces valid SQL with empty dates array', () => {
     const { sql, params } = buildLookaheadFreeQuery([]);
-    // Should still produce syntactically valid SQL (WHERE date IN ())
-    expect(sql).toContain('WITH lagged AS');
-    expect(sql).toContain('WHERE date IN');
+    // Empty input returns a no-match query instead of invalid WHERE date IN ()
+    expect(sql).toContain('WHERE 1=0');
     expect(params).toEqual([]);
   });
 });

--- a/packages/mcp-server/tests/unit/field-timing.test.ts
+++ b/packages/mcp-server/tests/unit/field-timing.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for field classification and LAG CTE builder.
+ *
+ * Validates:
+ * - Every spx_daily column (except date) has a timing annotation
+ * - Derived sets cover all classified columns with correct counts
+ * - Sets are mutually exclusive
+ * - Known pitfall classifications are correct (Return_5D, Prev_Return_Pct, etc.)
+ * - buildLookaheadFreeQuery() produces valid lookahead-free SQL
+ */
+
+// @ts-expect-error - importing from bundled output
+import {
+  OPEN_KNOWN_FIELDS,
+  CLOSE_KNOWN_FIELDS,
+  STATIC_FIELDS,
+  buildLookaheadFreeQuery,
+  SCHEMA_DESCRIPTIONS,
+} from '../../dist/test-exports.js';
+
+const spxColumns = SCHEMA_DESCRIPTIONS.market.tables.spx_daily.columns;
+
+describe('Field Classification', () => {
+  test('every spx_daily column except date has a timing annotation', () => {
+    for (const [name, desc] of Object.entries(spxColumns) as [string, { timing?: string }][]) {
+      if (name === 'date') {
+        expect(desc.timing).toBeUndefined();
+        continue;
+      }
+      expect(desc.timing).toBeDefined();
+      expect(['open', 'close', 'static']).toContain(desc.timing);
+    }
+  });
+
+  test('date column has no timing annotation', () => {
+    expect(spxColumns.date.timing).toBeUndefined();
+  });
+});
+
+describe('Derived Sets', () => {
+  test('derived sets cover all 55 classified columns', () => {
+    const allClassified = new Set([
+      ...OPEN_KNOWN_FIELDS,
+      ...CLOSE_KNOWN_FIELDS,
+      ...STATIC_FIELDS,
+    ]);
+
+    // Get all non-date columns
+    const nonDateColumns = Object.keys(spxColumns).filter(name => name !== 'date');
+
+    expect(allClassified.size).toBe(55);
+    expect(allClassified.size).toBe(nonDateColumns.length);
+
+    // Every non-date column should be in exactly one set
+    for (const col of nonDateColumns) {
+      expect(allClassified.has(col)).toBe(true);
+    }
+  });
+
+  test('derived sets are mutually exclusive', () => {
+    // Check all three pairwise: open vs close, open vs static, close vs static
+    for (const field of OPEN_KNOWN_FIELDS) {
+      expect(CLOSE_KNOWN_FIELDS.has(field)).toBe(false);
+      expect(STATIC_FIELDS.has(field)).toBe(false);
+    }
+    for (const field of CLOSE_KNOWN_FIELDS) {
+      expect(OPEN_KNOWN_FIELDS.has(field)).toBe(false);
+      expect(STATIC_FIELDS.has(field)).toBe(false);
+    }
+    for (const field of STATIC_FIELDS) {
+      expect(OPEN_KNOWN_FIELDS.has(field)).toBe(false);
+      expect(CLOSE_KNOWN_FIELDS.has(field)).toBe(false);
+    }
+  });
+
+  test('OPEN_KNOWN_FIELDS has exactly 8 fields', () => {
+    expect(OPEN_KNOWN_FIELDS.size).toBe(8);
+  });
+
+  test('CLOSE_KNOWN_FIELDS has exactly 44 fields', () => {
+    expect(CLOSE_KNOWN_FIELDS.size).toBe(44);
+  });
+
+  test('STATIC_FIELDS has exactly 3 fields', () => {
+    expect(STATIC_FIELDS.size).toBe(3);
+  });
+
+  // Specific classification correctness (guards against known pitfalls)
+  test('Return_5D is close-derived (not open-known)', () => {
+    expect(CLOSE_KNOWN_FIELDS.has('Return_5D')).toBe(true);
+    expect(OPEN_KNOWN_FIELDS.has('Return_5D')).toBe(false);
+  });
+
+  test('Return_20D is close-derived (not open-known)', () => {
+    expect(CLOSE_KNOWN_FIELDS.has('Return_20D')).toBe(true);
+    expect(OPEN_KNOWN_FIELDS.has('Return_20D')).toBe(false);
+  });
+
+  test('Prev_Return_Pct is open-known (not close-derived)', () => {
+    expect(OPEN_KNOWN_FIELDS.has('Prev_Return_Pct')).toBe(true);
+    expect(CLOSE_KNOWN_FIELDS.has('Prev_Return_Pct')).toBe(false);
+  });
+
+  test('Consecutive_Days is close-derived', () => {
+    expect(CLOSE_KNOWN_FIELDS.has('Consecutive_Days')).toBe(true);
+  });
+
+  test('date is not in any derived set', () => {
+    expect(OPEN_KNOWN_FIELDS.has('date')).toBe(false);
+    expect(CLOSE_KNOWN_FIELDS.has('date')).toBe(false);
+    expect(STATIC_FIELDS.has('date')).toBe(false);
+  });
+});
+
+describe('buildLookaheadFreeQuery', () => {
+  test('produces SQL with WITH lagged AS CTE', () => {
+    const { sql } = buildLookaheadFreeQuery(['2025-01-06']);
+    expect(sql).toContain('WITH lagged AS');
+  });
+
+  test('passes open-known fields through without LAG', () => {
+    const { sql } = buildLookaheadFreeQuery(['2025-01-06']);
+    // Open-known fields should appear as plain quoted identifiers, not wrapped in LAG()
+    expect(sql).toContain('"Prior_Close"');
+    expect(sql).toContain('"Gap_Pct"');
+    // They should NOT be inside LAG() calls
+    expect(sql).not.toMatch(/LAG\("Prior_Close"\)/);
+    expect(sql).not.toMatch(/LAG\("Gap_Pct"\)/);
+  });
+
+  test('wraps close-derived fields in LAG()', () => {
+    const { sql } = buildLookaheadFreeQuery(['2025-01-06']);
+    expect(sql).toContain('LAG("close") OVER (ORDER BY date) AS "prev_close"');
+    expect(sql).toContain('LAG("RSI_14") OVER (ORDER BY date) AS "prev_RSI_14"');
+  });
+
+  test('passes static fields through without LAG', () => {
+    const { sql } = buildLookaheadFreeQuery(['2025-01-06']);
+    expect(sql).toContain('"Day_of_Week"');
+    expect(sql).not.toMatch(/LAG\("Day_of_Week"\)/);
+  });
+
+  test('uses parameterized placeholders for dates', () => {
+    const { sql, params } = buildLookaheadFreeQuery(['2025-01-06']);
+    expect(sql).toContain('$1');
+    expect(params).toEqual(['2025-01-06']);
+  });
+
+  test('handles multiple dates with correct placeholders', () => {
+    const dates = ['2025-01-06', '2025-01-07', '2025-01-08'];
+    const { sql, params } = buildLookaheadFreeQuery(dates);
+    expect(sql).toContain('$1, $2, $3');
+    expect(params).toEqual(dates);
+  });
+
+  test('uses ORDER BY date in LAG window (not calendar arithmetic)', () => {
+    const { sql } = buildLookaheadFreeQuery(['2025-01-06']);
+    expect(sql).toContain('OVER (ORDER BY date)');
+    expect(sql).not.toContain('DATEADD');
+    expect(sql).not.toContain('INTERVAL');
+  });
+});

--- a/packages/mcp-server/tests/unit/filters.test.ts
+++ b/packages/mcp-server/tests/unit/filters.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Unit tests for shared filter utilities.
+ *
+ * Validates:
+ * - filterByStrategy case-insensitive matching
+ * - filterByDateRange Eastern Time string comparison (timezone-safe)
+ * - filterByDateRange YYYY-MM-DD input validation
+ * - filterDailyLogsByDateRange parity with filterByDateRange
+ * - Edge cases: empty arrays, undefined params, malformed dates
+ */
+
+// @ts-expect-error - importing from bundled output
+import {
+  filterByStrategy,
+  filterByDateRange,
+  filterDailyLogsByDateRange,
+} from '../../dist/test-exports.js';
+
+// =============================================================================
+// Test Data Helpers
+// =============================================================================
+
+/** Minimal Trade-like object for filter testing */
+function makeTrade(dateStr: string, strategy = 'Test Strategy', pl = 100) {
+  return {
+    dateOpened: new Date(dateStr + 'T14:00:00.000Z'), // midday UTC to test timezone handling
+    timeOpened: '09:30:00',
+    openingPrice: 100,
+    legs: '1 SPY 470C',
+    premium: 500,
+    pl,
+    numContracts: 1,
+    fundsAtClose: 10000,
+    marginReq: 2000,
+    strategy,
+    openingCommissionsFees: 1,
+    closingCommissionsFees: 1,
+    openingShortLongRatio: 0,
+  };
+}
+
+/** Minimal DailyLogEntry-like object */
+function makeDailyLog(dateStr: string) {
+  return {
+    date: new Date(dateStr + 'T14:00:00.000Z'),
+    netLiquidity: 10000,
+    currentFunds: 10000,
+    withdrawn: 0,
+    tradingFunds: 10000,
+    dailyPl: 0,
+    dailyPlPct: 0,
+    drawdownPct: 0,
+  };
+}
+
+const trades = [
+  makeTrade('2025-01-06', 'Alpha Strategy'),
+  makeTrade('2025-01-07', 'Beta Strategy'),
+  makeTrade('2025-01-08', 'Alpha Strategy'),
+  makeTrade('2025-01-09', 'gamma strategy'),
+  makeTrade('2025-01-10', 'Alpha Strategy'),
+];
+
+const dailyLogs = [
+  makeDailyLog('2025-01-06'),
+  makeDailyLog('2025-01-07'),
+  makeDailyLog('2025-01-08'),
+  makeDailyLog('2025-01-09'),
+  makeDailyLog('2025-01-10'),
+];
+
+// =============================================================================
+// filterByStrategy
+// =============================================================================
+
+describe('filterByStrategy', () => {
+  test('returns all trades when strategy is undefined', () => {
+    expect(filterByStrategy(trades, undefined)).toHaveLength(5);
+  });
+
+  test('filters by exact strategy name (case-insensitive)', () => {
+    const result = filterByStrategy(trades, 'alpha strategy');
+    expect(result).toHaveLength(3);
+    expect(result.every((t: { strategy: string }) => t.strategy === 'Alpha Strategy')).toBe(true);
+  });
+
+  test('matches regardless of case', () => {
+    expect(filterByStrategy(trades, 'GAMMA STRATEGY')).toHaveLength(1);
+    expect(filterByStrategy(trades, 'Gamma Strategy')).toHaveLength(1);
+  });
+
+  test('returns empty array for non-existent strategy', () => {
+    expect(filterByStrategy(trades, 'Nonexistent')).toHaveLength(0);
+  });
+
+  test('handles empty trades array', () => {
+    expect(filterByStrategy([], 'Alpha Strategy')).toHaveLength(0);
+  });
+});
+
+// =============================================================================
+// filterByDateRange
+// =============================================================================
+
+describe('filterByDateRange', () => {
+  test('returns all trades when no dates provided', () => {
+    expect(filterByDateRange(trades)).toHaveLength(5);
+  });
+
+  test('returns all trades when both dates are undefined', () => {
+    expect(filterByDateRange(trades, undefined, undefined)).toHaveLength(5);
+  });
+
+  test('filters by startDate only', () => {
+    const result = filterByDateRange(trades, '2025-01-08');
+    expect(result).toHaveLength(3);
+  });
+
+  test('filters by endDate only', () => {
+    const result = filterByDateRange(trades, undefined, '2025-01-08');
+    expect(result).toHaveLength(3);
+  });
+
+  test('filters by both startDate and endDate', () => {
+    const result = filterByDateRange(trades, '2025-01-07', '2025-01-09');
+    expect(result).toHaveLength(3);
+  });
+
+  test('includes trades on exact start date', () => {
+    const result = filterByDateRange(trades, '2025-01-06', '2025-01-06');
+    expect(result).toHaveLength(1);
+  });
+
+  test('includes trades on exact end date', () => {
+    const result = filterByDateRange(trades, '2025-01-10', '2025-01-10');
+    expect(result).toHaveLength(1);
+  });
+
+  test('returns empty when range matches no trades', () => {
+    expect(filterByDateRange(trades, '2025-02-01', '2025-02-28')).toHaveLength(0);
+  });
+
+  test('handles empty trades array', () => {
+    expect(filterByDateRange([], '2025-01-01', '2025-12-31')).toHaveLength(0);
+  });
+
+  // --- Input validation ---
+
+  test('ignores malformed startDate (not YYYY-MM-DD)', () => {
+    // Should return all trades (malformed date is silently skipped)
+    expect(filterByDateRange(trades, '2025-1-8')).toHaveLength(5);
+    expect(filterByDateRange(trades, 'foo')).toHaveLength(5);
+    expect(filterByDateRange(trades, '')).toHaveLength(5);
+    expect(filterByDateRange(trades, '01/08/2025')).toHaveLength(5);
+  });
+
+  test('ignores malformed endDate (not YYYY-MM-DD)', () => {
+    expect(filterByDateRange(trades, undefined, '2025-1-8')).toHaveLength(5);
+    expect(filterByDateRange(trades, undefined, 'bar')).toHaveLength(5);
+  });
+
+  test('valid startDate with malformed endDate applies only startDate', () => {
+    const result = filterByDateRange(trades, '2025-01-09', 'bad-date');
+    expect(result).toHaveLength(2); // Jan 9, Jan 10
+  });
+
+  test('malformed startDate with valid endDate applies only endDate', () => {
+    const result = filterByDateRange(trades, 'nope', '2025-01-07');
+    expect(result).toHaveLength(2); // Jan 6, Jan 7
+  });
+
+  // --- Timezone safety ---
+
+  test('date comparison uses Eastern Time calendar dates (not UTC)', () => {
+    // Trade created with UTC time that could cross date boundary in some timezones
+    // 2025-01-08T04:00:00Z = 2025-01-07T23:00:00 ET (still Jan 7 in Eastern)
+    const edgeTrade = makeTrade('2025-01-07');
+    edgeTrade.dateOpened = new Date('2025-01-08T04:00:00.000Z'); // midnight-ish UTC, still Jan 7 ET
+
+    const result = filterByDateRange([edgeTrade], '2025-01-07', '2025-01-07');
+    expect(result).toHaveLength(1); // Should be included as Jan 7 in Eastern
+  });
+
+  test('late-evening ET trade stays on correct date', () => {
+    // 2025-01-08T03:59:00Z = 2025-01-07T22:59:00 ET
+    const lateTrade = makeTrade('2025-01-07');
+    lateTrade.dateOpened = new Date('2025-01-08T03:59:00.000Z');
+
+    const result = filterByDateRange([lateTrade], '2025-01-08', '2025-01-08');
+    expect(result).toHaveLength(0); // This is Jan 7 in ET, not Jan 8
+  });
+});
+
+// =============================================================================
+// filterDailyLogsByDateRange
+// =============================================================================
+
+describe('filterDailyLogsByDateRange', () => {
+  test('returns all logs when no dates provided', () => {
+    expect(filterDailyLogsByDateRange(dailyLogs)).toHaveLength(5);
+  });
+
+  test('filters by startDate', () => {
+    expect(filterDailyLogsByDateRange(dailyLogs, '2025-01-08')).toHaveLength(3);
+  });
+
+  test('filters by endDate', () => {
+    expect(filterDailyLogsByDateRange(dailyLogs, undefined, '2025-01-08')).toHaveLength(3);
+  });
+
+  test('filters by both dates', () => {
+    expect(filterDailyLogsByDateRange(dailyLogs, '2025-01-07', '2025-01-09')).toHaveLength(3);
+  });
+
+  test('ignores malformed dates', () => {
+    expect(filterDailyLogsByDateRange(dailyLogs, 'bad', 'also-bad')).toHaveLength(5);
+  });
+
+  test('handles empty array', () => {
+    expect(filterDailyLogsByDateRange([], '2025-01-01', '2025-12-31')).toHaveLength(0);
+  });
+});

--- a/packages/mcp-server/tests/unit/intraday-timing.test.ts
+++ b/packages/mcp-server/tests/unit/intraday-timing.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Unit tests for intraday checkpoint timing utilities.
+ *
+ * Validates:
+ * - Checkpoint constant counts and ordering
+ * - parseTimeToHHMM for various time formats
+ * - getKnownSpxCheckpoints / getKnownVixCheckpoints temporal filtering
+ * - buildIntradayContext with lookahead-free checkpoint filtering
+ * - Edge cases: 00:00:00 (missing time), before market, after market, BigInt handling
+ */
+
+// @ts-expect-error - importing from bundled output
+import {
+  SPX_CHECKPOINTS,
+  VIX_CHECKPOINTS,
+  SPX_15MIN_OUTCOME_FIELDS,
+  VIX_OUTCOME_FIELDS,
+  VIX_OHLC_OUTCOME_FIELDS,
+  parseTimeToHHMM,
+  getKnownSpxCheckpoints,
+  getKnownVixCheckpoints,
+  buildIntradayContext,
+} from '../../dist/test-exports.js';
+
+// =============================================================================
+// Checkpoint Constants
+// =============================================================================
+
+describe('Checkpoint Constants', () => {
+  test('SPX_CHECKPOINTS has 26 entries (15-min intervals 09:30-15:45)', () => {
+    expect(SPX_CHECKPOINTS).toHaveLength(26);
+  });
+
+  test('VIX_CHECKPOINTS has 14 entries (~30-min intervals)', () => {
+    expect(VIX_CHECKPOINTS).toHaveLength(14);
+  });
+
+  test('SPX checkpoints are in ascending order', () => {
+    for (let i = 1; i < SPX_CHECKPOINTS.length; i++) {
+      expect(SPX_CHECKPOINTS[i]).toBeGreaterThan(SPX_CHECKPOINTS[i - 1]);
+    }
+  });
+
+  test('VIX checkpoints are in ascending order', () => {
+    for (let i = 1; i < VIX_CHECKPOINTS.length; i++) {
+      expect(VIX_CHECKPOINTS[i]).toBeGreaterThan(VIX_CHECKPOINTS[i - 1]);
+    }
+  });
+
+  test('SPX starts at 930 and ends at 1545', () => {
+    expect(SPX_CHECKPOINTS[0]).toBe(930);
+    expect(SPX_CHECKPOINTS[SPX_CHECKPOINTS.length - 1]).toBe(1545);
+  });
+
+  test('VIX starts at 930 and ends at 1545', () => {
+    expect(VIX_CHECKPOINTS[0]).toBe(930);
+    expect(VIX_CHECKPOINTS[VIX_CHECKPOINTS.length - 1]).toBe(1545);
+  });
+
+  test('every VIX checkpoint is also an SPX checkpoint', () => {
+    const spxSet = new Set(SPX_CHECKPOINTS);
+    for (const cp of VIX_CHECKPOINTS) {
+      expect(spxSet.has(cp)).toBe(true);
+    }
+  });
+});
+
+// =============================================================================
+// Outcome Field Constants
+// =============================================================================
+
+describe('Outcome Field Constants', () => {
+  test('SPX_15MIN_OUTCOME_FIELDS has 9 fields', () => {
+    expect(SPX_15MIN_OUTCOME_FIELDS).toHaveLength(9);
+  });
+
+  test('VIX_OUTCOME_FIELDS has 14 fields', () => {
+    expect(VIX_OUTCOME_FIELDS).toHaveLength(14);
+  });
+
+  test('VIX_OHLC_OUTCOME_FIELDS has 3 fields (high, low, close -- not open)', () => {
+    expect(VIX_OHLC_OUTCOME_FIELDS).toHaveLength(3);
+    expect(VIX_OHLC_OUTCOME_FIELDS).toContain('high');
+    expect(VIX_OHLC_OUTCOME_FIELDS).toContain('low');
+    expect(VIX_OHLC_OUTCOME_FIELDS).toContain('close');
+    expect(VIX_OHLC_OUTCOME_FIELDS).not.toContain('open');
+  });
+
+  test('SPX outcome fields include MOC and percentage move fields', () => {
+    expect(SPX_15MIN_OUTCOME_FIELDS).toContain('MOC_30min');
+    expect(SPX_15MIN_OUTCOME_FIELDS).toContain('Pct_0930_to_Close');
+    expect(SPX_15MIN_OUTCOME_FIELDS).toContain('Afternoon_Move');
+  });
+
+  test('VIX outcome fields include spike/crush flags', () => {
+    expect(VIX_OUTCOME_FIELDS).toContain('VIX_Spike_Flag');
+    expect(VIX_OUTCOME_FIELDS).toContain('VIX_Crush_Flag');
+    expect(VIX_OUTCOME_FIELDS).toContain('VIX_Full_Day_Move');
+  });
+});
+
+// =============================================================================
+// parseTimeToHHMM
+// =============================================================================
+
+describe('parseTimeToHHMM', () => {
+  test('parses 09:30:00 to 930', () => {
+    expect(parseTimeToHHMM('09:30:00')).toBe(930);
+  });
+
+  test('parses 09:35:00 to 935', () => {
+    expect(parseTimeToHHMM('09:35:00')).toBe(935);
+  });
+
+  test('parses 14:30:00 to 1430', () => {
+    expect(parseTimeToHHMM('14:30:00')).toBe(1430);
+  });
+
+  test('parses 00:00:00 to 0 (missing time default)', () => {
+    expect(parseTimeToHHMM('00:00:00')).toBe(0);
+  });
+
+  test('parses 15:45:00 to 1545 (last checkpoint)', () => {
+    expect(parseTimeToHHMM('15:45:00')).toBe(1545);
+  });
+
+  test('parses 16:00:00 to 1600 (after market close)', () => {
+    expect(parseTimeToHHMM('16:00:00')).toBe(1600);
+  });
+});
+
+// =============================================================================
+// getKnownSpxCheckpoints
+// =============================================================================
+
+describe('getKnownSpxCheckpoints', () => {
+  test('trade at 09:30 sees only P_0930', () => {
+    const result = getKnownSpxCheckpoints(930);
+    expect(result).toEqual(['P_0930']);
+  });
+
+  test('trade at 09:35 sees only P_0930 (not P_0945)', () => {
+    const result = getKnownSpxCheckpoints(935);
+    expect(result).toEqual(['P_0930']);
+  });
+
+  test('trade at 09:44 sees only P_0930 (one less than 09:45)', () => {
+    const result = getKnownSpxCheckpoints(944);
+    expect(result).toEqual(['P_0930']);
+  });
+
+  test('trade at 09:45 sees P_0930 and P_0945', () => {
+    const result = getKnownSpxCheckpoints(945);
+    expect(result).toEqual(['P_0930', 'P_0945']);
+  });
+
+  test('trade at 10:30 sees 5 checkpoints', () => {
+    const result = getKnownSpxCheckpoints(1030);
+    expect(result).toEqual(['P_0930', 'P_0945', 'P_1000', 'P_1015', 'P_1030']);
+  });
+
+  test('trade at 15:45 sees all 26 checkpoints', () => {
+    const result = getKnownSpxCheckpoints(1545);
+    expect(result).toHaveLength(26);
+    expect(result[0]).toBe('P_0930');
+    expect(result[result.length - 1]).toBe('P_1545');
+  });
+
+  test('trade at 16:00 (after market) sees all 26 checkpoints', () => {
+    const result = getKnownSpxCheckpoints(1600);
+    expect(result).toHaveLength(26);
+  });
+
+  test('trade at 00:00 (missing time) sees no checkpoints', () => {
+    const result = getKnownSpxCheckpoints(0);
+    expect(result).toEqual([]);
+  });
+
+  test('trade at 09:29 (before market) sees no checkpoints', () => {
+    const result = getKnownSpxCheckpoints(929);
+    expect(result).toEqual([]);
+  });
+
+  test('checkpoint names use P_HHMM format with zero-padded 4 digits', () => {
+    const result = getKnownSpxCheckpoints(945);
+    expect(result[0]).toBe('P_0930');
+    expect(result[1]).toBe('P_0945');
+  });
+});
+
+// =============================================================================
+// getKnownVixCheckpoints
+// =============================================================================
+
+describe('getKnownVixCheckpoints', () => {
+  test('trade at 09:30 sees only VIX_0930', () => {
+    const result = getKnownVixCheckpoints(930);
+    expect(result).toEqual(['VIX_0930']);
+  });
+
+  test('trade at 09:35 sees only VIX_0930 (next VIX checkpoint is 10:00)', () => {
+    const result = getKnownVixCheckpoints(935);
+    expect(result).toEqual(['VIX_0930']);
+  });
+
+  test('trade at 10:30 sees VIX_0930, VIX_1000, VIX_1030', () => {
+    const result = getKnownVixCheckpoints(1030);
+    expect(result).toEqual(['VIX_0930', 'VIX_1000', 'VIX_1030']);
+  });
+
+  test('trade at 15:45 sees all 14 VIX checkpoints', () => {
+    const result = getKnownVixCheckpoints(1545);
+    expect(result).toHaveLength(14);
+  });
+
+  test('trade at 00:00 sees no checkpoints', () => {
+    const result = getKnownVixCheckpoints(0);
+    expect(result).toEqual([]);
+  });
+
+  test('VIX has fewer checkpoints than SPX at same time (30-min vs 15-min)', () => {
+    const spx = getKnownSpxCheckpoints(1200);
+    const vix = getKnownVixCheckpoints(1200);
+    expect(vix.length).toBeLessThan(spx.length);
+  });
+});
+
+// =============================================================================
+// buildIntradayContext
+// =============================================================================
+
+describe('buildIntradayContext', () => {
+  // Mock SPX row with P_HHMM columns
+  const mockSpxRow: Record<string, unknown> = {
+    date: '2025-01-06',
+    open: 5900.0,
+    P_0930: 5900.0,
+    P_0945: 5905.5,
+    P_1000: 5910.0,
+    P_1015: 5908.0,
+    P_1030: 5912.5,
+    P_1045: 5915.0,
+  };
+
+  // Mock VIX row with VIX_HHMM columns
+  const mockVixRow: Record<string, unknown> = {
+    date: '2025-01-06',
+    open: 14.50,
+    VIX_0930: 14.50,
+    VIX_1000: 14.75,
+    VIX_1030: 14.60,
+  };
+
+  test('returns null when both spxData and vixData are null', () => {
+    const result = buildIntradayContext('09:35:00', null, null);
+    expect(result).toBeNull();
+  });
+
+  test('returns context when only spxData is provided', () => {
+    const result = buildIntradayContext('09:35:00', mockSpxRow, null);
+    expect(result).not.toBeNull();
+    expect(result.spx).not.toBeNull();
+    expect(result.vix).toBeNull();
+  });
+
+  test('returns context when only vixData is provided', () => {
+    const result = buildIntradayContext('09:35:00', null, mockVixRow);
+    expect(result).not.toBeNull();
+    expect(result.spx).toBeNull();
+    expect(result.vix).not.toBeNull();
+  });
+
+  test('sets tradeEntryTime and tradeEntryTimeHHMM correctly', () => {
+    const result = buildIntradayContext('09:35:00', mockSpxRow, null);
+    expect(result.tradeEntryTime).toBe('09:35:00');
+    expect(result.tradeEntryTimeHHMM).toBe(935);
+  });
+
+  // --- SPX temporal filtering ---
+
+  test('trade at 09:35 sees only P_0930 in SPX knownCheckpoints', () => {
+    const result = buildIntradayContext('09:35:00', mockSpxRow, null);
+    expect(result.spx.knownCheckpoints).toEqual({ P_0930: 5900.0 });
+  });
+
+  test('trade at 10:00 sees P_0930, P_0945, P_1000 but not P_1015', () => {
+    const result = buildIntradayContext('10:00:00', mockSpxRow, null);
+    expect(result.spx.knownCheckpoints).toEqual({
+      P_0930: 5900.0,
+      P_0945: 5905.5,
+      P_1000: 5910.0,
+    });
+    expect(result.spx.knownCheckpoints).not.toHaveProperty('P_1015');
+  });
+
+  test('nearestCheckpoint is the latest known checkpoint', () => {
+    const result = buildIntradayContext('10:00:00', mockSpxRow, null);
+    expect(result.spx.nearestCheckpoint).toEqual({ time: '1000', price: 5910.0 });
+  });
+
+  test('moveFromOpen calculates percent change from open to nearest', () => {
+    // nearestPrice = 5910.0, openPrice = 5900.0
+    // moveFromOpen = ((5910 - 5900) / 5900) * 100 = 0.17 (rounded to 2 decimal places)
+    const result = buildIntradayContext('10:00:00', mockSpxRow, null);
+    expect(result.spx.moveFromOpen).toBeCloseTo(0.17, 2);
+  });
+
+  // --- VIX temporal filtering ---
+
+  test('trade at 09:35 sees only VIX_0930 in VIX knownCheckpoints', () => {
+    const result = buildIntradayContext('09:35:00', null, mockVixRow);
+    expect(result.vix.knownCheckpoints).toEqual({ VIX_0930: 14.50 });
+  });
+
+  test('trade at 10:30 sees VIX_0930, VIX_1000, VIX_1030', () => {
+    const result = buildIntradayContext('10:30:00', null, mockVixRow);
+    expect(result.vix.knownCheckpoints).toEqual({
+      VIX_0930: 14.50,
+      VIX_1000: 14.75,
+      VIX_1030: 14.60,
+    });
+  });
+
+  test('VIX nearestCheckpoint is the latest known VIX checkpoint', () => {
+    const result = buildIntradayContext('10:30:00', null, mockVixRow);
+    expect(result.vix.nearestCheckpoint).toEqual({ time: '1030', value: 14.60 });
+  });
+
+  // --- Edge cases ---
+
+  test('timeOpened 00:00:00 returns empty knownCheckpoints (not null context)', () => {
+    const result = buildIntradayContext('00:00:00', mockSpxRow, mockVixRow);
+    expect(result).not.toBeNull();
+    expect(result.tradeEntryTimeHHMM).toBe(0);
+    expect(result.spx.knownCheckpoints).toEqual({});
+    expect(result.spx.nearestCheckpoint).toBeNull();
+    expect(result.spx.moveFromOpen).toBeNull();
+    expect(result.vix.knownCheckpoints).toEqual({});
+    expect(result.vix.nearestCheckpoint).toBeNull();
+  });
+
+  test('handles BigInt values from DuckDB by converting to Number', () => {
+    const bigIntRow: Record<string, unknown> = {
+      date: '2025-01-06',
+      open: BigInt(5900),
+      P_0930: BigInt(5900),
+      P_0945: BigInt(5905),
+    };
+    const result = buildIntradayContext('09:45:00', bigIntRow, null);
+    expect(result.spx.knownCheckpoints).toEqual({ P_0930: 5900, P_0945: 5905 });
+    expect(typeof result.spx.knownCheckpoints['P_0930']).toBe('number');
+  });
+
+  test('handles null checkpoint values in data row (skips them)', () => {
+    const sparseRow: Record<string, unknown> = {
+      date: '2025-01-06',
+      open: 5900.0,
+      P_0930: 5900.0,
+      P_0945: null,
+      P_1000: 5910.0,
+    };
+    const result = buildIntradayContext('10:00:00', sparseRow, null);
+    // P_0945 is null so should be skipped
+    expect(result.spx.knownCheckpoints).toEqual({ P_0930: 5900.0, P_1000: 5910.0 });
+    // nearestCheckpoint should be P_1000 (last non-null)
+    expect(result.spx.nearestCheckpoint).toEqual({ time: '1000', price: 5910.0 });
+  });
+
+  test('moveFromOpen is null when open price is missing', () => {
+    const noOpenRow: Record<string, unknown> = {
+      date: '2025-01-06',
+      P_0930: 5900.0,
+    };
+    const result = buildIntradayContext('09:30:00', noOpenRow, null);
+    expect(result.spx.moveFromOpen).toBeNull();
+  });
+
+  test('both SPX and VIX populated when both provided', () => {
+    const result = buildIntradayContext('10:30:00', mockSpxRow, mockVixRow);
+    expect(result.spx).not.toBeNull();
+    expect(result.vix).not.toBeNull();
+    expect(Object.keys(result.spx.knownCheckpoints).length).toBeGreaterThan(0);
+    expect(Object.keys(result.vix.knownCheckpoints).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Classified all 55 `spx_daily` columns by temporal availability (8 open-known, 3 static, 44 close-derived) with single-source-of-truth in `schema-metadata.ts`
- Fixed lookahead bias in `suggest_filters` (24 filters, 14 lagged via LAG CTE) and `analyze_regime_performance` (3 lagged segmentBy options)
- Restored `enrich_trades` MCP tool with lag-aware `sameDay`/`priorDay` structural grouping, pagination, and opt-in outcome fields with bias warning
- Extended `describe_database` with `timing` metadata on columns, reusable LAG CTE template, and 7 lag-aware example queries
- Added per-trade intraday SPX (26 checkpoints) and VIX (14 checkpoints) enrichment with time-based temporal filtering
- MCP server v1.0.1 → v1.1.0 (3 minor releases across 5 phases)

### Key files

| File | Change |
|------|--------|
| `packages/mcp-server/src/utils/schema-metadata.ts` | `timing` property on all 55 spx_daily `ColumnDescription` entries |
| `packages/mcp-server/src/utils/field-timing.ts` | NEW — derived sets + `buildLookaheadFreeQuery()` LAG CTE builder |
| `packages/mcp-server/src/utils/intraday-timing.ts` | NEW — per-trade checkpoint temporal filtering |
| `packages/mcp-server/src/tools/market-data.ts` | Fixed suggest_filters, regime analysis; new enrich_trades tool |
| `packages/mcp-server/src/tools/schema.ts` | `timing` on ColumnInfo, `lagTemplate`, `generateLagTemplate()` |

### Stats

- 5 phases (55-59), 32 commits, 23 files changed
- +3,762 / -153 lines
- 282 tests pass (69 new: 19 field-timing + 50 intraday-timing)

## Test plan

- [x] `npm test` — all 282 tests pass
- [x] Field classification completeness test ensures all columns annotated
- [x] SQL validation: `suggest_filters` output matches manual LAG queries against live blocks
- [x] SQL validation: same-day (lookahead) queries produce different counts, confirming LAG is active
- [x] Milestone audit passed: 13/13 requirements, 5/5 phases, 23/23 integration points, 7/7 E2E flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)