### PR TITLE
feat: show skipped WFA windows and improve parameter sweep UX

### DIFF
--- a/app/(platform)/walk-forward/page.tsx
+++ b/app/(platform)/walk-forward/page.tsx
@@ -64,7 +64,10 @@ import {
   downloadFile,
   generateExportFilename,
 } from "@tradeblocks/lib";
-import type { WalkForwardOptimizationTarget } from "@tradeblocks/lib";
+import type {
+  WalkForwardOptimizationTarget,
+  SkippedWindow,
+} from "@tradeblocks/lib";
 import { useBlockStore, useWalkForwardStore } from "@tradeblocks/lib/stores";
 
 const TARGET_LABELS: Record<WalkForwardOptimizationTarget, string> = {
@@ -114,6 +117,7 @@ export default function WalkForwardPage() {
   );
 
   const [showFailingOnly, setShowFailingOnly] = useState(false);
+  const [showSkippedWindows, setShowSkippedWindows] = useState(false);
   const [minOosTrades, setMinOosTrades] = useState(0);
   const [periodRange, setPeriodRange] = useState<[number, number]>([1, 1]);
   const [openDetails, setOpenDetails] = useState<Record<string, boolean>>({});
@@ -243,6 +247,8 @@ export default function WalkForwardPage() {
       );
 
       return {
+        kind: "period" as const,
+        sortKey: new Date(period.inSampleStart).getTime(),
         label: `Period ${index + 1}`,
         inSampleRange: `${formatDate(period.inSampleStart)} → ${formatDate(
           period.inSampleEnd
@@ -263,6 +269,22 @@ export default function WalkForwardPage() {
     });
   }, [results]);
 
+  // Build skipped window summaries for the unified timeline
+  const skippedSummaries = useMemo(() => {
+    if (!results) return [];
+    return results.results.skippedWindows.map(
+      (sw: SkippedWindow, index: number) => ({
+        kind: "skipped" as const,
+        sortKey: new Date(sw.inSampleStart).getTime(),
+        label: `Skipped ${index + 1}`,
+        inSampleRange: `${formatDate(sw.inSampleStart)} → ${formatDate(sw.inSampleEnd)}`,
+        outSampleRange: `${formatDate(sw.outOfSampleStart)} → ${formatDate(sw.outOfSampleEnd)}`,
+        reason: sw.reason,
+        detail: sw.detail,
+      })
+    );
+  }, [results]);
+
   const rangeFilteredSummaries = useMemo(() => {
     const [start, end] = periodRange;
     return periodSummaries.filter((_, idx) => {
@@ -279,6 +301,23 @@ export default function WalkForwardPage() {
       return true;
     });
   }, [rangeFilteredSummaries, showFailingOnly, minOosTrades]);
+
+  // Unified timeline: merge periods + skipped windows when toggle is on
+  type PeriodEntry = (typeof periodSummaries)[number];
+  type SkippedEntry = (typeof skippedSummaries)[number];
+  type TimelineEntry = PeriodEntry | SkippedEntry;
+
+  const timelineEntries = useMemo((): TimelineEntry[] => {
+    if (!showSkippedWindows || skippedSummaries.length === 0) {
+      return filteredPeriodSummaries;
+    }
+    const merged = [
+      ...filteredPeriodSummaries,
+      ...skippedSummaries,
+    ];
+    merged.sort((a, b) => a.sortKey - b.sortKey);
+    return merged;
+  }, [filteredPeriodSummaries, skippedSummaries, showSkippedWindows]);
 
   const miniBars = useMemo(() => {
     return filteredPeriodSummaries.map((period) => {
@@ -530,6 +569,19 @@ export default function WalkForwardPage() {
                       Only failing windows (&lt;60% retention)
                     </span>
                   </label>
+                  {skippedSummaries.length > 0 && (
+                    <label className="flex items-center gap-2">
+                      <Checkbox
+                        checked={showSkippedWindows}
+                        onCheckedChange={(v) =>
+                          setShowSkippedWindows(Boolean(v))
+                        }
+                      />
+                      <span className="text-muted-foreground">
+                        Show skipped windows ({skippedSummaries.length})
+                      </span>
+                    </label>
+                  )}
                   <div className="flex items-center gap-2">
                     <span className="text-muted-foreground text-xs">
                       Min OOS trades
@@ -576,7 +628,7 @@ export default function WalkForwardPage() {
                 </div>
               </CardHeader>
               <CardContent className="p-0">
-                {filteredPeriodSummaries.length === 0 ? (
+                {timelineEntries.length === 0 ? (
                   <div className="py-10 text-center text-sm text-muted-foreground">
                     {periodSummaries.length === 0
                       ? "Run the analysis to populate this table."
@@ -598,7 +650,60 @@ export default function WalkForwardPage() {
                         </TableRow>
                       </TableHeader>
                       <TableBody>
-                        {filteredPeriodSummaries.map((period) => {
+                        {timelineEntries.map((entry) => {
+                          if (entry.kind === "skipped") {
+                            const isTradeIssue =
+                              entry.reason === "insufficient_is_trades" ||
+                              entry.reason === "insufficient_oos_trades";
+                            const reasonLabel = isTradeIssue
+                              ? "Not enough trades"
+                              : "No viable params";
+                            const explanation = isTradeIssue
+                              ? "This window didn\u2019t have enough trades to produce reliable statistics. Try lowering the minimum trade requirement or using wider windows."
+                              : "Every parameter combination was rejected by risk checks, performance floors, or produced undefined metrics (e.g. zero drawdown \u2192 undefined Calmar). Try relaxing constraints or widening parameter ranges.";
+                            return (
+                              <TableRow
+                                key={entry.label}
+                                className="bg-amber-50/50 dark:bg-amber-950/10"
+                              >
+                                <TableCell className="font-medium border-l-2 border-l-amber-400/60">
+                                  <span className="text-amber-700 dark:text-amber-400 text-sm font-medium">
+                                    Skipped
+                                  </span>
+                                </TableCell>
+                                <TableCell className="text-sm text-muted-foreground">
+                                  {entry.inSampleRange}
+                                </TableCell>
+                                <TableCell className="text-sm text-muted-foreground">
+                                  {entry.outSampleRange}
+                                </TableCell>
+                                <TableCell colSpan={4} className="text-sm">
+                                  <HoverCard>
+                                    <HoverCardTrigger asChild>
+                                      <span className="inline-flex items-center gap-1.5 cursor-help text-amber-700 dark:text-amber-400">
+                                        <AlertTriangle className="h-3.5 w-3.5" />
+                                        {reasonLabel}
+                                        <span className="text-muted-foreground font-normal">
+                                          — {entry.detail}
+                                        </span>
+                                      </span>
+                                    </HoverCardTrigger>
+                                    <HoverCardContent className="w-80">
+                                      <div className="space-y-2">
+                                        <p className="text-sm font-medium">{reasonLabel}</p>
+                                        <p className="text-xs text-muted-foreground leading-relaxed">
+                                          {explanation}
+                                        </p>
+                                      </div>
+                                    </HoverCardContent>
+                                  </HoverCard>
+                                </TableCell>
+                                <TableCell />
+                              </TableRow>
+                            );
+                          }
+
+                          const period = entry;
                           const delta =
                             period.outSampleMetric - period.inSampleMetric;
                           const deltaClass =

--- a/app/(platform)/walk-forward/page.tsx
+++ b/app/(platform)/walk-forward/page.tsx
@@ -272,7 +272,7 @@ export default function WalkForwardPage() {
   // Build skipped window summaries for the unified timeline
   const skippedSummaries = useMemo(() => {
     if (!results) return [];
-    return results.results.skippedWindows.map(
+    return (results.results.skippedWindows ?? []).map(
       (sw: SkippedWindow, index: number) => ({
         kind: "skipped" as const,
         sortKey: new Date(sw.inSampleStart).getTime(),

--- a/components/walk-forward/period-selector.tsx
+++ b/components/walk-forward/period-selector.tsx
@@ -280,9 +280,10 @@ export function WalkForwardPeriodSelector({ blockId, addon }: PeriodSelectorProp
         <div
           key={key}
           className={cn(
-            "space-y-2 rounded-lg border p-3 transition-opacity",
-            enabled ? "border-border/40" : "border-border/20 opacity-60"
+            "space-y-2 rounded-lg border p-3 transition-colors",
+            enabled ? "border-border/40 bg-card" : "border-border/30 cursor-pointer hover:border-border/50 hover:bg-muted/30"
           )}
+          onClick={!enabled ? () => toggleParameter(key, true) : undefined}
         >
           <div className="flex items-start justify-between gap-3">
             <div className="flex items-center gap-3">
@@ -820,6 +821,17 @@ export function WalkForwardPeriodSelector({ blockId, addon }: PeriodSelectorProp
             </div>
           </div>
         </div>
+
+        {/* Nudge when no parameters enabled - above the collapsible so it's always visible */}
+        {!Object.values(extendedParameterRanges).some(([,,,enabled]) => enabled) && (
+          <div className="flex items-start gap-2.5 rounded-md border border-blue-200 dark:border-blue-800/50 bg-blue-50/50 dark:bg-blue-950/20 px-3 py-2.5">
+            <Sparkles className="h-4 w-4 text-blue-500 mt-0.5 shrink-0" />
+            <p className="text-xs text-blue-700 dark:text-blue-300 leading-relaxed">
+              Enable at least one parameter sweep to run the analysis. The optimizer tests combinations
+              across your ranges to find the best settings for each window.
+            </p>
+          </div>
+        )}
 
         <Collapsible open={parametersOpen} onOpenChange={setParametersOpen}>
           <CollapsibleTrigger asChild>

--- a/components/walk-forward/walk-forward-summary.tsx
+++ b/components/walk-forward/walk-forward-summary.tsx
@@ -108,6 +108,16 @@ export function WalkForwardSummary({ results }: WalkForwardSummaryProps) {
   const consistencyPct = (results.stats.consistencyScore || 0) * 100
   const windowCount = results.periods.length
 
+  // Count skipped window reasons
+  const skippedWindows = results.skippedWindows ?? []
+  const skippedCount = skippedWindows.length
+  const insufficientTradesCount = skippedWindows.filter(
+    (w) => w.reason === "insufficient_is_trades" || w.reason === "insufficient_oos_trades"
+  ).length
+  const noViableParamsCount = skippedWindows.filter(
+    (w) => w.reason === "no_viable_params"
+  ).length
+
   return (
     <Card className={cn("border-l-4", style.border)}>
       <CardContent className="pt-6 space-y-6">
@@ -150,6 +160,21 @@ export function WalkForwardSummary({ results }: WalkForwardSummaryProps) {
             <p className="text-sm text-muted-foreground">
               {summaryMessages[assessment.overall]}
             </p>
+            {skippedCount > 0 && (
+              <p className="text-xs text-muted-foreground/80">
+                {skippedCount} window{skippedCount !== 1 ? "s" : ""} skipped
+                {" ("}
+                {[
+                  insufficientTradesCount > 0 &&
+                    `${insufficientTradesCount} insufficient trades`,
+                  noViableParamsCount > 0 &&
+                    `${noViableParamsCount} no viable params`,
+                ]
+                  .filter(Boolean)
+                  .join(", ")}
+                {")"}
+              </p>
+            )}
           </div>
         </div>
 

--- a/packages/lib/calculations/walk-forward-analyzer.ts
+++ b/packages/lib/calculations/walk-forward-analyzer.ts
@@ -12,6 +12,7 @@ import {
   PerformanceFloorConfig,
   DiversificationConfig,
   PeriodDiversificationMetrics,
+  SkippedWindow,
 } from '../models/walk-forward'
 import { PortfolioStatsCalculator } from './portfolio-stats'
 import { calculateKellyMetrics } from './kelly'
@@ -95,7 +96,7 @@ export class WalkForwardAnalyzer {
     })
 
     const periods: WalkForwardPeriodResult[] = []
-    let skippedPeriods = 0
+    const skippedWindows: SkippedWindow[] = []
     let totalParameterTests = 0
 
     for (let index = 0; index < windows.length; index++) {
@@ -109,7 +110,11 @@ export class WalkForwardAnalyzer {
       const minOutSample = options.config.minOutOfSampleTrades ?? DEFAULT_MIN_OUT_SAMPLE_TRADES
 
       if (inSampleTrades.length < minInSample || outSampleTrades.length < minOutSample) {
-        skippedPeriods++
+        const reason = inSampleTrades.length < minInSample ? 'insufficient_is_trades' as const : 'insufficient_oos_trades' as const
+        const detail = inSampleTrades.length < minInSample
+          ? `${inSampleTrades.length} IS trades < min ${minInSample}`
+          : `${outSampleTrades.length} OOS trades < min ${minOutSample}`
+        skippedWindows.push({ ...window, reason, detail })
         continue
       }
 
@@ -206,7 +211,11 @@ export class WalkForwardAnalyzer {
       totalParameterTests += tested
 
       if (!bestCombo) {
-        skippedPeriods++
+        skippedWindows.push({
+          ...window,
+          reason: 'no_viable_params',
+          detail: `All ${combinationIterator.count} combo${combinationIterator.count === 1 ? '' : 's'} rejected`,
+        })
         continue
       }
 
@@ -261,7 +270,7 @@ export class WalkForwardAnalyzer {
       sortedTrades.length,
       startedAt,
       completedAt,
-      skippedPeriods
+      skippedWindows
     )
 
     options.onProgress?.({
@@ -737,13 +746,13 @@ export class WalkForwardAnalyzer {
     analyzedTrades: number,
     startedAt: Date,
     completedAt: Date = new Date(),
-    skippedPeriods = 0
+    skippedWindows: SkippedWindow[] = []
   ): WalkForwardResults {
     const summary = this.calculateSummary(periods)
     const stats = {
       totalPeriods,
       evaluatedPeriods: periods.length,
-      skippedPeriods,
+      skippedPeriods: skippedWindows.length,
       totalParameterTests,
       analyzedTrades,
       durationMs: completedAt.getTime() - startedAt.getTime(),
@@ -755,6 +764,7 @@ export class WalkForwardAnalyzer {
 
     return {
       periods,
+      skippedWindows,
       summary: { ...summary, robustnessScore },
       stats,
     }

--- a/packages/lib/models/walk-forward.ts
+++ b/packages/lib/models/walk-forward.ts
@@ -150,6 +150,16 @@ export interface WalkForwardWindow {
   outOfSampleEnd: Date
 }
 
+export type WindowSkipReason =
+  | 'insufficient_is_trades'
+  | 'insufficient_oos_trades'
+  | 'no_viable_params'
+
+export interface SkippedWindow extends WalkForwardWindow {
+  reason: WindowSkipReason
+  detail: string
+}
+
 export interface WalkForwardPeriodResult extends WalkForwardWindow {
   optimalParameters: Record<string, number>
   inSampleMetrics: PortfolioStats
@@ -185,6 +195,7 @@ export interface WalkForwardRunStats {
 
 export interface WalkForwardResults {
   periods: WalkForwardPeriodResult[]
+  skippedWindows: SkippedWindow[]
   summary: WalkForwardSummary
   stats: WalkForwardRunStats
 }

--- a/tests/unit/walk-forward-analyzer.test.ts
+++ b/tests/unit/walk-forward-analyzer.test.ts
@@ -1630,4 +1630,144 @@ describe('WalkForwardAnalyzer edge cases and stress tests', () => {
       expect(Number.isFinite(period.targetMetricOutOfSample)).toBe(true)
     })
   })
+
+  describe('skipped window tracking', () => {
+    it('captures skipped windows due to insufficient IS trades', async () => {
+      const trades = createTestTrades([100, 200], '2024-01-01', 30, 50_000)
+
+      const config: WalkForwardConfig = {
+        inSampleDays: 30,
+        outOfSampleDays: 15,
+        stepSizeDays: 15,
+        optimizationTarget: 'netPl',
+        parameterRanges: { kellyMultiplier: [1, 1, 1] },
+        minInSampleTrades: 10,
+        minOutOfSampleTrades: 1,
+      }
+
+      const result = await analyzer.analyze({ trades, config })
+
+      expect(result.results.skippedWindows.length).toBeGreaterThan(0)
+      expect(result.results.stats.skippedPeriods).toBe(result.results.skippedWindows.length)
+
+      const insufficientIS = result.results.skippedWindows.filter(
+        (w) => w.reason === 'insufficient_is_trades'
+      )
+      expect(insufficientIS.length).toBeGreaterThan(0)
+      expect(insufficientIS[0].detail).toMatch(/IS trades < min/)
+      expect(insufficientIS[0].inSampleStart).toBeInstanceOf(Date)
+      expect(insufficientIS[0].inSampleEnd).toBeInstanceOf(Date)
+    })
+
+    it('captures skipped windows due to insufficient OOS trades', async () => {
+      // Create trades clustered in first 20 days only
+      const trades = createTestTrades(
+        [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000],
+        '2024-01-01',
+        1,
+        50_000
+      )
+
+      const config: WalkForwardConfig = {
+        inSampleDays: 10,
+        outOfSampleDays: 30,
+        stepSizeDays: 10,
+        optimizationTarget: 'netPl',
+        parameterRanges: { kellyMultiplier: [1, 1, 1] },
+        minInSampleTrades: 1,
+        minOutOfSampleTrades: 5,
+      }
+
+      const result = await analyzer.analyze({ trades, config })
+
+      const insufficientOOS = result.results.skippedWindows.filter(
+        (w) => w.reason === 'insufficient_oos_trades'
+      )
+      // The OOS window extends past the trade data, so some windows should have insufficient OOS trades
+      if (insufficientOOS.length > 0) {
+        expect(insufficientOOS[0].detail).toMatch(/OOS trades < min/)
+      }
+    })
+
+    it('captures skipped windows due to no viable parameter combo', async () => {
+      const trades = createTestTrades(
+        [100, -5000, 100, -5000, 100, -5000, 100, -5000],
+        '2024-01-01',
+        2,
+        10_000
+      )
+
+      const config: WalkForwardConfig = {
+        inSampleDays: 8,
+        outOfSampleDays: 4,
+        stepSizeDays: 4,
+        optimizationTarget: 'netPl',
+        parameterRanges: {
+          kellyMultiplier: [1, 1, 1],
+          maxDrawdownPct: [1, 1, 1],
+        },
+        minInSampleTrades: 2,
+        minOutOfSampleTrades: 1,
+      }
+
+      const result = await analyzer.analyze({ trades, config })
+
+      const noViable = result.results.skippedWindows.filter(
+        (w) => w.reason === 'no_viable_params'
+      )
+      if (noViable.length > 0) {
+        expect(noViable[0].detail).toMatch(/combo/)
+      }
+    })
+
+    it('returns empty skippedWindows when all windows succeed', async () => {
+      const trades = createTestTrades(
+        [500, -250, 650, -100, 300, -400, 700, 200, -150, 450, -200, 550],
+        '2024-01-02',
+        3,
+        40_000
+      )
+
+      const config: WalkForwardConfig = {
+        inSampleDays: 18,
+        outOfSampleDays: 9,
+        stepSizeDays: 9,
+        optimizationTarget: 'netPl',
+        parameterRanges: { kellyMultiplier: [1, 1, 1] },
+        minInSampleTrades: 2,
+        minOutOfSampleTrades: 1,
+      }
+
+      const result = await analyzer.analyze({ trades, config })
+
+      expect(result.results.skippedWindows).toEqual([])
+      expect(result.results.stats.skippedPeriods).toBe(0)
+      expect(result.results.periods.length).toBeGreaterThan(0)
+    })
+
+    it('skipped windows preserve date ranges for UI display', async () => {
+      const trades = createTestTrades([100], '2024-01-01', 1, 50_000)
+
+      const config: WalkForwardConfig = {
+        inSampleDays: 10,
+        outOfSampleDays: 5,
+        stepSizeDays: 5,
+        optimizationTarget: 'netPl',
+        parameterRanges: { kellyMultiplier: [1, 1, 1] },
+        minInSampleTrades: 5,
+        minOutOfSampleTrades: 5,
+      }
+
+      const result = await analyzer.analyze({ trades, config })
+
+      // With only 1 trade and min 5 required, windows should be skipped
+      for (const skipped of result.results.skippedWindows) {
+        expect(skipped.inSampleStart).toBeInstanceOf(Date)
+        expect(skipped.inSampleEnd).toBeInstanceOf(Date)
+        expect(skipped.outOfSampleStart).toBeInstanceOf(Date)
+        expect(skipped.outOfSampleEnd).toBeInstanceOf(Date)
+        expect(skipped.inSampleEnd.getTime()).toBeLessThan(skipped.outOfSampleStart.getTime())
+      }
+    })
+  })
 })

--- a/tests/unit/walk-forward-store.test.ts
+++ b/tests/unit/walk-forward-store.test.ts
@@ -86,6 +86,7 @@ function createMockAnalysis(blockId = 'block-1'): WalkForwardAnalysis {
     config: DEFAULT_WALK_FORWARD_CONFIG,
     results: {
       periods: [period],
+      skippedWindows: [],
       summary: {
         avgInSamplePerformance: 475,
         avgOutOfSamplePerformance: 320,

--- a/tests/unit/walk-forward-verdict.test.ts
+++ b/tests/unit/walk-forward-verdict.test.ts
@@ -45,6 +45,7 @@ function createMockResults(options: {
 }): WalkForwardResults {
   return {
     periods: [],
+    skippedWindows: [],
     summary: {
       avgInSamplePerformance: 1000,
       avgOutOfSamplePerformance: options.degradationFactor * 1000,


### PR DESCRIPTION
## Summary

- **Skipped window tracking**: The WFA analyzer now captures why windows were skipped (insufficient trades or no viable parameter combinations) with detail strings. Skipped windows render as amber-highlighted rows in the period table with a "Show skipped windows" toggle, inline reasons, and actionable hover tooltips explaining what to adjust.
- **Summary skip breakdown**: The WFA summary card shows "X windows skipped (Y insufficient trades, Z no viable params)" when applicable.
- **Parameter sweep UX**: Disabled parameter cards are no longer nearly invisible (`opacity-60` removed). Entire card is clickable to enable. A blue nudge message appears above the Parameter Sweeps collapsible guiding new users to enable at least one parameter.

## Test plan

- [x] Walk-forward analyzer tests pass (66 tests) — skipped window capture verified
- [x] Walk-forward verdict tests pass (54 tests) — mock data updated with `skippedWindows`
- [ ] Run WFA with settings that produce skipped windows (low min trades, tight constraints) and verify amber rows appear with correct reasons
- [ ] Toggle "Show skipped windows" checkbox on/off in Window Data tab
- [ ] Hover skipped row to see actionable tooltip
- [ ] Verify parameter sweep cards are visible and clickable when unchecked
- [ ] Verify blue nudge message appears when no parameters are enabled, disappears when one is checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)