### PR TITLE
fix(trade-replay): guard markPrice against blown spreads

### DIFF
--- a/packages/mcp-server/src/utils/trade-replay.ts
+++ b/packages/mcp-server/src/utils/trade-replay.ts
@@ -82,14 +82,17 @@ export interface ReplayResult {
  * more accurate mark price than HL2. This is opt-in — existing data without
  * bid/ask continues to use HL2 identically.
  *
- * Guards against crossed exchange quotes (bid > ask) by falling back to HL2,
- * since the computed mid is meaningless in that case.
+ * Guards against broken exchange quotes (crossed bid>ask; blown ask>10×bid
+ * with mid>$1) by falling back to HL2.
  */
 export function markPrice(bar: Pick<BarRow, 'high' | 'low' | 'bid' | 'ask'>): number {
   const { bid, ask } = bar;
   const hl2 = (bar.high + bar.low) / 2;
   if (bid != null && ask != null && (bid > 0 || ask > 0)) {
-    if (bid > 0 && ask > 0 && bid > ask) return hl2;
+    if (bid > 0 && ask > 0) {
+      if (bid > ask) return hl2;
+      if (ask > 10 * bid && (bid + ask) / 2 > 1) return hl2;
+    }
     return (bid + ask) / 2;
   }
   return hl2;

--- a/packages/mcp-server/tests/unit/trade-replay.test.ts
+++ b/packages/mcp-server/tests/unit/trade-replay.test.ts
@@ -4,10 +4,41 @@ import {
   computeStrategyPnlPath,
   computeReplayMfeMae,
   resolveOODateRange,
+  markPrice,
   type ReplayLeg,
   type PnlPoint,
   type BarRow,
 } from '../../src/test-exports.js';
+
+describe('markPrice', () => {
+  it('returns bid/ask midpoint when both are positive and well-formed', () => {
+    expect(markPrice({ high: 5, low: 4, bid: 2, ask: 3 })).toBe(2.5);
+  });
+
+  it('falls back to HL2 when bid/ask are missing', () => {
+    expect(markPrice({ high: 6, low: 4, bid: null as unknown as number, ask: null as unknown as number })).toBe(5);
+  });
+
+  it('falls back to HL2 on crossed quotes (bid > ask)', () => {
+    expect(markPrice({ high: 10, low: 8, bid: 5, ask: 3 })).toBe(9);
+  });
+
+  it('falls back to HL2 on blown spreads (ask > 10×bid with mid > $1)', () => {
+    // Noise-day quote: bid=0.05, ask=10.00 ⇒ raw mid = 5.025 (phantom).
+    // Guard triggers because ask > 10*bid AND mid > 1.
+    expect(markPrice({ high: 0.2, low: 0.1, bid: 0.05, ask: 10.0 })).toBeCloseTo(0.15, 6);
+  });
+
+  it('does not apply blown-spread guard when mid is at/below $1', () => {
+    // Penny-wide cheap option: ask/bid ratio >10 but mid is sub-dollar; keep mid.
+    expect(markPrice({ high: 0.5, low: 0.3, bid: 0.05, ask: 0.6 })).toBeCloseTo(0.325, 6);
+  });
+
+  it('keeps midpoint for normal wide-but-not-blown spreads', () => {
+    // ask/bid = 5x; guard does not fire (needs > 10x).
+    expect(markPrice({ high: 3, low: 1, bid: 1, ask: 5 })).toBe(3);
+  });
+});
 
 describe('parseLegsString', () => {
   it('parses single call leg', () => {


### PR DESCRIPTION
## Summary

`markPrice()` in `packages/mcp-server/src/utils/trade-replay.ts` only guarded against crossed quotes (`bid > ask`). On noise-day minutes — typically the 09:30–09:31 opening rotation, but also occasionally intraday on illiquid strikes — the exchange can publish a tiny stub bid alongside a huge ask (e.g. `bid=0.05`, `ask=10.00`). The raw `(bid+ask)/2` then becomes a phantom mark (here, `5.025`) bearing no relation to the true value, contaminating P&L paths, MFE/MAE, exit triggers, and the underlying-spot map reconstructed from underlying bars.

## The fix

Add the second leg of the guard: when `ask > 10 * bid` **and** the raw mid exceeds `$1`, fall back to HL2. The mid>$1 floor preserves legitimate penny-wide cheap options where a 10× ratio is normal and the mid is still meaningful.

```ts
if (bid > 0 && ask > 0) {
  if (bid > ask) return hl2;
  if (ask > 10 * bid && (bid + ask) / 2 > 1) return hl2;
}
```

## Tests

Added six unit tests in `packages/mcp-server/tests/unit/trade-replay.test.ts`:

- well-formed quotes return mid
- missing bid/ask falls back to HL2
- crossed quotes (`bid > ask`) fall back to HL2
- **blown spreads** (`ask > 10×bid` with mid > $1) fall back to HL2 — fails without this PR
- sub-dollar option with 12× ratio keeps the mid (guard correctly does **not** fire)
- 5× wide spread keeps the mid (guard correctly does **not** fire)

All 1,235 unit tests in `packages/mcp-server` pass locally.

## Provenance

Spotted during a cross-repo audit comparing the public `tradeblocks` MCP server with its private downstream consumer. The blown-spread guard exists in the private consumer and was the difference that mattered; porting it back here is independently valuable regardless of any other reconciliation work that may or may not follow.

## Test plan

- [ ] CI green on `feat/tradeblocks-3.0`
- [ ] Reviewer (longpshorn) confirms guard logic matches intent
- [ ] No downstream consumer depends on the phantom mid behavior (none expected; mid was already non-deterministic on bad quotes)