### PR TITLE
feat(connection): symmetric ext-hook on read-only DuckDB connection path

### DIFF
--- a/packages/mcp-server/src/db/connection.ts
+++ b/packages/mcp-server/src/db/connection.ts
@@ -17,7 +17,8 @@
  *      file exists; see CLAUDE.md §Extension point pattern)
  *
  * On close: CHECKPOINT → DETACH market → closeSync() to flush WAL reliably.
- * On RO open: ATTACH market.duckdb READ_ONLY (no table creation).
+ * On RO open: ATTACH market.duckdb READ_ONLY (no table creation), then invoke
+ *   connection.ext.ts with `mode: "read_only"` (symmetric to the RW hook).
  *
  * DuckDB is single-process: only one process can open a database file at a time
  * (even read-only fails when another process holds a write lock with an active WAL).
@@ -381,6 +382,7 @@ async function openReadWriteConnection(
     await ext.default(connection, {
       baseDir: path.dirname(dbPath),
       marketDbPath: storedMarketDbPath!,
+      mode: "read_write",
     });
   } catch {
     // No extensions present — defaults apply
@@ -420,6 +422,26 @@ async function openReadOnlyConnection(
   if (storedMarketDbPath) {
     await attachMarketDb(connection, storedMarketDbPath, "read_only");
   }
+
+  // Optional extensions on the read-only path. Symmetric to the read-write
+  // hook in openReadWriteConnection — same `connection.ext.js` plugin contract,
+  // distinguished by the `mode` option so a single extension file can branch
+  // on RW vs RO (e.g., skip table-creation side effects, register read-only
+  // views only). connection.ext.ts is intentionally absent in this repo; the
+  // dynamic import fails silently and defaults apply.
+  try {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore — connection.ext.ts is intentionally absent in this repo; dynamic import fails silently
+    const ext = await import('./connection.ext.js');
+    await ext.default(connection, {
+      baseDir: path.dirname(dbPath),
+      marketDbPath: storedMarketDbPath!,
+      mode: "read_only",
+    });
+  } catch {
+    // No extensions present — defaults apply
+  }
+
   connectionMode = "read_only";
   return connection;
 }


### PR DESCRIPTION
## Summary

Makes the `connection.ext.js` plugin contract symmetric across DuckDB connection modes:

- `openReadWriteConnection` already invokes an optional `connection.ext.js` plugin (around line 380) so downstream consumers can attach private adapters or register additional tables/views after the canonical schema is in place.
- `openReadOnlyConnection` had no analogous hook — any private adapters silently never loaded on the read-only path.

This PR closes the asymmetry:

1. The existing RW invocation now passes `mode: \"read_write\"` in its options object.
2. `openReadOnlyConnection` gains a matching `connection.ext.js` invocation with `mode: \"read_only\"` after the market DB attach, so a single ext file can branch on the mode (e.g., skip side-effectful table creation, register read-only views only).

## Behavior in this repo

**Unchanged.** `connection.ext.ts` is intentionally absent in tradeblocks; both dynamic imports fail silently and defaults apply on both paths, exactly as today. The hook surface is what changes; the public-lib runtime path is identical.

## Changes

- `packages/mcp-server/src/db/connection.ts`:
  - `openReadWriteConnection`: add `mode: \"read_write\"` to the existing ext invocation's options object.
  - `openReadOnlyConnection`: add a symmetric try/catch ext invocation with `mode: \"read_only\"`.
  - Header docstring updated to mention the RO-side hook (line 20).

## Local verification

- `npm run lint` — clean (eslint pre-commit hook also ran clean).
- `npx tsc --noEmit` from `packages/mcp-server/` — my changes typecheck. Three pre-existing errors in `src/utils/exit-triggers.ts` (also present on base) unrelated to this PR.
- No new test fixtures: the .ext file is absent so the dynamic import remains a silent no-op; existing integration tests continue to exercise both connection paths.
- No forbidden tokens (`holodeck`, `private-packages`, `tradeblocks-private`) introduced.