### PR TITLE
docs(market-stores+tickers): scrub internal-ticket vocab from public-lib docs

### DIFF
--- a/packages/mcp-server/src/market/stores/chain-sql.ts
+++ b/packages/mcp-server/src/market/stores/chain-sql.ts
@@ -1,12 +1,12 @@
 /**
- * Pure SQL builder for ChainStore reads (Market Data 3.0 — Phase 2 Wave 1).
+ * Pure SQL builder for ChainStore reads.
  *
  * Option chains are partitioned by (underlying, date). A single `readChain`
  * call targets exactly one partition, so the builder binds two positional
  * parameters: $1=underlying, $2=date.
  *
- * Purity contract (CONTEXT.md D-05): no `this`, no `ctx`, no DuckDB value-level
- * imports. Tests in `tests/unit/market/stores/chain-sql.test.ts`.
+ * Purity contract: no `this`, no `ctx`, no DuckDB value-level imports. Tests
+ * in `tests/unit/market/stores/chain-sql.test.ts`.
  */
 import type { BuiltSQL } from "./spot-sql.js";
 

--- a/packages/mcp-server/src/market/stores/enriched-sql.ts
+++ b/packages/mcp-server/src/market/stores/enriched-sql.ts
@@ -1,5 +1,5 @@
 /**
- * Pure SQL builder for EnrichedStore reads (Market Data 3.0 — Phase 2 Wave 1).
+ * Pure SQL builder for EnrichedStore reads.
  *
  * The enriched read supports two optional joins controlled by flags:
  *   - `includeOhlcv`   → LEFT JOIN a daily RTH aggregate of `market.spot`
@@ -11,9 +11,8 @@
  * (`$1=ticker`, `$2=from`, `$3=to`) — the builder never duplicates params
  * just because a flag is flipped.
  *
- * Purity contract (PATTERNS.md "Pure SQL builders"; CONTEXT.md D-05): no `this`,
- * no `ctx`, no DB-connection value-level imports. Tests live in
- * `tests/unit/market/stores/enriched-sql.test.ts`.
+ * Purity contract: no `this`, no `ctx`, no DB-connection value-level imports.
+ * Tests live in `tests/unit/market/stores/enriched-sql.test.ts`.
  */
 import { rthDailyAggregateSubquery } from "./rth-aggregation.js";
 import type { BuiltSQL } from "./spot-sql.js";

--- a/packages/mcp-server/src/market/stores/quote-sql.ts
+++ b/packages/mcp-server/src/market/stores/quote-sql.ts
@@ -1,11 +1,10 @@
 /**
- * Pure SQL builder for QuoteStore reads (Market Data 3.0 — Phase 2 Wave 1).
+ * Pure SQL builder for QuoteStore reads.
  *
- * Emits the multi-ticker grouped-series read pattern (CONTEXT.md D-06): one
- * partition targeted by underlying + date range, with an `IN (...)` filter over
- * the OCC ticker list. Callers are responsible for having validated that every
- * OCC ticker resolves to the same underlying (D-07); this builder trusts its
- * caller on that front.
+ * Emits a multi-ticker grouped-series read: one partition targeted by
+ * underlying + date range, with an `IN (...)` filter over the OCC ticker list.
+ * Callers are responsible for having validated that every OCC ticker resolves
+ * to the same underlying; this builder trusts its caller on that front.
  *
  * Param layout:
  *   $1        → underlying
@@ -13,8 +12,8 @@
  *   $3        → to   (date)
  *   $4..$N    → occTickers (variable-length IN list)
  *
- * Purity contract (CONTEXT.md D-05): pure function, no DuckDB value-level
- * imports. Tests in `tests/unit/market/stores/quote-sql.test.ts`.
+ * Purity contract: pure function, no DuckDB value-level imports. Tests in
+ * `tests/unit/market/stores/quote-sql.test.ts`.
  */
 import type { BuiltSQL } from "./spot-sql.js";
 

--- a/packages/mcp-server/src/market/stores/spot-sql.ts
+++ b/packages/mcp-server/src/market/stores/spot-sql.ts
@@ -1,18 +1,19 @@
 /**
- * Pure SQL builders for SpotStore reads (Market Data 3.0 — Phase 2 Wave 1).
+ * Pure SQL builders for SpotStore reads.
  *
  * Every export is a pure function: given primitive inputs, it returns
  * `{ sql, params }` where `params` are positional bindings for DuckDB's
  * `$1`/`$2`/`$3` placeholders.
  *
- * Purity contract (CONTEXT.md D-05, PATTERNS.md "Pure SQL builders"):
+ * Purity contract:
  *   - No `this` / no `ctx` / no DB-connection value-level import
  *   - No side effects; no IO
- *   - Composable — concrete stores in Waves 2-3 feed the result to `conn.run()`
+ *   - Composable — concrete stores feed the result to `conn.run()`
  *
- * Security note (T-2-02): user-controlled values (ticker, from, to) are bound
+ * Security note: user-controlled values (ticker, from, to) are bound
  * positionally. The SQL strings never interpolate untrusted text. Partition-
- * value whitelisting + positional binding together mitigate SQL injection.
+ * value whitelisting at higher layers plus positional binding here together
+ * mitigate SQL injection.
  */
 
 /**
@@ -47,9 +48,8 @@ export function buildReadBarsSQL(
  * Aggregate minute bars in `market.spot` into RTH daily OHLCV rows.
  *
  * Uses DuckDB aggregate `first(col ORDER BY time)` / `last(col ORDER BY time)`
- * idioms (PATTERNS.md "rth-aggregation.ts"; RESEARCH.md Pitfall 3). Window-
- * function equivalents are explicitly avoided — they do NOT coexist with
- * `GROUP BY` and are a common source of incorrect ordering.
+ * idioms. Window-function equivalents are explicitly avoided — they do NOT
+ * coexist with `GROUP BY` and are a common source of incorrect ordering.
  */
 export function buildReadDailyBarsSQL(
   ticker: string,
@@ -87,9 +87,8 @@ export function buildReadDailyBarsSQL(
 /**
  * Project `(date, open)` using the RTH first-open aggregate.
  *
- * Used by the enricher Tier 2 VIX RTH open call site (RESEARCH.md "Enricher IO
- * Refactor Surface" call site 5) where only the opening tick of the VIX family
- * is needed for term-structure context computation.
+ * Used by the enricher's VIX RTH open path, where only the opening tick of
+ * the VIX family is needed for term-structure context computation.
  */
 export function buildReadRthOpensSQL(
   ticker: string,

--- a/packages/mcp-server/src/market/tickers/registry.ts
+++ b/packages/mcp-server/src/market/tickers/registry.ts
@@ -4,14 +4,14 @@
  * Seeded from bundled defaults (defaults.json). User-added entries via register()
  * persist to {dataRoot}/market/underlyings.json via saveUserOverride (loader.ts).
  *
- * Identity of this class (`TickerRegistry`, `TickerEntry`, `EntrySource`) is preserved
- * from the Plan 01-01 forward-declaration stub so `src/market/stores/types.ts` keeps
- * its type-only import intact.
+ * `src/market/stores/types.ts` imports `TickerRegistry`, `TickerEntry`, and
+ * `EntrySource` as types — keep those exported names stable.
  *
- * Defense-in-depth security layer 2 per RESEARCH.md Pitfall 3: every stored value is
- * validated against TICKER_RE at construction and at register() time. The MCP-tool
- * layer (Plan 05) applies the same regex at the Zod boundary; the writer (Plan 03)
- * applies its own whitelist at the partition-value boundary.
+ * Defense-in-depth: every stored value is validated against TICKER_RE at
+ * construction and at register() time. The MCP-tool layer applies the same
+ * regex at the Zod boundary; the writer applies its own whitelist at the
+ * partition-value boundary. Each layer is independently sufficient; together
+ * they prevent malformed/injected ticker strings from reaching DuckDB.
  */
 import { TICKER_RE } from "./schemas.js";
 
@@ -85,7 +85,9 @@ export class TickerRegistry {
 
   /**
    * Resolve a root symbol to its underlying.
-   * Identity fallback (returns the root unchanged) when unknown — per CONTEXT.md D-05.
+   * Identity fallback (returns the root unchanged) when unknown — unknown
+   * roots are treated as their own underlying so single-symbol tickers
+   * (e.g. leveraged ETFs) keep working without explicit registration.
    */
   resolve(root: string): string {
     return this.rootMap.get(root)?.underlying ?? root;
@@ -96,7 +98,7 @@ export class TickerRegistry {
    * - New underlying (not a bundled default): source = "user"
    * - Overriding a bundled default: source = "user-override"
    *
-   * @throws on invalid characters in `underlying` or any `root` (T-1-02 defense layer 2).
+   * @throws on invalid characters in `underlying` or any `root` (defense-in-depth — see file header).
    */
   register(entry: { underlying: string; roots: string[] }): TickerEntry {
     validate(entry.underlying, entry.roots);

--- a/packages/mcp-server/src/market/tickers/resolver.ts
+++ b/packages/mcp-server/src/market/tickers/resolver.ts
@@ -9,7 +9,7 @@
  * cannot import it). If the OCC-ticker regex is ever updated in one place,
  * update the other as well.
  */
-import type { TickerRegistry } from "./registry.js"; // TYPE-ONLY — break runtime cycle (Pitfall 10)
+import type { TickerRegistry } from "./registry.js"; // TYPE-ONLY — break runtime cycle with registry.ts
 
 // OCC-like option ticker shape: root + YYMMDD + C/P + 6-11 digit strike.
 // Standard OCC encodes strike × 1000 in 8 digits, but ThetaData emits wider
@@ -40,9 +40,9 @@ export function extractRoot(input: string): string {
 
 /**
  * Resolve any OCC ticker or bare root to its underlying.
- * Unknown roots return themselves (identity fallback per CONTEXT.md D-05) —
- * this is how leveraged ETFs (SPXL/SPXS/SPXU/SPXC) and any new symbol stay
- * correct without explicit registry entries.
+ * Unknown roots return themselves (identity fallback) — this is how
+ * leveraged ETFs (SPXL/SPXS/SPXU/SPXC) and any new symbol stay correct
+ * without explicit registry entries.
  */
 export function rootToUnderlying(input: string, registry: TickerRegistry): string {
   const root = extractRoot(input);


### PR DESCRIPTION
Tier: 3 (public-repo, doc-only)

## Summary

Pure JSDoc/comment scrub across 6 files in `packages/mcp-server/src/market/`. Removes internal-team vocab (Phase/Wave/Plan labels, D-NN/T-N-NN decision IDs, dangling pointers to private docs) and rewrites each comment to convey the *intent* a public reader needs.

Part 1 of 5 for tradeblocks-org/enterprise#110. Follows the precedent set by #306 (chain-loader) and #307 (quote-enricher).

## Files

- `packages/mcp-server/src/market/stores/{chain,enriched,quote,spot}-sql.ts`
- `packages/mcp-server/src/market/tickers/{registry,resolver}.ts`

+38 / −39 lines. Zero code-path changes; every modified line is a comment line.

## What changed in wording

- **Purity contracts** in `*-sql.ts` files: kept the "no this / no ctx / no DB value-level imports" invariant; dropped the `CONTEXT.md D-05` / `PATTERNS.md` pointers.
- **`spot-sql.ts` security note**: rewrote the `T-2-02` framing as "partition-value whitelisting at higher layers plus positional binding here together mitigate SQL injection" — names *where* each defense layer lives instead of pointing at a ticket.
- **`registry.ts` class header**: rewrote the "Plan 01-01 forward-declaration stub" provenance as the actual invariant — `src/market/stores/types.ts` imports these names as types, so the exported identifiers must stay stable.
- **`registry.ts` defense-in-depth header**: rewrote `RESEARCH.md Pitfall 3` framing into a concrete defense-in-depth explanation and added one sentence — "Each layer is independently sufficient; together they prevent malformed/injected ticker strings from reaching DuckDB."
- **`resolver.ts` + `registry.ts` identity-fallback comments**: replaced the `CONTEXT.md D-05` pointer with a self-contained explanation citing leveraged ETFs (SPXL/SPXS/SPXU/SPXC) as the example.

Two of the rewrites (`resolver.ts:42`, `registry.ts:88-90`) are multi-line and verbose — louder about the example, quieter about the principle. Reader-friendly but worth your eyeball.

## Verification

- Lint clean (`npm run lint -- --max-warnings=0`)
- Typecheck: 3 errors in `utils/exit-triggers.ts` reproduce on `origin/feat/tradeblocks-3.0` baseline — pre-existing, unrelated, untouched by this PR
- Internal-vocab grep on the 6 target files: clean (no Phase/Wave/Plan/D-NN/T-N-NN/SEP/INGEST/RESOLVE/Pitfall/CONTEXT.md/PATTERNS.md/RESEARCH.md/SUMMARY.md/ROADMAP.md tokens)
- Public-boundary grep repo-wide: clean (no holodeck / private-packages / tradeblocks-private leakage)
- Spot-checked each rewrite: technical substance (purity invariants, security posture, type-stability requirement) preserved or sharpened, not weakened

## What I'm asking

Does the new prose read well to an external lib consumer? One pass through the 6 files. The security/purity substance is preserved; the only judgment call is reader-friendliness of the rewrites.

## Test plan

- [x] Lint clean
- [x] Typecheck clean of new errors
- [x] Internal-vocab grep clean on target files
- [x] Public-boundary grep clean repo-wide
- [ ] Smith review

🤖 Generated with [Claude Code](https://claude.com/claude-code)