### PR TITLE
refactor(mcp-server): clarify greeks-revision helper naming and document revision history

### DIFF
--- a/packages/mcp-server/src/utils/option-quote-greeks.ts
+++ b/packages/mcp-server/src/utils/option-quote-greeks.ts
@@ -34,6 +34,12 @@ export interface QuoteGreeksStats {
   unresolvedRows: number;
 }
 
+/**
+ * Greeks computation revision.
+ * - 1 (legacy): hardcoded r = 0.045, q = 0.015
+ * - 2: per-day SOFR rate, q = 0 (rate-convention switch)
+ * - 3: revision 2 + provenance fields (rate_type, rate_value, gamma_source)
+ */
 export const OPTION_QUOTE_GREEKS_REVISION = 3;
 // Convention: SOFR overnight rate + zero dividend yield. Stored alongside each
 // computed greek row via `rate_type`, `rate_value`, and `gamma_source` so older
@@ -67,7 +73,7 @@ function hasExistingQuoteGreeks(row: QuoteGreekFields): boolean {
   return hasQuoteGreeks(row) || hasProviderFirstOrderGreeks(row);
 }
 
-function hasRevision2QuoteGreekProvenance(row: QuoteGreekFields): boolean {
+function hasQuoteGreekProvenanceFields(row: QuoteGreekFields): boolean {
   return row.rate_type === OPTION_QUOTE_GREEKS_RATE_TYPE
     && isFiniteNumber(row.rate_value ?? null)
     && row.gamma_source === OPTION_QUOTE_GREEKS_GAMMA_SOURCE;
@@ -84,7 +90,7 @@ export function normalizeExistingQuoteGreeks(
   if (
     row.greeks_source === "computed"
     && row.greeks_revision == null
-    && hasRevision2QuoteGreekProvenance(row)
+    && hasQuoteGreekProvenanceFields(row)
   ) {
     row.greeks_revision = OPTION_QUOTE_GREEKS_REVISION;
   }


### PR DESCRIPTION
# TradeBlocks Pull Request

## 🧱 What's Changed

Cosmetic cleanup in `packages/mcp-server/src/utils/option-quote-greeks.ts`:

1. Renamed `hasRevision2QuoteGreekProvenance` → `hasQuoteGreekProvenanceFields`. The helper gates the revision-3 stamp on rows that carry the provenance fields; the old name's "2" was a leftover from when those fields shipped in revision 2 and was misleading after revision 3 made them load-bearing.
2. Added inline JSDoc above `OPTION_QUOTE_GREEKS_REVISION = 3` summarizing the rate/dividend convention shift across revisions:
   - revision 1 (legacy): hardcoded `r = 0.045`, `q = 0.015`
   - revision 2: per-day SOFR rate, `q = 0`
   - revision 3: revision 2 + provenance fields (`rate_type`, `rate_value`, `gamma_source`)

No functional change. The renamed helper has no callers outside this file.

## ✅ Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [x] ♻️ Refactoring (no functional changes)

## 🧪 Testing

- [x] I have tested these changes locally
- [x] The app starts without errors
- [x] All existing functionality still works
- [x] New features work as expected

`npm run test:mcp` — 124 suites / 1637 tests pass.

## 📋 Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [ ] I have updated documentation if needed

## 🚀 Deployment Notes

None. Pure rename + JSDoc.

---

**Ready to build! 🧱**