### PR TITLE
chore(boundary): four import-direction safeguards for tradeblocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,25 @@ permissions:
   contents: read
 
 jobs:
+  import-boundary:
+    name: Import boundary gates
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Reverse-direction imports from sibling consumer repos must not appear
+      # anywhere under packages/** or app/**. The leading `!` inverts grep's
+      # exit code: pass when there are zero matches.
+      - name: Reverse import gate
+        run: '! git grep -E "(holodeck|private-packages|tradeblocks-private)" -- "packages/**" "app/**"'
+
+      # file:-protocol dependencies pin to local filesystem paths and would
+      # let a sibling repo silently slip into tradeblocks. None are permitted
+      # in the root or any workspace package.
+      - name: "No file: deps gate"
+        run: '! grep -q ''"file:'' package.json packages/*/package.json'
+
   frontend:
     name: Frontend (Next.js)
     runs-on: ubuntu-latest

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -53,4 +53,34 @@ export default tseslint.config(
       ],
     },
   },
+  // IMPORT BOUNDARY: block reverse-direction imports from sibling consumers.
+  // tradeblocks is a public library; no consumer module may leak into it.
+  // Paired with tsconfig `paths` lockdown and the CI "Reverse import gate".
+  {
+    files: ["**/*.{js,jsx,ts,tsx,mjs,cjs}"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["../holodeck/*", "**/../holodeck/*"],
+              message:
+                "Imports from sibling consumer repos are forbidden. tradeblocks must not depend on holodeck or any private sibling.",
+            },
+            {
+              group: ["**/private-packages/*"],
+              message:
+                "private-packages/* is reserved for private consumers. Public tradeblocks code must not import from it.",
+            },
+            {
+              group: ["@tradeblocks-private/*"],
+              message:
+                "@tradeblocks-private/* is a private scope. Public tradeblocks code must not import from it.",
+            },
+          ],
+        },
+      ],
+    },
+  },
 );

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -1,3 +1,6 @@
+// IMPORT BOUNDARY: do NOT add `paths` entries that reach out of this repo
+// (no `../<sibling>/*` aliases). `paths` is intentionally `{}`. See root
+// tsconfig.json header for the full rationale.
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -1,3 +1,6 @@
+// IMPORT BOUNDARY: do NOT add `paths` entries that reach out of this repo
+// (no `../<sibling>/*` aliases). MCP server resolves only in-tree modules
+// and published deps. See root tsconfig.json header for the full rationale.
 {
   "compilerOptions": {
     "target": "ES2022",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,9 @@
+// IMPORT BOUNDARY: do NOT add `paths` entries that reach out of this repo
+// (no `../<sibling>/*` aliases of any kind). The `paths` map below is
+// restricted to in-tree aliases only. Reverse-direction imports from sibling
+// consumer repos must not leak through tsconfig resolution. See
+// eslint.config.mjs no-restricted-imports + the "Reverse import gate" CI step
+// for the complementary defenses.
 {
   "compilerOptions": {
     "target": "ES2017",


### PR DESCRIPTION
## Summary

Four defense-in-depth safeguards against reverse-direction imports into `tradeblocks`. None of these patterns appear in the codebase today — this is **preventive hygiene** surfaced by a cross-repo audit. If a future consumer of `tradeblocks` lives as a filesystem sibling, these safeguards prevent reverse-direction imports from leaking private symbols back into the public lib.

All four are **blocking** (lint `error` severity, CI step failure). Lint and both grep checks pass locally on a clean tree.

## The four safeguards

### 1. tsconfig path lockdown
Header comments on three tsconfigs explicitly forbidding any out-of-tree `paths` aliases.

- `tsconfig.json` — root
- `packages/lib/tsconfig.json`
- `packages/mcp-server/tsconfig.json`

The `paths` maps remain restricted to in-tree aliases only. The comments are the safeguard — no `paths` entries were added.

### 2. ESLint `no-restricted-imports` (error)
New rule block in `eslint.config.mjs` with three blocking patterns:

| Pattern | Why |
|---|---|
| `../holodeck/*`, `**/../holodeck/*` | Sibling-consumer directory traversal |
| `**/private-packages/*` | Reserved private-consumer namespace |
| `@tradeblocks-private/*` | Reserved private scope |

Severity `error`, not `warn`. `npm run lint` passes — no existing code matches.

### 3. CI "Reverse import gate"
New step in `.github/workflows/ci.yml` (`import-boundary` job):

```sh
! git grep -E '(holodeck|private-packages|tradeblocks-private)' -- 'packages/**' 'app/**'
```

Restricted to `packages/**` and `app/**` so workflow-file / docs mentions of the forbidden tokens don't false-positive. The leading `!` inverts grep's exit code: pass when zero matches.

### 4. CI "No file: deps gate"
Second step in the same `import-boundary` job:

```sh
! grep -q '"file:' package.json packages/*/package.json
```

`file:`-protocol deps pin to local filesystem paths and would let a sibling repo silently slip in. None are permitted in root or any workspace package.

## Local verification

- `npm run lint` — clean
- `! git grep -E '(holodeck|private-packages|tradeblocks-private)' -- 'packages/**' 'app/**'` — exit 0 (zero hits)
- `! grep -q '"file:' package.json packages/*/package.json` — exit 0 (zero hits)
- `npx tsc --showConfig` on all three tsconfigs — parses cleanly with header comments

## Test plan

- [ ] CI `import-boundary` job passes (both steps green) on this PR
- [ ] Lint job still passes after the new `no-restricted-imports` rule
- [ ] Confirm intent / wording with @longpshorn before merge

## Framing

The audit context was a cross-repo review that asked "what defenses exist if a consumer of `tradeblocks` lived next to it on disk?" Today the answer was implicit — none. This PR makes the answer explicit and enforced. The defense-in-depth value is independent of any specific consumer scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)