### PR TITLE
chore(lib): retire .ext indirection stubs from public API surface

### DIFF
--- a/packages/mcp-server/src/db/connection.ts
+++ b/packages/mcp-server/src/db/connection.ts
@@ -13,8 +13,6 @@
  *   5. ensureMutableMarketTables() — _sync_metadata, data_coverage
  *   6. createMarketParquetViews() — views over shared Parquet files (opportunistic)
  *   7. ensureSyncTables() / ensureTradeDataTable() / ensureReportingDataTable()
- *   8. connection.ext.ts — optional private extension hook (present only when the ext
- *      file exists; see CLAUDE.md §Extension point pattern)
  *
  * On close: CHECKPOINT → DETACH market → closeSync() to flush WAL reliably.
  * On RO open: ATTACH market.duckdb READ_ONLY (no table creation).
@@ -369,27 +367,9 @@ async function openReadWriteConnection(
   // See market-schemas.ts §D-12 option_quote_minutes block for the canonical pattern.
   await ensureMarketDataTables(connection);
 
-  // Optional extensions (e.g., additional DB attachments).
-  // Phase 4 D-10: the legacy intraday write-table override hook was DELETED —
-  // every spot write now flows through SpotStore.writeBars (no override
-  // mechanism needed). The extension is invoked purely for its side effects —
-  // its return value is ignored.
-  try {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore — connection.ext.ts is intentionally absent in this repo; dynamic import fails silently
-    const ext = await import('./connection.ext.js');
-    await ext.default(connection, {
-      baseDir: path.dirname(dbPath),
-      marketDbPath: storedMarketDbPath!,
-    });
-  } catch {
-    // No extensions present — defaults apply
-  }
-
   // One-time metadata migration: DuckDB -> JSON files (Phase 3)
   // Runs only when TRADEBLOCKS_PARQUET=true and JSON files don't yet exist.
-  // Must run AFTER all DuckDB tables are created (profiles, sync, market schemas)
-  // and AFTER any connection.ext.ts (ext-provided tables) have been initialized.
+  // Must run AFTER all DuckDB tables are created (profiles, sync, market schemas).
   try {
     const blocksDir = (await import("../sync/index.js")).getBlocksDir(dataRoot);
     await migrateMetadataToJson(connection, dataRoot, blocksDir);

--- a/packages/mcp-server/src/test-exports.ext.ts
+++ b/packages/mcp-server/src/test-exports.ext.ts
@@ -1,5 +1,0 @@
-/**
- * Extension point for additional test exports.
- * Override this file to re-export backtest internals for testing.
- */
-export {};

--- a/packages/mcp-server/src/test-exports.ts
+++ b/packages/mcp-server/src/test-exports.ts
@@ -478,11 +478,9 @@ export type { FlatImportLogEntry } from './db/json-adapters.js';
 export { migrateMetadataToJson, type MigrationResult } from './db/json-migration.js';
 
 // ============================================================================
-// Market Data 3.0 — Phase 1 exports (MUST appear BEFORE the ext.ts wildcard below)
+// Market Data 3.0 — Phase 1 exports
 //
 // Per CONTEXT.md D-19: all Phase 1 modules are SHARED code; they re-export here.
-// Adding new symbols AFTER the `export * from './test-exports.ext.js'` line
-// silently masks them (RESEARCH.md Pitfall 9).
 // ============================================================================
 
 // Store interfaces + factory (Plan 01)
@@ -552,8 +550,6 @@ export {
 // Wave 1 deliverables: pure SQL builders, RTH aggregation helper, partition
 // enumerator, and the enrichment watermark JSON adapter. Concrete store
 // classes ship in Waves 2-3 and will re-export below in later plans.
-//
-// MUST appear BEFORE the './test-exports.ext.js' wildcard (Pitfall 10).
 // ============================================================================
 
 // Pure SQL builders (Plan 02-01)
@@ -600,8 +596,6 @@ export type { EnrichmentWatermarks } from './db/json-adapters.js';
 // Concrete classes ship one task at a time per Plan 02-03. Each task's
 // subset of exports is added here so tests can import the concrete class
 // names directly via `../../../src/test-exports.js`.
-//
-// MUST appear BEFORE the './test-exports.ext.js' wildcard (Pitfall 10).
 // ============================================================================
 
 // Concrete Spot store pair (Plan 02-03 Task 1)
@@ -628,8 +622,6 @@ export { DuckdbQuoteStore } from './market/stores/duckdb-quote-store.js';
 // Phase 1 abstract EnrichedStore and accept an injected SpotStore in their
 // constructors so that the enricher's IO boundaries (minute-bar reads,
 // watermark get/upsert) are satisfied without reimplementing the math.
-//
-// MUST appear BEFORE the './test-exports.ext.js' wildcard (Pitfall 10).
 // ============================================================================
 
 // Concrete Enriched store pair (Plan 02-04 Task 2)
@@ -672,8 +664,6 @@ export type {
 // The .mjs script itself is NOT re-exported (CONTEXT.md D-26 — scripts with
 // filesystem effects cannot be unit-tested cleanly via test-exports; unit tests
 // target the pure helpers).
-//
-// MUST appear BEFORE the './test-exports.ext.js' wildcard (RESEARCH §Pitfall 7).
 // ============================================================================
 
 export {
@@ -693,8 +683,6 @@ export type { GroupResult } from './utils/migrate-option-data-helpers.js';
 //
 // RESOLVE-02: Tool Dependency Registry
 // SEP-01: pipeline-side backfill helper (plan 04-06)
-//
-// MUST appear BEFORE the './test-exports.ext.js' wildcard (PATTERNS.md Pattern 6 / Pitfall 10).
 // ============================================================================
 export { TOOL_TICKER_DEPS, unionTickerDeps } from './utils/tool-ticker-deps.js';
 // ============================================================================
@@ -703,7 +691,6 @@ export { TOOL_TICKER_DEPS, unionTickerDeps } from './utils/tool-ticker-deps.js';
 // Market Data 3.0 — Phase 5 exports (Spot Backfill + Enrichment Rebuild)
 //
 // D-17/D-19: verification helper, sample-date selector, calibration probe.
-// MUST appear BEFORE the './test-exports.ext.js' wildcard (PATTERNS.md Pitfall 10).
 // ============================================================================
 export {
   selectVerificationSampleDates,
@@ -726,6 +713,3 @@ export type {
 } from './utils/enrichment-verification.js';
 export { calibrateProviderFetch } from './utils/calibration-probe.js';
 // ============================================================================
-
-// Extension point: additional test exports provided by the optional private extension.
-export * from './test-exports.ext.js';

--- a/packages/mcp-server/src/utils/providers/thetadata.ext.ts
+++ b/packages/mcp-server/src/utils/providers/thetadata.ext.ts
@@ -1,5 +1,0 @@
-/**
- * Extension point for OCC ticker builder.
- * Override this file to source buildOccTicker from a different module.
- */
-export { buildOccTicker } from '../trade-replay.js';

--- a/packages/mcp-server/src/utils/providers/thetadata.ts
+++ b/packages/mcp-server/src/utils/providers/thetadata.ts
@@ -1,4 +1,4 @@
-import { buildOccTicker } from "./thetadata.ext.js";
+import { buildOccTicker } from "../trade-replay.js";
 import {
   ThetaMddsClient,
   indexHistoryEod,

--- a/packages/mcp-server/tests/integration/wave-b-chain-consumer-contract.test.ts
+++ b/packages/mcp-server/tests/integration/wave-b-chain-consumer-contract.test.ts
@@ -37,7 +37,7 @@
  * Plan 04-03 migrates the orchestrator only (Task 3); plans 04-04
  * (Wave 3 option-leg path) and 04-06 (Wave 5 pipeline rewrite) handle
  * the rest. Some symbols (`ChainLoadResult` interface; chain-loader
- * `loadChainsBulk`/`loadChain` re-exports in test-exports.ext.ts) are
+ * `loadChainsBulk`/`loadChain` re-exports in test-exports.ts) are
  * preserved as transitional surface so the worktree compiles between
  * waves — see SUMMARY.md for the explicit Case B documentation.
  */

--- a/packages/mcp-server/tests/unit/market/tickers/resolver.test.ts
+++ b/packages/mcp-server/tests/unit/market/tickers/resolver.test.ts
@@ -13,9 +13,7 @@
  * Until then `npm run build` must succeed and imports must compile cleanly.
  */
 import { describe, it, expect } from "@jest/globals";
-// Import directly from source files, not via test-exports, because a sibling
-// re-export in test-exports.ext.ts pulls a .mjs devtool module that Jest can't
-// parse in this repo's current config (pre-existing issue from earlier commits).
+// Imported directly from source files rather than via test-exports.
 import { extractRoot, rootToUnderlying } from "../../../../src/market/tickers/resolver.js";
 import { TickerRegistry } from "../../../../src/market/tickers/registry.js";
 

--- a/packages/mcp-server/tests/unit/tool-ticker-deps.test.ts
+++ b/packages/mcp-server/tests/unit/tool-ticker-deps.test.ts
@@ -7,7 +7,7 @@
  *
  * Project convention: import via `../../src/test-exports.js` (PATTERNS.md
  * §Pattern 6). Plan 04-00 Task 1 surfaces TOOL_TICKER_DEPS + unionTickerDeps
- * through test-exports.ts BEFORE the test-exports.ext.js wildcard.
+ * through test-exports.ts.
  */
 import { describe, it, expect } from '@jest/globals';
 import {


### PR DESCRIPTION
## Summary

The `.ext.js` pattern (dynamic-import-with-silent-fail + static re-export stubs) was a workaround for an extension story that doesn't fit the current public-lib shape. All three indirections are dead-code in this repo — `connection.ext.ts` was never present (silent-fail by design), and the two static stubs only re-exported through to local modules. Removing them shrinks the public API surface before TradeBlocks 3.0 ships.

## Three indirections removed

### 1. `connection.ts` dynamic ext-import block
- `packages/mcp-server/src/db/connection.ts`: drop the try/catch `await import('./connection.ext.js')` block in `openReadWriteConnection`.
- Update header docstring (step 8 of startup sequence) and the metadata-migration ordering comment.

### 2. `test-exports.ext.ts` static wildcard
- `packages/mcp-server/src/test-exports.ts`: delete the trailing `export * from './test-exports.ext.js'` wildcard line.
- Delete the six \"MUST appear BEFORE the ext.js wildcard\" ordering-constraint comments scattered through the file — they existed only because the wildcard could shadow later exports. With the wildcard gone, the constraint is moot.
- Delete the `test-exports.ext.ts` stub file (5-LOC `export {};`).

### 3. `thetadata.ext.ts` static re-export stub
- `packages/mcp-server/src/utils/providers/thetadata.ts`: change `import { buildOccTicker } from \"./thetadata.ext.js\"` to import directly from `\"../trade-replay.js\"` (where the function is actually defined).
- Delete the `thetadata.ext.ts` stub file (5-LOC re-export through to the same source).

### Test-file comment updates
Three test files had explanatory comments referencing the removed `.ext.ts` patterns; updated to reflect the new shape:
- `tests/unit/tool-ticker-deps.test.ts`
- `tests/unit/market/tickers/resolver.test.ts`
- `tests/integration/wave-b-chain-consumer-contract.test.ts`

## Runtime behavior

**Unchanged.** The dynamic import was silent-fail (no `.ext` file in this repo); the two static stubs were no-op re-exports. All removals are pure indirection — every consumer continues to resolve the same symbols from the same underlying modules.

## Verification

- `npm run lint` — clean (eslint also runs in pre-commit hook).
- Root jest (`npm test`): **73 suites / 1256 tests pass**.
- mcp-server jest (`cd packages/mcp-server && npm test`): **120 suites / 1566 tests pass**.
- `! git grep -E '(holodeck|private-packages|tradeblocks-private)' -- 'packages/**' 'app/**'` — zero matches.
- `! grep -q '\"file:' package.json packages/*/package.json` — zero matches.
- Net diff: 8 files changed, **6 insertions, 54 deletions**. Pure subtraction.

## Why now

TradeBlocks 3.0 ships from `feat/tradeblocks-3.0`. Once that branch merges to `master`, the public API surface freezes. Keeping the three dead-stub indirections in the 3.0 release would commit them to the long-term public API — a worse outcome than removing them now while we can.