### PR TITLE
chore(package): expose mcp-server internal modules via exports map (tradeblocks-org/enterprise#78 Phase 5A)

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -8,6 +8,108 @@
   "bin": {
     "tradeblocks-mcp": "server/index.js"
   },
+  "exports": {
+    "./utils/market-provider": {
+      "types": "./src/utils/market-provider.ts",
+      "import": "./src/utils/market-provider.ts"
+    },
+    "./utils/black-scholes": {
+      "types": "./src/utils/black-scholes.ts",
+      "import": "./src/utils/black-scholes.ts"
+    },
+    "./utils/chain-loader": {
+      "types": "./src/utils/chain-loader.ts",
+      "import": "./src/utils/chain-loader.ts"
+    },
+    "./utils/option-quote-greeks": {
+      "types": "./src/utils/option-quote-greeks.ts",
+      "import": "./src/utils/option-quote-greeks.ts"
+    },
+    "./utils/option-time": {
+      "types": "./src/utils/option-time.ts",
+      "import": "./src/utils/option-time.ts"
+    },
+    "./utils/market-enricher": {
+      "types": "./src/utils/market-enricher.ts",
+      "import": "./src/utils/market-enricher.ts"
+    },
+    "./utils/provider-capabilities": {
+      "types": "./src/utils/provider-capabilities.ts",
+      "import": "./src/utils/provider-capabilities.ts"
+    },
+    "./utils/quote-parquet-projection": {
+      "types": "./src/utils/quote-parquet-projection.ts",
+      "import": "./src/utils/quote-parquet-projection.ts"
+    },
+    "./utils/data-availability": {
+      "types": "./src/utils/data-availability.ts",
+      "import": "./src/utils/data-availability.ts"
+    },
+    "./utils/data-quality": {
+      "types": "./src/utils/data-quality.ts",
+      "import": "./src/utils/data-quality.ts"
+    },
+    "./utils/providers/thetadata": {
+      "types": "./src/utils/providers/thetadata.ts",
+      "import": "./src/utils/providers/thetadata.ts"
+    },
+    "./utils/flatfile-importer": {
+      "types": "./src/utils/flatfile-importer.ts",
+      "import": "./src/utils/flatfile-importer.ts"
+    },
+    "./utils/quote-enricher": {
+      "types": "./src/utils/quote-enricher.ts",
+      "import": "./src/utils/quote-enricher.ts"
+    },
+    "./db/connection": {
+      "types": "./src/db/connection.ts",
+      "import": "./src/db/connection.ts"
+    },
+    "./db/data-root": {
+      "types": "./src/db/data-root.ts",
+      "import": "./src/db/data-root.ts"
+    },
+    "./db/backtest-schemas": {
+      "types": "./src/db/backtest-schemas.ts",
+      "import": "./src/db/backtest-schemas.ts"
+    },
+    "./db/parquet-writer": {
+      "types": "./src/db/parquet-writer.ts",
+      "import": "./src/db/parquet-writer.ts"
+    },
+    "./db/json-store": {
+      "types": "./src/db/json-store.ts",
+      "import": "./src/db/json-store.ts"
+    },
+    "./db/market-datasets": {
+      "types": "./src/db/market-datasets.ts",
+      "import": "./src/db/market-datasets.ts"
+    },
+    "./db/market-views": {
+      "types": "./src/db/market-views.ts",
+      "import": "./src/db/market-views.ts"
+    },
+    "./db/market-schemas": {
+      "types": "./src/db/market-schemas.ts",
+      "import": "./src/db/market-schemas.ts"
+    },
+    "./market/stores": {
+      "types": "./src/market/stores/index.ts",
+      "import": "./src/market/stores/index.ts"
+    },
+    "./market/tickers": {
+      "types": "./src/market/tickers/index.ts",
+      "import": "./src/market/tickers/index.ts"
+    },
+    "./market/tickers/resolver": {
+      "types": "./src/market/tickers/resolver.ts",
+      "import": "./src/market/tickers/resolver.ts"
+    },
+    "./market/tickers/schemas": {
+      "types": "./src/market/tickers/schemas.ts",
+      "import": "./src/market/tickers/schemas.ts"
+    }
+  },
   "scripts": {
     "build": "tsup && node scripts/copy-provider-assets.mjs && npm run build:http-server && npm run fix-http-import",
     "build:http-server": "esbuild src/http-server.ts --bundle --outfile=server/http-server.js --format=esm --platform=node --target=node18 --packages=external",
@@ -47,6 +149,7 @@
   "files": [
     "server",
     "dist",
+    "src",
     "agent-skills",
     "manifest.json"
   ],

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -97,9 +97,17 @@
       "types": "./src/market/stores/index.ts",
       "import": "./src/market/stores/index.ts"
     },
+    "./market/stores/types": {
+      "types": "./src/market/stores/types.ts",
+      "import": "./src/market/stores/types.ts"
+    },
     "./market/tickers": {
       "types": "./src/market/tickers/index.ts",
       "import": "./src/market/tickers/index.ts"
+    },
+    "./market/tickers/registry": {
+      "types": "./src/market/tickers/registry.ts",
+      "import": "./src/market/tickers/registry.ts"
     },
     "./market/tickers/resolver": {
       "types": "./src/market/tickers/resolver.ts",
@@ -108,6 +116,10 @@
     "./market/tickers/schemas": {
       "types": "./src/market/tickers/schemas.ts",
       "import": "./src/market/tickers/schemas.ts"
+    },
+    "./test-exports": {
+      "types": "./src/test-exports.ts",
+      "import": "./src/test-exports.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
Tier: 3

## What this changes

Adds a 28-entry `exports` map to `packages/mcp-server/package.json` and includes `"src"` in the `files` array. The exports map surfaces internal modules at named subpaths under three areas:

- `./utils/*` (13 entries) — market provider, black-scholes, chain-loader, option-quote-greeks, option-time, market-enricher, provider-capabilities, quote-parquet-projection, data-availability, data-quality, providers/thetadata, flatfile-importer, quote-enricher
- `./db/*` (8 entries) — connection, data-root, backtest-schemas, parquet-writer, json-store, market-datasets, market-views, market-schemas
- `./market/*` (6 entries) — stores, stores/types, tickers, tickers/registry, tickers/resolver, tickers/schemas
- `./test-exports` (1 entry) — test-only surface

(Total: 28 entries — see `packages/mcp-server/package.json` for the precise map.)

The conditional shape for each entry resolves both `types` and `import` to the `.ts` source under `./src/`. Adding `"src"` to `files` ensures that npm-installed consumers receive the same source tree that sibling `file:`-linked consumers resolve against — so deep-import behavior is identical across consumption modes.

## Why

A downstream sibling repository consumes `tradeblocks-mcp` via `file:` workspace link and needs to import ~28 internal subpaths (utilities, DB schemas, market stores/tickers). Today `packages/mcp-server/package.json` has no `exports` map, so deep imports fail with `ERR_PACKAGE_PATH_NOT_EXPORTED` under modern Node ESM resolution. This PR defines the public deep-import contract.

## Architectural choice — Option A (exports → src/ TS)

Three options were considered:

| | Option A — exports → src | Option B — per-file dist | Option C — conditional dual |
|---|---|---|---|
| npm install consumer | Unchanged (no deep-import surface advertised) | Unchanged | Unchanged |
| `file:` sibling consumer | Natural (matches existing TS-native pattern) | Adds build-order dependency | Same as A, plus condition complexity |
| tsup config churn | Zero | Significant rewrite | Same as B + condition wiring |
| Diff size | ~100 lines (one file) | ~300+ lines | ~400+ lines |
| Tarball size delta | +~1–2MB (src files) | Negligible | Negligible |

Option A was selected because:

1. npm-install consumers don't deep-import today and weren't promised that surface — they pay no cost from shipping `src/`.
2. The current sibling consumer already uses TS-native loaders (ts-jest, tsx), so resolving to `.ts` is the natural pattern there.
3. The blast radius is one file. Easy to audit, easy to extend.

Option B was tempting from a "looks like a normal npm package" instinct but was wrong for this scope.

## Audit + gap-fix history

This PR is the product of a two-step process:

1. Initial commit (`eff822a`) — 25-entry exports map + `"src"` in `files`.
2. Audit gap-fix commit (`ef6a65d`) — three subpaths missing from the original survey were added: `./market/stores/types`, `./market/tickers/registry`, `./test-exports`. All three target files exist in `src/` and are imported by the downstream sibling consumer; the omission was a survey error, not a design choice.

The plan-doc that ratified Option A and discovered the three gaps lives in the umbrella repo at `.planning/plans/2026-05-18-phase-5-tradeblocks-exports.md` (Tier 1, merged as `tradeblocks-org/enterprise#142`).

## What's NOT exported (deliberate exclusions)

The following surfaces are intentionally **not** in the exports map and must not be added:

- `./plugins` — plugin loader internals
- `./index` — package root (reserved; ships via `dist/server/bin`)
- `./utils/output-formatter` — MCP response shape helper
- `./server/*` — wholesale build-output prefix exclusion

These will be enforced by a CI durability gate in the immediate follow-up PR-5B (`romeo/78-phase-5b-exports-durability-gate`), which adds `scripts/verify-exports-surface.mjs` and a CI step checking both resolution and exclusion invariants.

## Verification done

Run from `packages/mcp-server/` and repo root respectively:

- `jq '.exports | keys | length' packages/mcp-server/package.json` → 28 ✅
- Per-entry resolution check (all 56 `types` + `import` paths exist on disk) → 0 MISSING ✅
- `npm test -w packages/mcp-server` → 120 suites / 1566 tests, all pass ✅
- `npm run build -w packages/mcp-server` → `server/index.js` (793KB) + `dist/test-exports.js` (352KB) produced cleanly ✅
- `npm pack` tarball includes 145 files under `package/src/`, total tarball 2.6MB ✅
- Smoke test via `tsx`: dynamic imports of `tradeblocks-mcp/utils/black-scholes`, `tradeblocks-mcp/db/data-root`, `tradeblocks-mcp/market/stores/types` all resolve from a sibling `file:` link ✅

## Cross-repo coordination anchor

The downstream consumer's restructure PR (Phase 3 of the umbrella arc) is sequenced **after** this PR merges. That PR's body will carry a line of the form:

```
Phase 5 merged: tradeblocks-org/tradeblocks#308@<merge-sha>
```

A future CI gate (Phase 7 deliverable) will parse and verify that anchor. When the squash-merge SHA on `feat/tradeblocks-3.0` is finalized, that's the SHA to quote.

## Follow-up: PR-5B

The durability-gate PR (`romeo/78-phase-5b-exports-durability-gate`) is already prepared on a branch stacked on top of this one. It adds CI enforcement that the exports map can't silently drift from the file system, and that the exclusion list stays excluded. It will open immediately after this PR merges.

## Tier 3 / merge protocol

Per `tradeblocks-org/enterprise#78` and the 3.0 architectural arc, this PR:

- Is Tier 3 (public-repo, published-surface change).
- Requires cross-Admiral review.
- **Must NOT be self-merged.**
- The originating author will not approve nor merge this PR.

## Cross-references

- Umbrella: `tradeblocks-org/enterprise#78` (3.0 architectural arc, Phase 5A)
- Plan doc (Tier 1): merged as `tradeblocks-org/enterprise#142`
- Architectural decision: ADR 0014 (lives in the umbrella repo)

## Test plan

- [x] All six pre-push checks pass locally (see Verification done above)
- [x] No `npm test` regressions
- [x] No `npm run build` regressions
- [x] Tarball ships `src/` for npm-install parity with `file:` consumers
- [ ] CI green on this PR
- [ ] Cross-Admiral review