### PR TITLE
docs: scrub stale internal-module references from comments

### DIFF
--- a/packages/mcp-server/src/tools/exit-analysis.ts
+++ b/packages/mcp-server/src/tools/exit-analysis.ts
@@ -179,9 +179,9 @@ async function fetchPriceMap(
     // Defense-in-depth: skip any underlying bar with a zero/null OHLC value.
     // The underlying ticker (SPX/QQQ/etc.) always has a real price — a zero
     // is a provider gap that would corrupt the price map and downstream
-    // trigger comparisons. bar-cache.ts leaves bars raw so option tickers
-    // can keep legitimate "no trade" zero rows; this filter is applied at
-    // the underlying-consumer site.
+    // trigger comparisons. Raw bars are left unfiltered upstream so option
+    // tickers can keep legitimate "no trade" zero rows; this filter is
+    // applied at the underlying-consumer site.
     for (const b of bars) {
       if (
         !Number.isFinite(b.open)  || b.open  <= 0 ||

--- a/packages/mcp-server/src/tools/market-data.ts
+++ b/packages/mcp-server/src/tools/market-data.ts
@@ -991,10 +991,11 @@ export function registerMarketDataTools(
             const list = intradayBarsByKey.get(mapKey) ?? [];
             for (const bar of bars) {
               // Defense-in-depth: skip underlying bars with zero/null OHLC
-              // (provider gaps from the spot ingest). bar-cache leaves these
-              // raw so option tickers can keep legitimate "no trade" zeros;
-              // underlyings always have a real price, so a zero is a bug
-              // that would corrupt downstream high/low/range computations.
+              // (provider gaps from the spot ingest). Raw bars are left
+              // unfiltered upstream so option tickers can keep legitimate
+              // "no trade" zeros; underlyings always have a real price, so
+              // a zero is a bug that would corrupt downstream high/low/range
+              // computations.
               if (
                 !Number.isFinite(bar.open)  || bar.open  <= 0 ||
                 !Number.isFinite(bar.high)  || bar.high  <= 0 ||

--- a/packages/mcp-server/src/tools/replay.ts
+++ b/packages/mcp-server/src/tools/replay.ts
@@ -272,26 +272,23 @@ export async function handleReplayTrade(
   }
 
   // ----- Fetch minute quotes for each option leg via QuoteStore -----
-  // Phase 4 Plan 04-04 — replaces the prior fetchBarsWithCache option-leg
-  // calls (which had no provider fallback after plan 04-01) with grouped
-  // stores.quote.readQuotes calls. Adapt QuoteRow → BarRow with mid =
-  // (bid+ask)/2 as open/high/low/close (D-14 mid-price contract).
+  // Adapt QuoteRow → BarRow with mid = (bid+ask)/2 as open/high/low/close
+  // (D-14 mid-price contract).
   //
-  // Pitfall 4 — group OCC tickers by underlying before each readQuotes
-  // call because QuoteStore enforces a single-underlying invariant per call.
+  // Pitfall — group OCC tickers by underlying before each readQuotes call
+  // because QuoteStore enforces a single-underlying invariant per call.
   // Typical replays have all legs under one underlying (single SPX trade);
   // multi-underlying replays issue one readQuotes per underlying.
   //
-  // Fallback root logic (SPX→SPXW etc.) is now implicit: the QuoteStore's
+  // Fallback root logic (SPX→SPXW etc.) is implicit: the QuoteStore's
   // tickers.resolve(extractRoot(...)) maps both SPX and SPXW to underlying
   // 'SPX'. The OCC ticker prefix in the chain is whatever the data layer
-  // ingested (typically SPXW). The pre-04-04 code had explicit fallback
-  // because `fetchBarsWithCache` keyed on full OCC ticker; the new path keys
-  // on underlying so the same data is reachable via either root.
+  // ingested (typically SPXW); keying on underlying makes the same data
+  // reachable via either root.
   //
-  // skip_quotes is now a no-op for option-leg reads — quotes ARE the source
-  // of truth here (the cached-bar fallback that skip_quotes used to gate is
-  // gone). Parameter remains in the schema for backward compat with callers.
+  // skip_quotes is a no-op for option-leg reads — quotes ARE the source of
+  // truth here. Parameter remains in the schema for backward compat with
+  // callers.
   void skip_quotes;
 
   const byUnderlying = new Map<string, string[]>();
@@ -370,7 +367,7 @@ export async function handleReplayTrade(
   // SPX/QQQ/etc. always have a real price — a zero in spot is a provider
   // gap (see ParquetSpotStore writer guard), and feeding it into Black-
   // Scholes greeks computation produces nonsense (S=0 → infinite delta etc.).
-  // bar-cache.ts deliberately leaves bars raw so option tickers can keep
+  // Raw bars are left unfiltered upstream so option tickers can keep
   // legitimate "no trade" zero rows; the filtering responsibility lives
   // here at the underlying-consumer site.
   if (underlyingBars.length > 0) {

--- a/packages/mcp-server/src/utils/providers/massive.ts
+++ b/packages/mcp-server/src/utils/providers/massive.ts
@@ -527,11 +527,9 @@ export class MassiveProvider implements MarketDataProvider {
       }
     }
 
-    // Quote enrichment (bid/ask backfill + synthetic gap bars) used to be
-    // handled by `fetchBarsWithCache → enrichWithQuotes` in bar-cache.ts.
-    // Phase 4 / D-05 / SEP-01 removed `enrichWithQuotes` (reads no longer
-    // trigger provider writes); the equivalent backfill now lives in the
-    // pipeline-side `enrich_quotes` MCP tool / quote-minute-cache.
+    // Quote enrichment (bid/ask backfill + synthetic gap bars) is handled
+    // out-of-band by the pipeline-side `enrich_quotes` MCP tool /
+    // quote-minute-cache; reads here never trigger provider writes.
 
     return allRows;
   }

--- a/packages/mcp-server/tests/integration/trade-replay.test.ts
+++ b/packages/mcp-server/tests/integration/trade-replay.test.ts
@@ -74,17 +74,13 @@ describe("replay_trade integration", () => {
       )
     `);
 
-    // Phase 4 Plan 04-02: handleReplayTrade now reads underlying bars via
-    // stores.spot.readBars (formerly fetchBarsWithCache) and VIX IVP via
-    // stores.enriched.read (formerly a raw SELECT against the retired legacy
-    // daily-view for ticker 'VIX').
-    // Create the minimal market schema in the in-memory DuckDB so the migrated
-    // handler-body store calls succeed. The tests intentionally leave these
-    // empty — option-leg bars are still mocked via fetch (plan 04-04 migrates
-    // option legs), and the underlying-bars empty result triggers the
-    // readDailyBars fallback (also empty), then handleReplayTrade omits greeks
-    // — exactly the same observable behavior as pre-migration when both
-    // sources were absent.
+    // handleReplayTrade reads underlying bars via stores.spot.readBars and
+    // VIX IVP via stores.enriched.read. Create the minimal market schema in
+    // the in-memory DuckDB so those store calls succeed. The tests
+    // intentionally leave these empty — option-leg bars are mocked via
+    // fetch, and the underlying-bars empty result triggers the
+    // readDailyBars fallback (also empty), then handleReplayTrade omits
+    // greeks.
     await conn.run(`CREATE SCHEMA IF NOT EXISTS market`);
     await conn.run(`
       CREATE TABLE market.spot (

--- a/packages/mcp-server/tests/integration/wave-a-spot-consumer-contract.test.ts
+++ b/packages/mcp-server/tests/integration/wave-a-spot-consumer-contract.test.ts
@@ -1,34 +1,11 @@
 /**
- * Wave A spot-consumer contract tests (Phase 4 Plan 04-01).
+ * Wave A spot-consumer contract tests.
  *
- * Exercises the migrated `checkDataAvailability`, `queryCoverage`, and
+ * Exercises the `checkDataAvailability`, `queryCoverage`, and
  * `importFlatFileDay` consumers against a real `MarketStores` bundle backed by
- * a tmp Parquet fixture. After Wave A migration, every read in these consumers
- * flows through `stores.spot.getCoverage` / `stores.enriched.getCoverage` /
+ * a tmp Parquet fixture. Every read in these consumers flows through
+ * `stores.spot.getCoverage` / `stores.enriched.getCoverage` /
  * `stores.quote.getCoverage`; every write flows through `stores.spot.writeBars`.
- *
- * Inventory of bar-cache.ts external consumers (verified 2026-04-18 at start
- * of plan 04-01):
- *
- *   src/tools/replay.ts                       imports fetchBarsWithCache
- *   src/utils/providers/massive.ts            references fetchBarsWithCache (comment only)
- *   src/backtest/loading/market-data-loader   imports readCachedBars + duplicates
- *                                              intradayDateSource / optionQuoteMinuteSource
- *   src/backtest/orchestrator.ts              imports fetchBarsForLegsBulk
- *   src/test-exports.ts                       re-exports the bar-cache surface
- *
- * Wave A scope (this plan): bar-cache.ts shrunk to keep ONLY the symbols that
- * other in-flight Wave 2 plans (04-02 = replay/loader spot path; 04-04 = option
- * legs / quote-minute-cache) still need so this branch keeps compiling.
- * fetchBarsWithCache, readCachedBars, mergeQuoteBars, fetchBarsForLegsBulk,
- * fetchEntryBarsForCandidates remain alive as a transitional surface — Plans
- * 04-02 and 04-04 finish the demolition.
- *
- * Critically deleted in this plan: enrichWithQuotes (the provider-side fetch
- * helper) plus the Phase 4 D-09 "silent empty" target — bar-cache.ts no longer
- * has any read path that triggers a provider call. fetchBarsWithCache itself
- * still has the API fallback because tools/replay.ts has not yet been migrated;
- * Plan 04-02 deletes it once replay.ts is on stores.
  */
 import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import {

--- a/packages/mcp-server/tests/integration/wave-a-tool-consumer-contract.test.ts
+++ b/packages/mcp-server/tests/integration/wave-a-tool-consumer-contract.test.ts
@@ -196,11 +196,8 @@ describe("wave-a tool/consumer contract — Phase 4 Plan 04-02", () => {
   // -----------------------------------------------------------------------
   describe("tools/replay.ts — underlying bar read", () => {
     it("stores.spot.readBars returns the same SPX bars used by the underlying-bars path", async () => {
-      // Task 2 migrates replay.ts:341 (fetchBarsWithCache for underlying) +
-      // line 393 (legacy daily-view SELECT for VIX IVP) onto stores. The contract
-      // here is that the underlying-bars read returns the fixture rows; the
-      // full handler test stays in tests/integration/trade-replay.test.ts
-      // (option-leg path is plan 04-04).
+      // Contract: the underlying-bars read returns the fixture rows. The
+      // full handler test stays in tests/integration/trade-replay.test.ts.
       const bars = await stores.spot.readBars(
         "SPX",
         "2025-01-02",

--- a/packages/mcp-server/tests/integration/wave-b-option-consumer-contract.test.ts
+++ b/packages/mcp-server/tests/integration/wave-b-option-consumer-contract.test.ts
@@ -18,7 +18,7 @@
  *     market.option_chain / market.option_quote_minutes view backed by it.
  *
  * Pre-migration external consumers of the symbols touched by this plan:
- *   - tools/replay.ts:284,302         fetchBarsWithCache (option-leg)
+ *   - tools/replay.ts:284,302         option-leg reads
  *   - tools/greeks-attribution.ts:382 SELECT DISTINCT date FROM the retired legacy minute-bar view
  *   - utils/sql-pnl.ts:103            retired legacy minute-bar SELECT + close fallback
  *   - backtest/loading/market-data-loader.ts:498-523  optionQuoteMinuteSource(date)

--- a/packages/mcp-server/tests/unit/providers/massive.test.ts
+++ b/packages/mcp-server/tests/unit/providers/massive.test.ts
@@ -698,9 +698,9 @@ describe("Quotes enrichment", () => {
   beforeEach(() => { process.env.MASSIVE_DATA_TIER = "quotes"; });
   afterEach(() => { delete process.env.MASSIVE_DATA_TIER; });
 
-  it("fetchBars returns bars without bid/ask — enrichment handled by bar-cache", async () => {
-    // Quote enrichment moved from fetchBars() to fetchBarsWithCache() in bar-cache.ts.
-    // fetchBars() now returns raw OHLCV bars; bid/ask are added by the cache layer.
+  it("fetchBars returns raw OHLCV bars without bid/ask enrichment", async () => {
+    // fetchBars() returns raw OHLCV bars; bid/ask enrichment is handled
+    // out-of-band by the pipeline-side enrich_quotes tool.
     fetchSpy
       .mockResolvedValueOnce(mockResponse(makeOptionBarsResponse()));
 


### PR DESCRIPTION
## Summary
Cleans up historical-provenance comments referencing internal modules that have since been removed. These were "we used to do X in <module>, now we do Y here" notes that no longer name a real file. Comment-only changes; zero runtime impact.

## Files touched
- packages/mcp-server/src/tools/replay.ts
- packages/mcp-server/src/tools/exit-analysis.ts
- packages/mcp-server/src/tools/market-data.ts
- packages/mcp-server/src/utils/providers/massive.ts
- 5 test files under packages/mcp-server/tests/

## Verification
- All tests pass: `npm run test:mcp` and `npm test`
- `npm run lint` clean
- `npm run build:mcp` clean