### PR TITLE
fix(trade-replay): use HL2 fallback when bid > ask

### DIFF
--- a/packages/mcp-server/src/utils/trade-replay.ts
+++ b/packages/mcp-server/src/utils/trade-replay.ts
@@ -81,12 +81,18 @@ export interface ReplayResult {
  * When providers supply bid/ask data (e.g., option chains), the midpoint is a
  * more accurate mark price than HL2. This is opt-in — existing data without
  * bid/ask continues to use HL2 identically.
+ *
+ * Guards against crossed exchange quotes (bid > ask) by falling back to HL2,
+ * since the computed mid is meaningless in that case.
  */
 export function markPrice(bar: Pick<BarRow, 'high' | 'low' | 'bid' | 'ask'>): number {
-  if (bar.bid != null && bar.ask != null && (bar.bid > 0 || bar.ask > 0)) {
-    return (bar.bid + bar.ask) / 2;
+  const { bid, ask } = bar;
+  const hl2 = (bar.high + bar.low) / 2;
+  if (bid != null && ask != null && (bid > 0 || ask > 0)) {
+    if (bid > 0 && ask > 0 && bid > ask) return hl2;
+    return (bid + ask) / 2;
   }
-  return (bar.high + bar.low) / 2;
+  return hl2;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 🧱 What's Changed

When a quote has crossed bid/ask values (`bid > ask`), the computed mid is meaningless and downstream pricing is unreliable. This adds an HL2 fallback for that specific edge case. Existing midpoint behavior is preserved for all valid (uncrossed) quotes.

The change is scoped to `markPrice()` in `packages/mcp-server/src/utils/trade-replay.ts`:

- If `bid > 0 && ask > 0 && bid > ask` → return HL2 instead of `(bid + ask) / 2`.
- All other code paths (HL2 when bid/ask absent, midpoint when both present and uncrossed) are unchanged.

## ✅ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)

## 🧪 Testing

- [x] I have tested these changes locally
- [x] The app starts without errors
- [x] All existing functionality still works
- [x] New features work as expected

`npm run test:mcp` — **116 suites / 1574 tests passing.**

## 📋 Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if needed

## 🚀 Deployment Notes

None. Pure correctness fix in a pricing utility — no API or schema changes.

---

**Ready to build! 🧱**