### PR TITLE
chore(ci): verify mcp-server exports map against drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,12 @@ jobs:
       - name: "No file: deps gate"
         run: '! grep -q ''"file:'' package.json packages/*/package.json'
 
+      # The tradeblocks-mcp exports map is the package's published surface.
+      # Verify every target file resolves on disk and that no excluded
+      # subpaths have crept in. See the script's header for the policy.
+      - name: Verify mcp-server exports surface
+        run: node packages/mcp-server/scripts/verify-exports-surface.mjs
+
   frontend:
     name: Frontend (Next.js)
     runs-on: ubuntu-latest

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -8,6 +8,108 @@
   "bin": {
     "tradeblocks-mcp": "server/index.js"
   },
+  "exports": {
+    "./utils/market-provider": {
+      "types": "./src/utils/market-provider.ts",
+      "import": "./src/utils/market-provider.ts"
+    },
+    "./utils/black-scholes": {
+      "types": "./src/utils/black-scholes.ts",
+      "import": "./src/utils/black-scholes.ts"
+    },
+    "./utils/chain-loader": {
+      "types": "./src/utils/chain-loader.ts",
+      "import": "./src/utils/chain-loader.ts"
+    },
+    "./utils/option-quote-greeks": {
+      "types": "./src/utils/option-quote-greeks.ts",
+      "import": "./src/utils/option-quote-greeks.ts"
+    },
+    "./utils/option-time": {
+      "types": "./src/utils/option-time.ts",
+      "import": "./src/utils/option-time.ts"
+    },
+    "./utils/market-enricher": {
+      "types": "./src/utils/market-enricher.ts",
+      "import": "./src/utils/market-enricher.ts"
+    },
+    "./utils/provider-capabilities": {
+      "types": "./src/utils/provider-capabilities.ts",
+      "import": "./src/utils/provider-capabilities.ts"
+    },
+    "./utils/quote-parquet-projection": {
+      "types": "./src/utils/quote-parquet-projection.ts",
+      "import": "./src/utils/quote-parquet-projection.ts"
+    },
+    "./utils/data-availability": {
+      "types": "./src/utils/data-availability.ts",
+      "import": "./src/utils/data-availability.ts"
+    },
+    "./utils/data-quality": {
+      "types": "./src/utils/data-quality.ts",
+      "import": "./src/utils/data-quality.ts"
+    },
+    "./utils/providers/thetadata": {
+      "types": "./src/utils/providers/thetadata.ts",
+      "import": "./src/utils/providers/thetadata.ts"
+    },
+    "./utils/flatfile-importer": {
+      "types": "./src/utils/flatfile-importer.ts",
+      "import": "./src/utils/flatfile-importer.ts"
+    },
+    "./utils/quote-enricher": {
+      "types": "./src/utils/quote-enricher.ts",
+      "import": "./src/utils/quote-enricher.ts"
+    },
+    "./db/connection": {
+      "types": "./src/db/connection.ts",
+      "import": "./src/db/connection.ts"
+    },
+    "./db/data-root": {
+      "types": "./src/db/data-root.ts",
+      "import": "./src/db/data-root.ts"
+    },
+    "./db/backtest-schemas": {
+      "types": "./src/db/backtest-schemas.ts",
+      "import": "./src/db/backtest-schemas.ts"
+    },
+    "./db/parquet-writer": {
+      "types": "./src/db/parquet-writer.ts",
+      "import": "./src/db/parquet-writer.ts"
+    },
+    "./db/json-store": {
+      "types": "./src/db/json-store.ts",
+      "import": "./src/db/json-store.ts"
+    },
+    "./db/market-datasets": {
+      "types": "./src/db/market-datasets.ts",
+      "import": "./src/db/market-datasets.ts"
+    },
+    "./db/market-views": {
+      "types": "./src/db/market-views.ts",
+      "import": "./src/db/market-views.ts"
+    },
+    "./db/market-schemas": {
+      "types": "./src/db/market-schemas.ts",
+      "import": "./src/db/market-schemas.ts"
+    },
+    "./market/stores": {
+      "types": "./src/market/stores/index.ts",
+      "import": "./src/market/stores/index.ts"
+    },
+    "./market/tickers": {
+      "types": "./src/market/tickers/index.ts",
+      "import": "./src/market/tickers/index.ts"
+    },
+    "./market/tickers/resolver": {
+      "types": "./src/market/tickers/resolver.ts",
+      "import": "./src/market/tickers/resolver.ts"
+    },
+    "./market/tickers/schemas": {
+      "types": "./src/market/tickers/schemas.ts",
+      "import": "./src/market/tickers/schemas.ts"
+    }
+  },
   "scripts": {
     "build": "tsup && node scripts/copy-provider-assets.mjs && npm run build:http-server && npm run fix-http-import",
     "build:http-server": "esbuild src/http-server.ts --bundle --outfile=server/http-server.js --format=esm --platform=node --target=node18 --packages=external",
@@ -47,6 +149,7 @@
   "files": [
     "server",
     "dist",
+    "src",
     "agent-skills",
     "manifest.json"
   ],

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -128,6 +128,7 @@
     "fix-http-import": "node -e \"const fs=require('fs');const f='server/index.js';let c=fs.readFileSync(f,'utf8');c=c.replace(/\\.\\/http-server-[A-Z0-9]+\\.js/g,'./http-server.js');fs.writeFileSync(f,c);\" && rm -f server/http-server-*.js server/http-server-*.map",
     "dev": "tsup --watch",
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
+    "verify:exports": "node scripts/verify-exports-surface.mjs",
     "mcpb:pack": "npm run build && node scripts/pack-mcpb.js",
     "pack:beta": "npm run build && npm pack --pack-destination .",
     "prepublishOnly": "npm run build"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -97,9 +97,17 @@
       "types": "./src/market/stores/index.ts",
       "import": "./src/market/stores/index.ts"
     },
+    "./market/stores/types": {
+      "types": "./src/market/stores/types.ts",
+      "import": "./src/market/stores/types.ts"
+    },
     "./market/tickers": {
       "types": "./src/market/tickers/index.ts",
       "import": "./src/market/tickers/index.ts"
+    },
+    "./market/tickers/registry": {
+      "types": "./src/market/tickers/registry.ts",
+      "import": "./src/market/tickers/registry.ts"
     },
     "./market/tickers/resolver": {
       "types": "./src/market/tickers/resolver.ts",
@@ -108,6 +116,10 @@
     "./market/tickers/schemas": {
       "types": "./src/market/tickers/schemas.ts",
       "import": "./src/market/tickers/schemas.ts"
+    },
+    "./test-exports": {
+      "types": "./src/test-exports.ts",
+      "import": "./src/test-exports.ts"
     }
   },
   "scripts": {

--- a/packages/mcp-server/scripts/verify-exports-surface.mjs
+++ b/packages/mcp-server/scripts/verify-exports-surface.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+// Verifies the tradeblocks-mcp package exports map against drift.
+//
+// Two checks run against packages/mcp-server/package.json:
+//
+//   Check 1 — Resolution. Every target path referenced by the exports map
+//             (across all conditional shapes: string, or object with
+//             types/import/require/default) must exist on disk relative to
+//             packages/mcp-server/. Catches deleted/renamed source files
+//             that would silently break downstream consumers at install
+//             time.
+//
+//   Check 2 — Exclusion. A small set of subpaths is deliberately scoped
+//             out of the public surface. Any future addition of these
+//             subpaths to the exports map is a deliberate widening and
+//             should be a discrete decision, not a drive-by add.
+//
+// A third check — a coverage manifest declaring "consumer expects subpath
+// X to exist" — was considered and deferred. Such a manifest just shifts
+// the discipline elsewhere without a clear ownership story, and the
+// YAGNI risk is real. If consumer breakage from a missing-but-expected
+// subpath becomes a real problem, revisit by either (a) seeding the
+// manifest from observed downstream imports or (b) running downstream
+// consumer test suites as a CI matrix.
+//
+// Run from anywhere — paths resolve relative to this script's location.
+// Exits 0 on pass, 1 on fail.
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(__dirname, "..");
+const packageJsonPath = resolve(packageRoot, "package.json");
+
+// Subpaths deliberately scoped out of the public surface. Each exclusion
+// is a maintenance-contract decision — adding any of these to the exports
+// map should be a discrete PR, not an incidental change.
+//
+//   ./plugins                — plugin loader internals; not part of the
+//                              consumer-facing surface.
+//   ./index                  — package root entry; reserved (the package
+//                              ships via dist/server/bin, not src/index).
+//   ./utils/output-formatter — MCP-response formatting helper, coupled to
+//                              MCP server response shape; not for reuse.
+//
+// The prefix ./server/ is excluded wholesale: the server/ directory is a
+// build output and any subpath under it would expose build internals.
+const EXCLUDED_SUBPATHS = new Set([
+  "./plugins",
+  "./index",
+  "./utils/output-formatter",
+]);
+const EXCLUDED_PREFIXES = ["./server/"];
+
+// Conditional exports may use any of the Node-defined conditions (types,
+// import, require, default) plus user-defined ones. The walker recurses
+// across every key it finds rather than gating on a known list, so a
+// future condition (e.g. node, browser) does not silently hide a target.
+
+function collectTargets(entry, subpath) {
+  if (typeof entry === "string") {
+    return [{ condition: null, target: entry }];
+  }
+  if (entry && typeof entry === "object") {
+    const targets = [];
+    for (const key of Object.keys(entry)) {
+      const value = entry[key];
+      if (typeof value !== "string") {
+        // Nested conditional shape (e.g. { import: { types: ..., default: ... } })
+        // is legal in Node's exports spec. Recurse.
+        targets.push(
+          ...collectTargets(value, subpath).map((t) => ({
+            condition: t.condition ? `${key}.${t.condition}` : key,
+            target: t.target,
+          }))
+        );
+        continue;
+      }
+      targets.push({ condition: key, target: value });
+    }
+    return targets;
+  }
+  throw new Error(
+    `Unexpected exports entry shape for "${subpath}": ${JSON.stringify(entry)}`
+  );
+}
+
+function main() {
+  const pkg = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+  const exportsMap = pkg.exports;
+
+  if (!exportsMap || typeof exportsMap !== "object") {
+    console.error(
+      `verify-exports-surface: no exports map found in ${packageJsonPath}`
+    );
+    process.exit(1);
+  }
+
+  const resolutionFailures = [];
+  const exclusionFailures = [];
+
+  for (const subpath of Object.keys(exportsMap)) {
+    // Check 2: exclusion
+    if (EXCLUDED_SUBPATHS.has(subpath)) {
+      exclusionFailures.push({
+        subpath,
+        reason: `listed in EXCLUDED_SUBPATHS`,
+      });
+    } else {
+      for (const prefix of EXCLUDED_PREFIXES) {
+        if (subpath.startsWith(prefix)) {
+          exclusionFailures.push({
+            subpath,
+            reason: `matches excluded prefix "${prefix}"`,
+          });
+          break;
+        }
+      }
+    }
+
+    // Check 1: resolution
+    const targets = collectTargets(exportsMap[subpath], subpath);
+    for (const { condition, target } of targets) {
+      if (typeof target !== "string" || !target.startsWith("./")) {
+        resolutionFailures.push({
+          subpath,
+          condition,
+          target,
+          reason: `target is not a relative path starting with "./"`,
+        });
+        continue;
+      }
+      const absolute = resolve(packageRoot, target);
+      if (!existsSync(absolute)) {
+        resolutionFailures.push({
+          subpath,
+          condition,
+          target,
+          reason: `target file does not exist at ${absolute}`,
+        });
+      }
+    }
+  }
+
+  let failed = false;
+
+  if (resolutionFailures.length > 0) {
+    failed = true;
+    console.error("");
+    console.error("Check 1 (Resolution) FAILED:");
+    for (const f of resolutionFailures) {
+      const cond = f.condition ? ` [${f.condition}]` : "";
+      console.error(`  ${f.subpath}${cond} -> ${f.target}`);
+      console.error(`    ${f.reason}`);
+    }
+  }
+
+  if (exclusionFailures.length > 0) {
+    failed = true;
+    console.error("");
+    console.error("Check 2 (Exclusion) FAILED:");
+    for (const f of exclusionFailures) {
+      console.error(`  ${f.subpath}`);
+      console.error(`    ${f.reason}`);
+    }
+    console.error("");
+    console.error(
+      "  Adding an excluded subpath to the exports map is a deliberate"
+    );
+    console.error(
+      "  widening of the public surface. If intentional, update the"
+    );
+    console.error(
+      "  EXCLUDED_SUBPATHS / EXCLUDED_PREFIXES list in this script with"
+    );
+    console.error("  a comment explaining the new policy.");
+  }
+
+  if (failed) {
+    console.error("");
+    console.error("verify-exports-surface: FAIL");
+    process.exit(1);
+  }
+
+  const entryCount = Object.keys(exportsMap).length;
+  console.log(
+    `verify-exports-surface: OK (${entryCount} entries, all targets resolve, no excluded subpaths present)`
+  );
+}
+
+main();


### PR DESCRIPTION
Worktree: /home/romeo/code/tradeblocks-org/tradeblocks-romeo-78-phase-5b-exports-durability-gate

**Stacked on #308.** PR base is `romeo/78-phase-5a-boundary-exposure` (not master). Review only the single commit on top — GitHub will auto-update the base to `feat/tradeblocks-3.0` once #308 merges, at which point this becomes a clean standalone PR against the dev branch.

## What it does

Adds a CI verifier (`packages/mcp-server/scripts/verify-exports-surface.mjs`) that defends the `exports` map introduced by #308 against drift. Two checks:

### Check 1 — Resolution
Every entry in `packages/mcp-server/package.json`'s `exports` map must resolve to a file that exists on disk. Walks the conditional shape (string entries, flat objects with `types`/`import`/`require`/`default`, nested conditionals — handled via recursion that walks all keys rather than gating on a known condition list). Catches refactor-deletes-file-but-forgets-to-remove-from-exports failures that would otherwise break sibling consumers at install time with no signal here.

### Check 2 — Exclusion
Hardcoded list of subpaths that must NOT appear in the exports map:
- `./plugins`
- `./index`
- `./utils/output-formatter`
- Anything under `./server/`

These surfaces exist as source files (or build outputs) but were deliberately excluded from #308's exports map. If a future PR adds them, exit 1 with a clear message pointing at the deliberate-scoping rationale. A future PR that does want to widen the surface needs to be a discrete decision, not a drive-by.

### Check 3 — Coverage manifest (deferred)
Script header documents why a manifest-based coverage check was deferred for v1 (YAGNI — shifts discipline elsewhere without solving the underlying drift problem). Future PR can add it with the rationale in the header for context.

## Implementation

- **`packages/mcp-server/scripts/verify-exports-surface.mjs`** — new, 193 LOC, pure Node stdlib (`node:fs`, `node:path`, `node:url`). No dependencies.
- **`.github/workflows/ci.yml`** — +6 lines, new step in the existing `import-boundary` job. Sits alongside #302's reverse-import and no-file-deps gates. Same lightweight feel (no `npm ci` needed, single `node ...` invocation against the checked-out tree).
- **`packages/mcp-server/package.json`** — +1 line, `verify:exports` npm script entry.

Colocation rationale: this repo's existing pattern places per-package scripts under `packages/<pkg>/scripts/` (e.g. `pack-mcpb.js`, `copy-provider-assets.mjs`). No top-level `scripts/` exists. The verifier follows the established pattern.

## Verification

- `node packages/mcp-server/scripts/verify-exports-surface.mjs` on current tree: `OK (25 entries, all targets resolve, no excluded subpaths present)`, exit 0.
- **Sanity check 1** (force-fail): injected a non-existent target file path → Check 1 fired with absolute-path diagnostic for both `[types]` and `[import]` conditions, exit 1. Reverted.
- **Sanity check 2** (force-fail): injected `./plugins` and `./server/index` into exports map → Check 2 fired with distinct messages for exact-match and prefix-match cases, exit 1. Reverted.
- `npm run lint` (root): clean.
- `npm test` (root): **73 suites / 1256 tests pass**.
- `npm test` (packages/mcp-server): **120 suites / 1566 tests pass**.

## Pre-PR Worf gate: PASS WITH NOTES

- **Tier:** Tier 3 (public-repo CI workflow change + public-package package.json script entry).
- **Vocab discipline:** clean across the script, package.json hunk, ci.yml hunk, and commit message.
- **Conditional-exports walker:** verified to handle string, flat-object, and nested-conditional shapes.
- **Sanity checks reproduced** by Worf independently.
- **CI step soundness:** non-piped `run:`, no silent-pass risk, fires on `pull_request` to master (same trigger pattern as the existing boundary gates).

Worf flagged four non-blocking notes:

1. **PR base flag (handled).** `--base romeo/78-phase-5a-boundary-exposure` was set explicitly at PR-create time per Worf's reminder.
2. **Bare-string `exports` edge case.** If a future PR sets `pkg.exports` to a single string (legal Node spec), the script reports "no exports map found" rather than walking it. Non-issue today; flagged for future-engineer context.
3. **Coverage-manifest deferral well-documented** in the script header. No action.
4. **Pre-existing trigger limitation.** All three import-boundary gates only fire on PRs targeting master. PRs into release branches would skip. Inherits from #302's pattern; not a PR-5B regression.

## Net diff

3 files changed: `packages/mcp-server/scripts/verify-exports-surface.mjs` (new, +193), `.github/workflows/ci.yml` (+6), `packages/mcp-server/package.json` (+1).