### PR TITLE
fix: buildOutcomeQuery VIX join alias corruption

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks-mcp",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "MCP server for options trade analysis",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "type": "module",

--- a/packages/mcp-server/src/utils/field-timing.ts
+++ b/packages/mcp-server/src/utils/field-timing.ts
@@ -169,9 +169,9 @@ export const STATIC_FIELDS: ReadonlySet<string> = new Set([
 // ============================================================================
 
 // Build the VIX JOIN clause (three LEFT JOINs: vix, vix9d, vix3m)
-function buildVixJoins(): string {
+function buildVixJoins(baseAlias: string = "d"): string {
   return VIX_TABLE_ALIASES
-    .map(alias => `LEFT JOIN market.daily ${alias} ON ${alias}.date = d.date AND ${alias}.ticker = '${VIX_TICKER_FOR_ALIAS[alias]}'`)
+    .map(alias => `LEFT JOIN market.daily ${alias} ON ${alias}.date = ${baseAlias}.date AND ${alias}.ticker = '${VIX_TICKER_FOR_ALIAS[alias]}'`)
     .join("\n      ");
 }
 
@@ -390,7 +390,7 @@ export function buildOutcomeQuery(
     )
     SELECT m.ticker, m.date, ${dailyCloseCols}, ${vixCloseCols}, ${derivedCloseCols}
     FROM market.daily m
-    ${vixJoins.replace(/d\.date/g, 'm.date')}
+    ${buildVixJoins("m")}
     LEFT JOIN market._context_derived cd ON cd.date = m.date
     JOIN requested
       ON m.ticker = requested.ticker

--- a/packages/mcp-server/tests/unit/field-timing.test.ts
+++ b/packages/mcp-server/tests/unit/field-timing.test.ts
@@ -344,4 +344,16 @@ describe('buildOutcomeQuery', () => {
     expect(sql).toContain('m.date = requested.date');
     expect(params).toEqual(['SPX', '2025-01-06', 'MSFT', '2025-01-07']);
   });
+
+  test('ticker+date path joins VIX tables on m.date without corrupting aliases', () => {
+    const { sql } = buildOutcomeQuery([
+      { ticker: 'SPX', date: '2025-01-06' },
+    ]);
+
+    // VIX joins should reference m.date (not d.date) since base table alias is m
+    expect(sql).toContain('vix9d.date = m.date');
+    expect(sql).toContain('vix3m.date = m.date');
+    // Must NOT contain corrupted alias "vix9m" (regression: regex replace turned vix9d.date into vix9m.date)
+    expect(sql).not.toContain('vix9m');
+  });
 });


### PR DESCRIPTION
## Summary
- `buildOutcomeQuery`'s ticker+date path used a regex (`/d\.date/g`) to rewrite VIX joins from `d.date` to `m.date`, but this matched `d.date` inside `vix9d.date`, corrupting it to `vix9m.date` — causing `enrich_trades` to fail with "Referenced table vix9m not found"
- Parameterized `buildVixJoins(baseAlias)` so callers pass the alias directly instead of regex-replacing
- Added regression test asserting `vix9m` never appears in generated SQL
- Bumps MCP server to v2.2.1

## Test plan
- [x] All 38 field-timing tests pass (including new regression test)
- [x] Build succeeds
- [ ] Verify `enrich_trades` works against a live block after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)