### PR TITLE
fix: refactor buildOutcomeQuery to eliminate shared alias state

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks-mcp",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "MCP server for options trade analysis",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "type": "module",

--- a/packages/mcp-server/src/utils/field-timing.ts
+++ b/packages/mcp-server/src/utils/field-timing.ts
@@ -353,27 +353,39 @@ export function buildOutcomeQuery(
     return { sql: `SELECT * FROM market.daily WHERE 1=0`, params: [] };
   }
 
-  const dailyCloseCols = [...DAILY_CLOSE_FIELDS].map((f) => `d."${f}"`).join(", ");
   const vixCloseCols = VIX_FIELD_MAPPINGS
     .filter(m => m.timing === 'close')
     .map(m => `${m.tableAlias}."${m.sourceCol}" AS "${m.alias}"`)
     .join(", ");
   const derivedCloseCols = [...DERIVED_CLOSE_FIELDS].map(f => `cd."${f}"`).join(", ");
-  const vixJoins = buildVixJoins();
 
   if (typeof tradeDatesOrKeys[0] === "string") {
-    const tradeDates = tradeDatesOrKeys as string[];
-    const placeholders = tradeDates.map((_, i) => `$${i + 1}`).join(", ");
-    const sql = `SELECT d.date, ${dailyCloseCols}, ${vixCloseCols}, ${derivedCloseCols}
-    FROM market.daily d
-    ${vixJoins}
-    LEFT JOIN market._context_derived cd ON cd.date = d.date
-    WHERE d.ticker = $${tradeDates.length + 1}
-      AND d.date IN (${placeholders})`;
-    return { sql, params: [...tradeDates, DEFAULT_MARKET_TICKER] };
+    return buildOutcomeQueryForDates(tradeDatesOrKeys as string[], vixCloseCols, derivedCloseCols);
   }
 
-  const tradeKeys = tradeDatesOrKeys as MarketLookupKey[];
+  return buildOutcomeQueryForKeys(tradeDatesOrKeys as MarketLookupKey[], vixCloseCols, derivedCloseCols);
+}
+
+function buildOutcomeQueryForDates(
+  tradeDates: string[], vixCloseCols: string, derivedCloseCols: string
+): { sql: string; params: string[] } {
+  const a = "d";
+  const dailyCloseCols = [...DAILY_CLOSE_FIELDS].map((f) => `${a}."${f}"`).join(", ");
+  const placeholders = tradeDates.map((_, i) => `$${i + 1}`).join(", ");
+  const sql = `SELECT ${a}.date, ${dailyCloseCols}, ${vixCloseCols}, ${derivedCloseCols}
+    FROM market.daily ${a}
+    ${buildVixJoins(a)}
+    LEFT JOIN market._context_derived cd ON cd.date = ${a}.date
+    WHERE ${a}.ticker = $${tradeDates.length + 1}
+      AND ${a}.date IN (${placeholders})`;
+  return { sql, params: [...tradeDates, DEFAULT_MARKET_TICKER] };
+}
+
+function buildOutcomeQueryForKeys(
+  tradeKeys: MarketLookupKey[], vixCloseCols: string, derivedCloseCols: string
+): { sql: string; params: string[] } {
+  const a = "m";
+  const dailyCloseCols = [...DAILY_CLOSE_FIELDS].map((f) => `${a}."${f}"`).join(", ");
   const normalizedKeys = tradeKeys.map((k) => ({
     date: k.date,
     ticker: k.ticker || DEFAULT_MARKET_TICKER,
@@ -388,13 +400,13 @@ export function buildOutcomeQuery(
   const sql = `WITH requested(ticker, date) AS (
       VALUES ${valuePlaceholders.join(", ")}
     )
-    SELECT m.ticker, m.date, ${dailyCloseCols}, ${vixCloseCols}, ${derivedCloseCols}
-    FROM market.daily m
-    ${buildVixJoins("m")}
-    LEFT JOIN market._context_derived cd ON cd.date = m.date
+    SELECT ${a}.ticker, ${a}.date, ${dailyCloseCols}, ${vixCloseCols}, ${derivedCloseCols}
+    FROM market.daily ${a}
+    ${buildVixJoins(a)}
+    LEFT JOIN market._context_derived cd ON cd.date = ${a}.date
     JOIN requested
-      ON m.ticker = requested.ticker
-     AND m.date = requested.date`;
+      ON ${a}.ticker = requested.ticker
+     AND ${a}.date = requested.date`;
 
   return { sql, params: values };
 }

--- a/packages/mcp-server/tests/unit/field-timing.test.ts
+++ b/packages/mcp-server/tests/unit/field-timing.test.ts
@@ -345,7 +345,7 @@ describe('buildOutcomeQuery', () => {
     expect(params).toEqual(['SPX', '2025-01-06', 'MSFT', '2025-01-07']);
   });
 
-  test('ticker+date path joins VIX tables on m.date without corrupting aliases', () => {
+  test('ticker+date path uses m alias consistently (no d. references)', () => {
     const { sql } = buildOutcomeQuery([
       { ticker: 'SPX', date: '2025-01-06' },
     ]);
@@ -355,5 +355,8 @@ describe('buildOutcomeQuery', () => {
     expect(sql).toContain('vix3m.date = m.date');
     // Must NOT contain corrupted alias "vix9m" (regression: regex replace turned vix9d.date into vix9m.date)
     expect(sql).not.toContain('vix9m');
+    // Daily close columns must use m. prefix, not d. (base table is aliased as m)
+    expect(sql).not.toMatch(/\bd\."(high|low|close|RSI_14|ATR_Pct)"/);
+    expect(sql).toContain('m."high"');
   });
 });


### PR DESCRIPTION
## Summary
- Follow-up to #266 — the VIX join alias fix exposed a second bug: `dailyCloseCols` was built with hardcoded `d.` prefix but shared across both query paths (the ticker+date path uses `m`)
- Split `buildOutcomeQuery` into `buildOutcomeQueryForDates` (alias `d`) and `buildOutcomeQueryForKeys` (alias `m`), each defining the base alias once and using it for all column/join generation
- No more shared mutable state between the two code paths

## Test plan
- [x] All 38 field-timing tests pass
- [x] Regression test asserts no `d.` references leak into the `m`-aliased path
- [ ] Verify `enrich_trades` works end-to-end after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)