### PR TITLE
fix(data-root): store on globalThis to survive bundle duplication

### DIFF
--- a/packages/mcp-server/src/db/data-root.ts
+++ b/packages/mcp-server/src/db/data-root.ts
@@ -12,6 +12,10 @@
  * would give each bundle its own _dataRoot, leaving one path correct (set by
  * the CLI parser) and the other null (a consumer reads its own copy and falls
  * back to the default → wrong path).
+ *
+ * Note: globalThis is per-realm. Consumers running this across Workers, VM
+ * contexts, or sandboxed iframes will see the same divergence across realm
+ * boundaries and must coordinate state another way.
  */
 const KEY = "__tradeblocks_data_root__";
 type GlobalSlot = { [KEY]?: string | null };

--- a/packages/mcp-server/src/db/data-root.ts
+++ b/packages/mcp-server/src/db/data-root.ts
@@ -6,18 +6,25 @@
  *
  * Set via --data-root CLI flag or TRADEBLOCKS_DATA_ROOT env var.
  * When not set, getDataRoot() falls back to its argument (backward compat).
+ *
+ * Stored on globalThis so all bundle instances in the same process share state.
+ * tsup duplicates this module across separate bundles; a module-scoped variable
+ * would give each bundle its own _dataRoot, leaving one path correct (set by
+ * the CLI parser) and the other null (a consumer reads its own copy and falls
+ * back to the default → wrong path).
  */
-let _dataRoot: string | null = null;
+const KEY = "__tradeblocks_data_root__";
+type GlobalSlot = { [KEY]?: string | null };
 
 export function setDataRoot(dir: string): void {
-  _dataRoot = dir;
+  (globalThis as GlobalSlot)[KEY] = dir;
 }
 
 export function getDataRoot(fallback: string): string {
-  return _dataRoot ?? fallback;
+  return (globalThis as GlobalSlot)[KEY] ?? fallback;
 }
 
 /** Reset for testing. Not used in production. */
 export function resetDataRoot(): void {
-  _dataRoot = null;
+  (globalThis as GlobalSlot)[KEY] = null;
 }

--- a/packages/mcp-server/tests/unit/data-root.test.ts
+++ b/packages/mcp-server/tests/unit/data-root.test.ts
@@ -31,4 +31,19 @@ describe("data-root", () => {
     expect(getDataRoot("/any-other-fallback")).toBe("/custom");
     expect(getDataRoot("/yet-another")).toBe("/custom");
   });
+
+  it("state is stored on globalThis so bundle duplicates share it", () => {
+    // tsup duplicates this module across separate bundles. Each bundle gets
+    // its own module-local closure, so a module-scoped variable would not be
+    // visible across bundles. Storing on globalThis means whichever bundle
+    // runs first sets the slot, and every other bundle reads it back.
+    const KEY = "__tradeblocks_data_root__";
+    setDataRoot("/from-bundle-a");
+    expect((globalThis as Record<string, unknown>)[KEY]).toBe("/from-bundle-a");
+
+    // Simulate "bundle B" writing directly to globalThis (because its own
+    // module-local would have been a separate variable in real bundling).
+    (globalThis as Record<string, unknown>)[KEY] = "/from-bundle-b";
+    expect(getDataRoot("/fallback")).toBe("/from-bundle-b");
+  });
 });


### PR DESCRIPTION
## Bug

`packages/mcp-server/src/db/data-root.ts` held the `--data-root` override in a module-local variable:

```ts
let _dataRoot: string | null = null;
```

tsup duplicates this module across separate bundles in the same process. Each bundle ends up with its own `_dataRoot` closure, so a `setDataRoot()` call from the CLI parser in one bundle is invisible to a `getDataRoot()` call from another bundle. The consumer reads `null` and falls back to whatever default path the caller passed, which is wrong any time the user supplied `--data-root` or `TRADEBLOCKS_DATA_ROOT`.

Single-bundle deployments are unaffected (the build that ships today is single-bundle), but the bug was caught during a cross-repo audit and is a latent footgun for any future multi-bundle consumer in the same process.

## Fix

Move the slot to `globalThis[__tradeblocks_data_root__]`. The public API (`setDataRoot`, `getDataRoot`, `resetDataRoot`) is unchanged. All bundle duplicates resolve to the same storage location, so writes from one are visible to reads from any other.

```ts
const KEY = "__tradeblocks_data_root__";
type GlobalSlot = { [KEY]?: string | null };

export function setDataRoot(dir: string): void {
  (globalThis as GlobalSlot)[KEY] = dir;
}

export function getDataRoot(fallback: string): string {
  return (globalThis as GlobalSlot)[KEY] ?? fallback;
}

export function resetDataRoot(): void {
  (globalThis as GlobalSlot)[KEY] = null;
}
```

## Test

Existing tests cover the public API (fallback, override, reset). Added one test that asserts the storage location — `setDataRoot("/x")` writes to `globalThis[__tradeblocks_data_root__]`, and a direct write to that slot is reflected by `getDataRoot()`. This pins the bundle-duplication invariant: the property we depend on is that the storage is a single named global slot, not a module local.

Full mcp-server suite: 120 suites, 1560 tests, all passing.

## Scope

`data-root.ts` and its test only. No call-site changes — the public API is preserved.