### PR TITLE
docs(chain-loader): scrub internal-ticket vocab from public-lib docs

### DIFF
--- a/packages/mcp-server/src/utils/chain-loader.ts
+++ b/packages/mcp-server/src/utils/chain-loader.ts
@@ -3,12 +3,12 @@
  *
  * Pure helpers for option chain filtering and deduplication.
  *
- * Phase 4 Plan 04-03: the three-step cache-lifecycle fetch path is GONE
- * (D-05 / SEP-01 — reads never trigger provider fetches). Per-date chain
- * reads now flow through `stores.chain.readChain(underlying, date)`
- * (Phase 2 ChainStore API). Empty array is the new skip signal — the
- * legacy `ChainSkipResult` / `isChainSkip` type-guard pair has been
- * deleted along with the SQL builders that backed the cache lookups.
+ * The three-step cache-lifecycle fetch path is gone — reads never trigger
+ * provider fetches. Per-date chain reads now flow through
+ * `stores.chain.readChain(underlying, date)` (ChainStore API). Empty array
+ * is the skip signal — the legacy `ChainSkipResult` / `isChainSkip`
+ * type-guard pair has been deleted along with the SQL builders that backed
+ * the cache lookups.
  *
  * Surviving public surface (this file):
  *   - filterChain(contracts, filter)        pure DTE / contract-type filter
@@ -17,19 +17,16 @@
  *                                           on-the-wire contract shape (also
  *                                           re-exported from market/stores/types.ts)
  *
- * Transitional surface (Case B — to be removed by plan 04-04):
+ * Transitional surface (deprecated, scheduled for removal):
  *   - ChainLoadResult interface             { contracts: ContractRow[], source: 'cache' }
- *                                           still type-referenced by many backtest
- *                                           internals (entry-resolver, market-data-loader,
- *                                           data-prep, simulation/helpers, types,
- *                                           cache, quote-minute-cache). Plan 04-04
- *                                           atomically rewrites those consumers to
- *                                           accept `ContractRow[]` directly and
- *                                           deletes this interface.
+ *                                           preserved until downstream consumers
+ *                                           are rewritten to accept `ContractRow[]`
+ *                                           directly.
  *
  * Anything not listed above (loadChain, loadChainsBulk, buildCachedChainQuery,
  * optionChainPartitionSource, chainColumnsSql, chainRowFromSql, ChainResult,
- * ChainSkipResult, ChainSkipReason, isChainSkip) was DELETED in plan 04-03.
+ * ChainSkipResult, ChainSkipReason, isChainSkip) was deleted as part of the
+ * ChainStore migration.
  */
 
 // ---------------------------------------------------------------------------
@@ -49,8 +46,8 @@ export interface ContractRow {
 
 /**
  * Transitional shape — see file header. The `source` field is fixed to
- * `'cache'` post-Phase-4 because reads never fetch (SEP-01). Plan 04-04
- * deletes this interface and switches downstream consumers to plain
+ * `'cache'` because reads no longer fetch from a provider. This interface
+ * is scheduled for removal once downstream consumers are switched to plain
  * `ContractRow[]`.
  *
  * Do NOT add new code that constructs ChainLoadResult; use ContractRow[].
@@ -109,28 +106,23 @@ export function filterChain(contracts: ContractRow[], filter: ChainFilterOptions
 }
 
 // ---------------------------------------------------------------------------
-// Transitional throw-stubs (Case B — deleted by plan 04-04)
+// Transitional throw-stubs (deprecated, scheduled for removal)
 //
-// The Phase 4 Plan 04-03 charter is "delete the cache-miss fetchers" — and the
-// concrete read path (Massive HTTP + INSERT OR REPLACE INTO market.option_chain)
-// IS gone. The named symbols below survive ONLY as throw-stubs to keep the
-// worktree compiling between plan 04-03 (Wave 3) and plan 04-04 (also Wave 3),
-// which migrates the remaining callers in:
-//   - src/backtest/loading/data-prep.ts
-//   - src/backtest/loading/market-data-loader.ts
-//   - src/utils/quote-minute-cache.ts
-//   - src/utils/data-pipeline.ts
-// to use `stores.chain.readChain(...)` directly.
+// The cache-miss fetch path (Massive HTTP + INSERT OR REPLACE INTO
+// market.option_chain) is gone. The named symbols below survive ONLY as
+// throw-stubs to keep downstream consumers compiling until they have been
+// rewritten to use `stores.chain.readChain(...)` directly.
 //
 // These stubs MUST NEVER be invoked at runtime. They exist purely so static
-// type-checking and Jest module-graph resolution succeed in the interval
-// between waves. Plan 04-04 deletes them entirely.
+// type-checking and Jest module-graph resolution succeed in the interim.
 // ---------------------------------------------------------------------------
 
 /**
- * @deprecated Phase 4 Plan 04-03 — DELETED. Use `stores.chain.readChain(underlying, date)`
- * instead. Empty array is the new skip signal (replaces ChainSkipResult). This stub
- * throws at runtime to make accidental callers loud; plan 04-04 removes it entirely.
+ * @deprecated Removed in the ChainStore migration. Use
+ * `stores.chain.readChain(underlying, date)` instead — empty array is the
+ * new skip signal (replaces `ChainSkipResult`). This stub throws at runtime
+ * to make accidental callers loud and will be deleted once consumers have
+ * been rewritten.
  */
 export async function loadChain(
   _underlying: string,
@@ -139,15 +131,16 @@ export async function loadChain(
   _opts?: { dataDir?: string; maxDte?: number },
 ): Promise<ChainLoadResult> {
   throw new Error(
-    "chain-loader.loadChain is DELETED in plan 04-03 (Phase 4). " +
-    "Use stores.chain.readChain(underlying, date) instead — empty array is the new skip signal. " +
-    "Plan 04-04 (Wave 3) removes this stub.",
+    "chain-loader.loadChain has been removed. " +
+    "Use stores.chain.readChain(underlying, date) instead — empty array is the new skip signal.",
   );
 }
 
 /**
- * @deprecated Phase 4 Plan 04-03 — DELETED. Use a `for (const date of dates)` loop
- * with `stores.chain.readChain(underlying, date)` instead. Plan 04-04 removes this stub.
+ * @deprecated Removed in the ChainStore migration. Use a
+ * `for (const date of dates)` loop with `stores.chain.readChain(underlying, date)`
+ * instead. This stub throws at runtime and will be deleted once consumers
+ * have been rewritten.
  */
 export async function loadChainsBulk(
   _underlying: string,
@@ -156,8 +149,7 @@ export async function loadChainsBulk(
   _opts?: { dataDir?: string },
 ): Promise<Map<string, ChainLoadResult>> {
   throw new Error(
-    "chain-loader.loadChainsBulk is DELETED in plan 04-03 (Phase 4). " +
-    "Use a per-date loop with stores.chain.readChain(underlying, date) instead. " +
-    "Plan 04-04 (Wave 3) removes this stub.",
+    "chain-loader.loadChainsBulk has been removed. " +
+    "Use a per-date loop with stores.chain.readChain(underlying, date) instead.",
   );
 }

--- a/packages/mcp-server/tests/integration/wave-b-chain-consumer-contract.test.ts
+++ b/packages/mcp-server/tests/integration/wave-b-chain-consumer-contract.test.ts
@@ -1,45 +1,29 @@
 /**
- * Wave B chain-consumer contract tests (Phase 4 Plan 04-03).
+ * Chain-consumer contract tests.
  *
  * Exercises the migrated orchestrator chain-read path and the surviving
  * pure-utility surface of `utils/chain-loader.ts` after the surgical
  * deletion of `loadChain` / `loadChainsBulk` / `buildCachedChainQuery`
  * / `optionChainPartitionSource` and the chain-skip Result types.
  *
- * Wave B scope (this plan):
- *   - chain-loader.ts: delete the three-step cache-lifecycle fetch path,
- *     the SQL builders, and the skip-result types. Preserve the pure
- *     utilities (`filterChain` / `deduplicateContracts`) plus the
- *     `ContractRow` type alias and (transitionally per Case B) the
- *     `ChainLoadResult` interface so plan 04-04 can clean it up
- *     atomically with the remaining backtest internals.
- *   - quote-enricher.ts: delete `enrichQuotesForTickers` /
- *     `fetchExistingCoverage`. Preserve the pure planners
- *     (`shouldSkipEnrichment` / `buildEnrichmentPlan`).
- *   - market-datasets.ts: drop `option_chain` / `option_quote_minutes`
- *     from `CanonicalPartitionedDataset` (D-12) — the new 3.0 layout is
+ * Scope:
+ *   - chain-loader.ts: the three-step cache-lifecycle fetch path, the SQL
+ *     builders, and the skip-result types are deleted. Pure utilities
+ *     (`filterChain` / `deduplicateContracts`) are preserved, along with
+ *     the `ContractRow` type alias and (transitionally) the
+ *     `ChainLoadResult` interface.
+ *   - quote-enricher.ts: `enrichQuotesForTickers` and
+ *     `fetchExistingCoverage` are deleted. Pure planners
+ *     (`shouldSkipEnrichment` / `buildEnrichmentPlan`) are preserved.
+ *   - market-datasets.ts: `option_chain` and `option_quote_minutes` are
+ *     dropped from `CanonicalPartitionedDataset` — the 3.0 layout is
  *     served via `DATASETS_V3` exclusively.
- *   - backtest/orchestrator.ts: per-date chain read goes through
- *     `stores.chain.readChain(...)`; empty-array is the new skip signal
- *     replacing `isChainSkip`.
+ *   - Per-date chain reads go through `stores.chain.readChain(...)`;
+ *     empty array is the new skip signal replacing `isChainSkip`.
  *
- * Pre-deletion external consumers of the deleted symbols (verified at
- * start of plan 04-03):
- *
- *   src/backtest/orchestrator.ts                      loadChain + isChainSkip + ChainLoadResult
- *   src/backtest/loading/data-prep.ts                 loadChainsBulk + ChainLoadResult
- *   src/backtest/loading/market-data-loader.ts        loadChainsBulk + ChainLoadResult
- *   src/utils/quote-minute-cache.ts                   loadChainsBulk + loadChain + ChainLoadResult
- *   src/utils/data-pipeline.ts                        loadChainsBulk + loadChain
- *   src/tools/data-pipeline.ts                        enrichQuotesForTickers (3 call sites)
- *   src/utils/data-pipeline.ts                        enrichQuotesForTickers (1 call site)
- *
- * Plan 04-03 migrates the orchestrator only (Task 3); plans 04-04
- * (Wave 3 option-leg path) and 04-06 (Wave 5 pipeline rewrite) handle
- * the rest. Some symbols (`ChainLoadResult` interface; chain-loader
- * `loadChainsBulk`/`loadChain` re-exports in test-exports.ts) are
- * preserved as transitional surface so the worktree compiles between
- * waves — see SUMMARY.md for the explicit Case B documentation.
+ * Transitional surface still exported (`ChainLoadResult` interface; the
+ * throw-stubs for `loadChain` / `loadChainsBulk`) is preserved so
+ * downstream consumers continue to compile during the rewrite.
  */
 import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import {
@@ -168,20 +152,20 @@ describe("chain-loader + quote-enricher — exported API shape after surgical de
   });
 
   it("chain-loader: SQL builders + cache-lifecycle internals are deleted", () => {
-    // Three-step cache lifecycle gone (D-05 / SEP-01 — reads never trigger fetches).
-    // The SQL builders and partition-source helpers that backed the deleted
-    // cache reads are also gone.
+    // The three-step cache lifecycle is gone — reads never trigger provider
+    // fetches. The SQL builders and partition-source helpers that backed the
+    // deleted cache reads are also gone.
     expect((chainLoader as unknown as Record<string, unknown>).buildCachedChainQuery).toBeUndefined();
     expect((chainLoader as unknown as Record<string, unknown>).optionChainPartitionSource).toBeUndefined();
     expect((chainLoader as unknown as Record<string, unknown>).chainColumnsSql).toBeUndefined();
     expect((chainLoader as unknown as Record<string, unknown>).chainRowFromSql).toBeUndefined();
   });
 
-  it("chain-loader: loadChain / loadChainsBulk are throw-stubs (Case B — plan 04-04 deletes)", async () => {
-    // The fetch implementations are gone. The named exports survive transitionally
-    // to keep the worktree compiling between plan 04-03 (Wave 3) and plan 04-04
-    // (Wave 3) which migrates the remaining backtest-internals callers. Calling
-    // them at runtime must throw with a marker referring to plan 04-03.
+  it("chain-loader: loadChain / loadChainsBulk are throw-stubs", async () => {
+    // The fetch implementations are gone. The named exports survive
+    // transitionally so downstream consumers continue to compile. Calling
+    // them at runtime must throw with a marker pointing at the replacement
+    // API (stores.chain.readChain).
     const loadChain = (chainLoader as unknown as Record<string, unknown>).loadChain;
     const loadChainsBulk = (chainLoader as unknown as Record<string, unknown>).loadChainsBulk;
 
@@ -198,8 +182,9 @@ describe("chain-loader + quote-enricher — exported API shape after surgical de
         caught = e;
       }
       expect(caught).not.toBeNull();
-      expect(String((caught as Error).message)).toMatch(/plan 04-03/i);
-      // Sanity: the message names the symbol so future grep-walkers find the right plan.
+      // Message must point readers at the replacement API.
+      expect(String((caught as Error).message)).toContain("stores.chain.readChain");
+      // Sanity: the message names the symbol so future grep-walkers can find it.
       expect(String((caught as Error).message)).toContain(name === "loadChain" ? "loadChain" : "loadChainsBulk");
     }
   });

--- a/packages/mcp-server/tests/unit/chain-loader.test.ts
+++ b/packages/mcp-server/tests/unit/chain-loader.test.ts
@@ -1,18 +1,17 @@
 /**
  * Unit tests for chain-loader.ts.
  *
- * Phase 4 Plan 04-03: the three-step cache-lifecycle fetch path was
- * deleted (D-05 / SEP-01 — reads never trigger provider fetches). The
- * surviving public surface is the pure-utility set: `filterChain` +
- * `deduplicateContracts` + `ContractRow`. The legacy `loadChain` /
- * `loadChainsBulk` / `isChainSkip` cases are removed; equivalent
- * coverage of the new path lives in
+ * The three-step cache-lifecycle fetch path was deleted (reads no longer
+ * trigger provider fetches). The surviving public surface is the
+ * pure-utility set: `filterChain` + `deduplicateContracts` + `ContractRow`.
+ * The legacy `loadChain` / `loadChainsBulk` / `isChainSkip` cases are
+ * removed; equivalent coverage of the new path lives in
  * `tests/integration/wave-b-chain-consumer-contract.test.ts`
  * (orchestrator now calls `stores.chain.readChain`).
  *
- * Original requirements covered: CHAIN-03 (filter-by-DTE/contract_type),
- * CHAIN-04 historical skip semantics — superseded by the empty-array
- * skip signal asserted in wave-b-chain-consumer-contract.test.ts.
+ * Original requirements covered: filter-by-DTE / contract_type;
+ * historical skip semantics are superseded by the empty-array skip
+ * signal asserted in wave-b-chain-consumer-contract.test.ts.
  */
 
 import { filterChain, type ContractRow } from "../../src/test-exports.js";


### PR DESCRIPTION
## Summary

`chain-loader.ts` and its two test files carried documentation written for an internal migration plan — references to `Phase 4 Plan 04-03`, `Plan 04-04`, `Wave B`, `Case B`, `D-05`, `SEP-01`, plus private architecture paths like `src/backtest/loading/data-prep.ts` and `src/backtest/orchestrator.ts`. None of those concepts make sense to public-lib readers; the private paths don't even exist in this repo.

This PR rewrites the doc comments to describe the public-lib contract in its own terms.

## What the docs now say

- The cache-lifecycle fetch path is gone; reads no longer trigger provider fetches.
- Per-date chain reads go through `stores.chain.readChain(underlying, date)`.
- Empty array is the new skip signal (replacing `ChainSkipResult` / `isChainSkip`).
- `loadChain` / `loadChainsBulk` survive as deprecated throw-stubs so downstream consumers continue to compile.

## Files touched (3, doc-only)

### `packages/mcp-server/src/utils/chain-loader.ts`
- Top-of-file docstring (lines 1-31)
- Transitional throw-stubs block comment (lines 109-119)
- `@deprecated` JSDoc on `loadChain` and `loadChainsBulk`
- Runtime error message text — now points at the replacement API (`stores.chain.readChain`) rather than an internal-ticket marker
- `ChainLoadResult` interface docstring

### `packages/mcp-server/tests/unit/chain-loader.test.ts`
- Top-of-file docstring

### `packages/mcp-server/tests/integration/wave-b-chain-consumer-contract.test.ts`
- Top-of-file docstring (kept the same scope summary, dropped the internal pre-deletion-consumers table)
- `loadChain` / `loadChainsBulk` throw-stub test block: updated test name, comments, and the error-message assertion (now asserts the message contains `stores.chain.readChain` rather than an internal-ticket marker)

## Out of scope (sibling cleanup)

`quote-enricher.ts` has the same class of internal-ticket vocab and is referenced by a still-dirty test block (lines 206-234 of wave-b). That cleanup is left for a follow-up PR so this one stays focused on the chain-loader surface.

## Behavior unchanged

- Runtime error messages still name the symbol (`loadChain` / `loadChainsBulk`) so grep-walkers find them; they additionally point at the replacement API (`stores.chain.readChain`).
- All exported symbols and signatures preserved.
- No code logic changes — pure doc + comment + error-message-text rewrites.

## Verification

- `npm run lint` — clean (eslint pre-commit hook also clean).
- Root jest (`npm test`): **73 suites / 1256 tests pass**.
- mcp-server jest (`cd packages/mcp-server && npm test`): **120 suites / 1566 tests pass**.
- `! git grep -E '(holodeck|private-packages|tradeblocks-private)' -- 'packages/**' 'app/**'` — zero matches.
- Net diff: 3 files changed, **69 insertions, 93 deletions**.