### PR TITLE
docs(quote-enricher): scrub internal-ticket vocab from public-lib docs

### DIFF
--- a/packages/mcp-server/src/utils/quote-enricher.ts
+++ b/packages/mcp-server/src/utils/quote-enricher.ts
@@ -3,21 +3,17 @@
  *
  * Pure helpers for option-quote enrichment planning.
  *
- * Phase 4 Plan 04-03: the I/O fetch loop (`enrichQuotesForTickers`) and its
- * coverage-probe helper (`fetchExistingCoverage`) were deleted — reads never
- * trigger provider fetches (D-05 / SEP-01).
- *
- * Phase 4 Plan 04-06 (Wave 5): the transitional `enrichQuotesForTickers`
- * throw-stub is now DELETED — every caller routes through
- * `backfillQuotes(stores, ...)` from `utils/quote-backfill.ts`.
+ * The I/O fetch loop (`enrichQuotesForTickers`) and its coverage-probe
+ * helper (`fetchExistingCoverage`) were deleted — reads no longer trigger
+ * provider fetches. Every caller routes through `backfillQuotes(stores, ...)`
+ * from `utils/quote-backfill.ts`.
  *
  * Surviving public surface (this file):
  *   - shouldSkipEnrichment(barCount, threshold)   pure density check
  *   - buildEnrichmentPlan(input)                  pure planner — groups
  *                                                 (ticker, date) combos
- *                                                 needing enrichment.
- *                                                 Reused by backfillQuotes
- *                                                 (Plan 04-06 / B2 / Path A).
+ *                                                 needing enrichment. Reused
+ *                                                 by backfillQuotes.
  *   - QuoteEnrichmentResult                       result-shape type — preserved
  *                                                 because internal callers may
  *                                                 still reference it; structurally
@@ -37,9 +33,9 @@ export interface EnrichmentPlanItem {
 
 /**
  * Result shape returned by the (deleted) `enrichQuotesForTickers` function.
- * Plan 04-06 swapped every call site to `backfillQuotes` whose result type
- * (`BackfillQuotesResult`) is structurally identical. We keep this alias as a
- * stable internal type name; callers may import either.
+ * Every call site has been switched to `backfillQuotes`, whose result type
+ * (`BackfillQuotesResult`) is structurally identical. This alias is kept
+ * as a stable internal type name; callers may import either.
  */
 export interface QuoteEnrichmentResult {
   tickersProcessed: number;
@@ -123,7 +119,6 @@ function expandDateRange(fromDate: string, toDate: string): string[] {
 }
 
 // ---------------------------------------------------------------------------
-// Phase 4 Plan 04-06: the `enrichQuotesForTickers` throw-stub from plan 04-03
-// is DELETED. Callers were migrated to `backfillQuotes(stores, ...)` from
-// `utils/quote-backfill.ts` in this same plan.
+// The `enrichQuotesForTickers` throw-stub has been deleted. All callers now
+// route through `backfillQuotes(stores, ...)` from `utils/quote-backfill.ts`.
 // ---------------------------------------------------------------------------

--- a/packages/mcp-server/tests/integration/wave-b-chain-consumer-contract.test.ts
+++ b/packages/mcp-server/tests/integration/wave-b-chain-consumer-contract.test.ts
@@ -219,17 +219,17 @@ describe("chain-loader + quote-enricher — exported API shape after surgical de
     expect(quoteEnricher.shouldSkipEnrichment(199)).toBe(false);
   });
 
-  it("quote-enricher: fetch loop is deleted (or stubbed to throw — Plan 04-06 wires backfillQuotes)", async () => {
+  it("quote-enricher: fetch loop is deleted (or stubbed to throw)", async () => {
     // Either the function is fully gone OR it survives as a throw-stub. The
-    // contract for plan 04-03 is "no provider fetch happens here". A throw-stub
-    // satisfies that and keeps callers in data-pipeline.ts type-checking until
-    // plan 04-06 swaps the implementation.
+    // contract is "no provider fetch happens here". A throw-stub satisfies
+    // that and keeps any remaining callers type-checking until they are
+    // rewritten to use `backfillQuotes(stores, ...)`.
     const stub = (quoteEnricher as unknown as Record<string, unknown>).enrichQuotesForTickers;
     if (typeof stub === "function") {
-      // Stub variant: must throw with the plan-04-03 marker so any accidental
-      // call is loud and traceable to the right plan. Call with an arg shape
-      // that satisfies whatever defensive guards the stub may have so it
-      // reaches the throw — the precise signature is documented in SUMMARY.md.
+      // Stub variant: must throw with a marker pointing at the replacement
+      // API so any accidental call is loud and traceable. Call with an arg
+      // shape that satisfies whatever defensive guards the stub may have so
+      // it reaches the throw.
       const fn = stub as (...args: unknown[]) => Promise<unknown> | unknown;
       let caught: unknown = null;
       try {
@@ -239,7 +239,9 @@ describe("chain-loader + quote-enricher — exported API shape after surgical de
         caught = e;
       }
       expect(caught).not.toBeNull();
-      expect(String((caught as Error).message)).toMatch(/plan 04-03/i);
+      // The message must mention the replacement API so future readers can
+      // find it.
+      expect(String((caught as Error).message)).toContain("backfillQuotes");
     } else {
       expect(stub).toBeUndefined();
     }


### PR DESCRIPTION
## Summary

Sibling cleanup to #306 (chain-loader doc scrub). Removes the same class of internal-ticket vocab (Phase 4 Plan 04-03 / Plan 04-06 / Wave 5 / D-05 / SEP-01 / B2 / Path A) from `quote-enricher.ts` and from the still-dirty quote-enricher test block in `wave-b-chain-consumer-contract.test.ts`.

## What the docs now say

- The I/O fetch loop (`enrichQuotesForTickers`) and its coverage-probe helper (`fetchExistingCoverage`) are gone; reads never trigger provider fetches.
- All callers route through `backfillQuotes(stores, ...)` from `utils/quote-backfill.ts`.
- Pure planners (`shouldSkipEnrichment`, `buildEnrichmentPlan`) and the `QuoteEnrichmentResult` type alias are preserved.

## Files touched (2, doc-only)

### `packages/mcp-server/src/utils/quote-enricher.ts`
- Top-of-file docstring (drops `Phase 4 Plan 04-03 / Plan 04-06 / Wave 5 / D-05 / SEP-01 / B2 / Path A` references)
- `QuoteEnrichmentResult` interface docstring
- Bottom-of-file `enrichQuotesForTickers` deletion note

### `packages/mcp-server/tests/integration/wave-b-chain-consumer-contract.test.ts`
- Quote-enricher fetch-loop stub test block (lines ~222-250 of the pre-merge state):
  - Updated test name (drops `Plan 04-06 wires backfillQuotes` parenthetical)
  - Updated body comments
  - Updated error-message assertion (now asserts the message contains `backfillQuotes` rather than the internal-ticket marker `/plan 04-03/i`)

## Behavior unchanged

- No code logic changes — pure doc + comment + test-comment rewrites.
- The stub-defensive branch of the wave-b test still asserts that any throw-stub message names the replacement API (`backfillQuotes`).
- The fully-deleted branch still asserts `undefined`.

## Relationship to #306

Companion PR. They touch different line ranges of `wave-b-chain-consumer-contract.test.ts`:
- #306: lines 1-43 (top docstring) + lines 164-189 (chain-loader stub test block)
- This PR: lines ~222-250 (quote-enricher stub test block)

Conflict-free in either merge order. Reviewing one doesn't block the other.

## Verification

- `npm run lint` — clean
- root jest (`npm test`): **73 suites / 1256 tests pass**
- mcp-server jest (`cd packages/mcp-server && npm test`): **120 suites / 1566 tests pass**
- `! git grep -E '(holodeck|private-packages|tradeblocks-private)' -- 'packages/**' 'app/**'` — zero matches
- Net diff: 2 files changed, **22 insertions, 25 deletions**