### PR TITLE
fix(market): empty enriched parquet on first-time enrichment + VIX1D classified as stock

### DIFF
--- a/packages/mcp-server/src/market/ingestor/market-ingestor.ts
+++ b/packages/mcp-server/src/market/ingestor/market-ingestor.ts
@@ -92,7 +92,7 @@ export class MarketIngestor {
   }
 
   private detectAssetClass(ticker: string): "stock" | "index" | "option" {
-    const VIX_FAMILY = new Set(["VIX", "VIX9D", "VIX3M", "VXN", "SPX", "NDX"]);
+    const VIX_FAMILY = new Set(["VIX", "VIX9D", "VIX1D", "VIX3M", "VXN", "SPX", "NDX"]);
     if (VIX_FAMILY.has(ticker)) return "index";
     if (/^[A-Z]{1,6}\d{6}[CP]\d{8}$/.test(ticker)) return "option";
     return "stock";

--- a/packages/mcp-server/src/utils/market-enricher.ts
+++ b/packages/mcp-server/src/utils/market-enricher.ts
@@ -732,6 +732,12 @@ async function setupParquetWorkingTables(
   // no constraints), so attach one explicitly here.
   await conn.run(`CREATE UNIQUE INDEX "idx_${dateContextTable}_date" ON "${dateContextTable}"(date)`);
 
+  // Same rationale for the daily working table: batchUpdateDaily uses
+  // INSERT OR REPLACE so first-time enrichment of a ticker (whose seed
+  // contains zero rows for that ticker) populates the working table from
+  // computed values rather than silently no-op-ing on UPDATE.
+  await conn.run(`CREATE UNIQUE INDEX "idx_${dailyTable}_pk" ON "${dailyTable}"(ticker, date)`);
+
   return { dailyTable, dateContextTable };
 }
 
@@ -828,12 +834,14 @@ async function batchUpdateDaily(
       return `(${params.join(", ")})`;
     })
     .join(", ");
-  const setClauses = columns.map((c) => `${c} = v.${c}`).join(", ");
+  // INSERT OR REPLACE (relies on UNIQUE INDEX on (ticker, date) attached in
+  // setupParquetWorkingTables). REPLACE semantics handle the re-enrichment
+  // case identically to the prior UPDATE; INSERT semantics are needed for
+  // first-time enrichment of a ticker whose seed contains no rows for it
+  // (previously silently dropped via the UPDATE no-op).
   const sql = `
-    UPDATE ${tableName} AS t
-    SET ${setClauses}
-    FROM (VALUES ${placeholders}) AS v(${allCols.join(", ")})
-    WHERE t.ticker = v.ticker AND t.date = v.date
+    INSERT OR REPLACE INTO ${tableName} (${allCols.join(", ")})
+    VALUES ${placeholders}
   `;
   const params = rows.flatMap((row) => allCols.map((col) => row[col] ?? null));
   await conn.run(sql, params as (string | number | boolean | null | bigint)[]);


### PR DESCRIPTION
Two narrowly-scoped data-pipeline bugs found while debugging an empty `market.enriched` view in 3.0 Parquet mode. Each fix is its own commit so they can be reverted independently.

## Bug 1 — `enrich_market_data` writes empty Parquet (commit 1: enricher)

In Parquet mode, `runEnrichment`'s daily working table is seeded from existing `enriched/ticker=*/data.parquet` files (or empty when none exist). `batchUpdateDaily` then issues an UPDATE keyed on `(ticker, date)`. For a ticker whose seed contains zero rows for it — first-time enrichment, or any state where the per-ticker enriched file was previously empty — the UPDATE matches no rows and silently no-ops. `flushEnrichedToParquet` then writes back a header-only Parquet (~675 bytes), perpetuating the empty state across every subsequent enrichment call.

**Fix**: switch to `INSERT OR REPLACE`, which inserts new rows when missing and replaces them when present. Add a UNIQUE index on `(ticker, date)` for the working dailyTable (mirroring the existing pattern for `dateContextTable`, which already does `INSERT OR REPLACE` in `runTier2`).

The batch shape, parameters, and column list are preserved verbatim — only the SQL keyword changes. No API changes, no schema changes.

## Bug 2 — VIX1D classified as stock (commit 2: ingestor)

`detectAssetClass` in `MarketIngestor` uses a hardcoded set of index tickers (`VIX`, `VIX9D`, `VIX3M`, `VXN`, `SPX`, `NDX`) to route ThetaData fetches. VIX1D wasn't in the set, so it fell through to `"stock"` and the provider hit `/v3/stock/history/eod?symbol=VIX1D` instead of `/v3/index/history/eod?symbol=VIX1D`. ThetaData's stock endpoint returns shells with all-zero OHLCV for an unknown stock symbol; `mapEodRow` coerces `undefined → 0`, so every VIX1D row in `market.spot_daily` had `open=high=low=close=0`.

**Fix**: add `VIX1D` to the index set. One-line change.

## Verification (local)

- **Bug 1**: First-time enrichment of an empty SPX (post-reset watermark) wrote 1,571 rows / 126 KB Parquet (was 0 rows / 675 B). Re-enriching a caught-up ticker is idempotent. Full `refresh_market_data → fetch_bars → auto-enrich → context` pipeline advances all 8 tickers cleanly through the next trading day; per-ticker file sizes grow by exactly one row's worth.
- **Bug 2**: Refetching the full VIX1D history wrote 754 trading-day rows of real OHLCV — values match ThetaData's index endpoint exactly (2026-04-22 close=12.28, 2026-04-24 close=16.62). Auto-enrichment now computes sensible values (RSI ~40-50, ATR_Pct ~55-75 reflecting VIX1D's high realized vol).

Both bugs were silent — no errors, just bad/empty data — and pre-existed the change. No new tests added in this PR; happy to follow up if you want explicit unit coverage for the empty-seed enrichment path.

## Diff size

```
 .../mcp-server/src/market/ingestor/market-ingestor.ts  |  2 +-
 packages/mcp-server/src/utils/market-enricher.ts       | 18 +++++++++++++-----
 2 files changed, 14 insertions(+), 6 deletions(-)
```