### PR TITLE
chore: org migration cleanup — davidromeo/tradeblocks → tradeblocks-org/tradeblocks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,23 @@
-# TradeBlocks Code Owners
-# Global owners for all files
-* @davidromeo
+# CODEOWNERS — tradeblocks-org/tradeblocks
+#
+# Path-based review routing. Both Admirals on every line by design — see
+# tradeblocks-org/enterprise CODEOWNERS for the full rationale.
 
-# Critical configuration files
-vercel.json @davidromeo
-requirements.txt @davidromeo
-.github/ @davidromeo
+# Public-facing — anything that ships to OO users (Tier 3)
+/packages/                              @davidromeo @longpshorn
+/app/                                   @davidromeo @longpshorn
+/components/                            @davidromeo @longpshorn
+/hooks/                                 @davidromeo @longpshorn
+/docs/                                  @davidromeo @longpshorn
+/public/                                @davidromeo @longpshorn
+/tests/                                 @davidromeo @longpshorn
+/tools/                                 @davidromeo @longpshorn
+/gpt/                                   @davidromeo @longpshorn
 
-# Core application
-app/main.py @davidromeo
-app/api/ @davidromeo
+# Build / CI / publish config — Tier 3
+/package.json                           @davidromeo @longpshorn
+/.github/workflows/                     @davidromeo @longpshorn
+/.github/CODEOWNERS                     @davidromeo @longpshorn
+
+# Default
+*                                       @davidromeo @longpshorn

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,4 +38,4 @@
 
 ---
 
-**Ready to build! 🧱** This PR will automatically deploy a preview on Vercel.
+**Ready to build! 🧱** This PR will automatically deploy a preview on Render.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,7 @@ on:
       - master
     paths:
       - 'packages/mcp-server/**'
-      - 'packages/agent-skills/**'
-      - 'lib/**'
+      - 'packages/lib/**'
   workflow_dispatch:
 
 permissions:
@@ -202,6 +201,10 @@ jobs:
 
             ### From Source
             ```bash
-            git clone https://github.com/davidromeo/tradeblocks
+            git clone https://github.com/tradeblocks-org/tradeblocks
             cd tradeblocks && npm install && npm run build:mcp
             ```
+
+            ---
+
+            Note: the canonical repo is now `tradeblocks-org/tradeblocks`. GitHub redirects keep old `davidromeo/tradeblocks` URLs working.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ tradeblocks/
 ### Development Setup
 
 ```bash
-git clone https://github.com/davidromeo/tradeblocks.git
+git clone https://github.com/tradeblocks-org/tradeblocks.git
 cd tradeblocks
 npm install
 npm run dev              # Web dashboard at http://localhost:3000

--- a/components/sidebar-footer-legal.tsx
+++ b/components/sidebar-footer-legal.tsx
@@ -91,7 +91,7 @@ export function SidebarFooterLegal() {
             </a>
             <span className="text-muted-foreground/50">•</span>
             <Link
-              href="https://github.com/davidromeo/tradeblocks"
+              href="https://github.com/tradeblocks-org/tradeblocks"
               target="_blank"
               className="inline-flex items-center gap-1 transition hover:text-foreground"
             >
@@ -166,7 +166,7 @@ export function SidebarFooterLegal() {
         </a>
         <span className="text-muted-foreground/50">•</span>
         <Link
-          href="https://github.com/davidromeo/tradeblocks"
+          href="https://github.com/tradeblocks-org/tradeblocks"
           target="_blank"
           className="inline-flex items-center gap-1.5 transition hover:text-foreground"
         >

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,8 +25,8 @@ See [packages/mcp-server/README.md](../packages/mcp-server/README.md) for platfo
 ### Docker
 
 ```bash
-docker pull ghcr.io/davidromeo/tradeblocks-mcp:latest
-docker run -v ~/Trading/backtests:/data ghcr.io/davidromeo/tradeblocks-mcp /data
+docker pull ghcr.io/tradeblocks-org/tradeblocks-mcp:latest
+docker run -v ~/Trading/backtests:/data ghcr.io/tradeblocks-org/tradeblocks-mcp /data
 ```
 
 ### Environment Variables
@@ -80,7 +80,7 @@ The web dashboard is a Next.js app for visual portfolio exploration — equity c
 ### Setup
 
 ```bash
-git clone https://github.com/davidromeo/tradeblocks.git
+git clone https://github.com/tradeblocks-org/tradeblocks.git
 cd tradeblocks
 npm install
 npm run dev

--- a/gpt/system-prompt.md
+++ b/gpt/system-prompt.md
@@ -35,7 +35,7 @@ Don't dump walls of information. Give focused answers.
 
 ## What is TradeBlocks?
 
-Browser-based options trading analyzer. Upload CSVs → get statistics, charts, Monte Carlo, walk-forward analysis, Kelly sizing. All data stays local (IndexedDB). Open source: github.com/davidromeo/tradeblocks
+Browser-based options trading analyzer. Upload CSVs → get statistics, charts, Monte Carlo, walk-forward analysis, Kelly sizing. All data stays local (IndexedDB). Open source: github.com/tradeblocks-org/tradeblocks
 
 **Built for Option Omega** backtests and portfolios.
 

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -16,7 +16,7 @@ Model Context Protocol (MCP) server for options trading analysis. Works with Cla
 
 ### Option 1: MCPB Bundle (Claude Desktop - One Click)
 
-Download the latest `.mcpb` file from [Releases](https://github.com/davidromeo/tradeblocks/releases) and double-click to install.
+Download the latest `.mcpb` file from [Releases](https://github.com/tradeblocks-org/tradeblocks/releases) and double-click to install.
 
 The installer will prompt you to select your Trading Data Directory.
 
@@ -37,7 +37,7 @@ See [Configuration by Platform](#configuration-by-platform) below for platform-s
 ### Option 3: From Source
 
 ```bash
-git clone https://github.com/davidromeo/tradeblocks
+git clone https://github.com/tradeblocks-org/tradeblocks
 cd tradeblocks
 npm install
 npm run build -w packages/mcp-server

--- a/packages/mcp-server/manifest.json
+++ b/packages/mcp-server/manifest.json
@@ -11,11 +11,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/davidromeo/tradeblocks"
+    "url": "https://github.com/tradeblocks-org/tradeblocks"
   },
-  "homepage": "https://github.com/davidromeo/tradeblocks",
-  "documentation": "https://github.com/davidromeo/tradeblocks/tree/master/packages/mcp-server",
-  "support": "https://github.com/davidromeo/tradeblocks/issues",
+  "homepage": "https://github.com/tradeblocks-org/tradeblocks",
+  "documentation": "https://github.com/tradeblocks-org/tradeblocks/tree/master/packages/mcp-server",
+  "support": "https://github.com/tradeblocks-org/tradeblocks/issues",
   "server": {
     "type": "node",
     "entry_point": "server/index.js",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -56,7 +56,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/davidromeo/tradeblocks",
+    "url": "https://github.com/tradeblocks-org/tradeblocks",
     "directory": "packages/mcp-server"
   }
 }

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -56,7 +56,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/tradeblocks-org/tradeblocks",
+    "url": "git+https://github.com/tradeblocks-org/tradeblocks.git",
     "directory": "packages/mcp-server"
   }
 }


### PR DESCRIPTION
Tier: 3

## Summary

Cleanup pass on `tradeblocks-org/tradeblocks` following the repo transfer from `davidromeo/tradeblocks` (2026-05-16). Updates references that GitHub redirects work around but display stale URLs to npm consumers and docs readers.

**Base note:** targeting `feat/tradeblocks-3.0` (the active 3.0 dev branch, 39 commits ahead of master with master fully merged in). These changes will flow to master as part of the 3.0 release merge. Targeting master directly would have created a noisy back-merge later.

## Changes

### CODEOWNERS
Rewrite. The previous file referenced nonexistent Flask-era files (`vercel.json`, `requirements.txt`, `app/main.py`, `app/api/`). New file matches the `tradeblocks-org/enterprise` CODEOWNERS pattern — both Admirals on every line by design. Tier differentiation comes from required-review count in branch protections, not from owner list. Path list adapted to the actual repo layout (no top-level `/lib/`; `lib` lives under `/packages/`).

### NPM-surface
- `packages/mcp-server/package.json` — `repository.url`
- `packages/mcp-server/manifest.json` — `repository`, `homepage`, `documentation`, `support` URLs (ships in `.mcpb` bundles, visible to Claude Desktop users)

### Workflows
- `release.yml` — release-notes clone URL + new "Repository moved" notice appended to the release-notes template
- `release.yml` paths filter — **drive-by fix**: dropped `packages/agent-skills/**` (removed workspace, never triggered anything) and corrected `lib/**` → `packages/lib/**`
- `beta-release.yml` — uses `${{ github.repository_owner }}` templating throughout, auto-resolves correctly. No literal `davidromeo` refs found. No edits needed.

### Docs + website
- `README.md`, `packages/mcp-server/README.md`, `docs/getting-started.md`, `gpt/system-prompt.md` — clone URLs and GHCR `docker pull` examples
- `components/sidebar-footer-legal.tsx` — sidebar GitHub icon hrefs (both occurrences)
- `.github/pull_request_template.md` — `Vercel` → `Render` (stale Flask-era reference; current deploys are Render)

## Risk surfaces

- Next NPM publish under provenance requires the Trusted Publisher rebind on npmjs.com (handled out-of-band by Admiral). Until rebind completes, do not push to master.
- GHCR images: old tags at `ghcr.io/davidromeo/tradeblocks-mcp` remain orphaned. New tags publish under `tradeblocks-org`. Docs now reflect the new path; users with the old path pinned in `docker-compose` silently keep using old images until they update.
- Render preview environments: GitHub App was pre-installed on `tradeblocks-org` with admin access before the transfer; previews continue to flow.

## Verification

- [ ] CODEOWNERS lint via `gh api` ruleset
- [ ] `release.yml` paths filter — syntax validated locally (`python3 -c 'import yaml; yaml.safe_load(...)'` passes)
- [ ] `manifest.json` validates as JSON; spot-check against the `.mcpb` spec
- [ ] Worf gate
- [ ] Patrick concur (Tier 3 cross-Admiral signal)

## Out of scope

- `packages/mcp-server/src/index.ts:162,165` references `davidromeo/tradeblocks-skills` — separate repo, follow-up issue filed.
- `.claude/CLAUDE.md` local-path leaks — constitutional cleanup, unrelated to transfer.
- `gpt/codebase-context.md` — autogenerated; refreshes on next `npm run gpt:context`.
- `releases/v*.md` — historical record, intentionally untouched.

## Related
- kanban #35
- ADR 0012 (forthcoming — companion PR on enterprise)