### PR TITLE
docs(tools): scrub internal-ticket vocab from public-lib docs

### DIFF
--- a/packages/mcp-server/src/tools/exit-analysis.ts
+++ b/packages/mcp-server/src/tools/exit-analysis.ts
@@ -80,7 +80,7 @@ const legSchema = z.object({
 // ---------------------------------------------------------------------------
 
 export const analyzeExitTriggersSchema = z.object({
-  // Replay inputs (same as replay_trade per D-02)
+  // Replay inputs (same shape as replay_trade)
   legs: z.array(legSchema).optional(),
   block_id: z.string().optional(),
   trade_index: z.number().optional(),
@@ -88,15 +88,12 @@ export const analyzeExitTriggersSchema = z.object({
   close_date: z.string().optional(),
   multiplier: z.number().default(100),
 
-  // Trigger configs per D-03
   triggers: z.array(triggerConfigSchema)
     .describe("Exit triggers to evaluate against the P&L path"),
 
-  // Per D-05
   actual_exit_timestamp: z.string().optional()
     .describe("Actual exit time for comparison (format: YYYY-MM-DD HH:MM)"),
 
-  // Per D-06
   leg_groups: z.array(z.object({
     label: z.string(),
     leg_indices: z.array(z.number()),
@@ -120,7 +117,6 @@ export const decomposeGreeksSchema = z.object({
   close_date: z.string().optional(),
   multiplier: z.number().default(100),
 
-  // Per D-08
   leg_groups: z.array(z.object({
     label: z.string(),
     leg_indices: z.array(z.number()),
@@ -155,10 +151,12 @@ function extractUnderlyingTicker(occTicker: string): string {
 
 /**
  * Read VIX, VIX9D, or underlying minute bars via SpotStore and build a
- * timestamp->price map. Phase 4 / SEP-01: reads NEVER trigger provider calls.
- * Falls back to daily aggregates when minute bars are absent (mirrors the
- * pattern in tools/replay.ts:343-358). Empty map on cache miss is the
- * silent-empty contract — callers treat absent data as "trigger inactive."
+ * timestamp->price map. Reads NEVER trigger provider calls — bars are
+ * served from the local store, with a daily-aggregate fallback when
+ * minute bars are absent (same pattern used in replay.ts for underlying
+ * fetches). An empty map on cache miss is the silent-empty contract —
+ * callers treat absent data as "trigger inactive" rather than as an
+ * error.
  */
 async function fetchPriceMap(
   stores: MarketStores,
@@ -205,7 +203,7 @@ async function fetchPriceMap(
 export async function handleAnalyzeExitTriggers(
   params: z.infer<typeof analyzeExitTriggersSchema>,
   baseDir: string,
-  stores: MarketStores,   // Phase 4 CONSUMER-01 — threaded through for Wave 2+ rewrite.
+  stores: MarketStores,
   injectedConn?: import("@duckdb/node-api").DuckDBConnection,
 ): Promise<ReturnType<typeof analyzeExitTriggers>> {
   const {
@@ -235,7 +233,7 @@ export async function handleAnalyzeExitTriggers(
   const pnlPath = replayResult.pnlPath;
   const replayLegs = replayResult.legs;
 
-  // Compute entry cost for percentage-based triggers (D-11)
+  // Compute entry cost for percentage-based triggers
   const entryCost = replayLegs.reduce((sum, leg) => {
     return sum + leg.entryPrice * leg.quantity * leg.multiplier;
   }, 0);
@@ -344,7 +342,7 @@ export async function handleAnalyzeExitTriggers(
 export async function handleDecomposeGreeks(
   params: z.infer<typeof decomposeGreeksSchema>,
   baseDir: string,
-  stores: MarketStores,   // Phase 4 CONSUMER-01 — threaded through for Wave 2+ rewrite.
+  stores: MarketStores,
   injectedConn?: import("@duckdb/node-api").DuckDBConnection,
 ): Promise<import("../utils/greeks-decomposition.js").GreeksDecompositionResult> {
   const {
@@ -446,7 +444,7 @@ export async function handleDecomposeGreeks(
 export function registerExitAnalysisTools(
   server: McpServer,
   baseDir: string,
-  stores: MarketStores,   // Phase 4 CONSUMER-01 — threaded through for Wave 2+ rewrite.
+  stores: MarketStores,
 ): void {
   server.registerTool(
     "analyze_exit_triggers",

--- a/packages/mcp-server/src/tools/greeks-attribution.ts
+++ b/packages/mcp-server/src/tools/greeks-attribution.ts
@@ -173,7 +173,7 @@ export function assessPrecision(
 export async function handleGetGreeksAttribution(
   params: z.infer<typeof getGreeksAttributionSchema>,
   baseDir: string,
-  stores: MarketStores,   // Phase 4 CONSUMER-01 — threaded through for Wave 2+ rewrite.
+  stores: MarketStores,
   injectedConn?: import("@duckdb/node-api").DuckDBConnection,
 ): Promise<AttributionSummaryResult | AttributionInstanceResult> {
   const { block_id, mode, trade_index, skip_quotes, detailed, strategy } = params;
@@ -194,7 +194,7 @@ async function handleSummaryMode(
   detailed: boolean,
   strategy: string | undefined,
   baseDir: string,
-  stores: MarketStores,   // Phase 4 CONSUMER-01 — threaded for Wave 2+ handler-body rewrite.
+  stores: MarketStores,
   injectedConn?: import("@duckdb/node-api").DuckDBConnection,
 ): Promise<AttributionSummaryResult> {
   const conn = injectedConn ?? await getConnection(baseDir);
@@ -340,7 +340,7 @@ async function handleInstanceMode(
   skip_quotes: boolean,
   detailed: boolean,
   baseDir: string,
-  stores: MarketStores,   // Phase 4 CONSUMER-01 — threaded for Wave 2+ handler-body rewrite.
+  stores: MarketStores,
   injectedConn?: import("@duckdb/node-api").DuckDBConnection,
 ): Promise<AttributionInstanceResult> {
   const conn = injectedConn ?? await getConnection(baseDir);
@@ -378,15 +378,11 @@ async function handleInstanceMode(
   // Build per-step entries from factor step arrays
   const stepCount = result.stepCount;
 
-  // Phase 4 Plan 04-04: weekday iteration replaces the prior raw SQL
-  // `SELECT DISTINCT date FROM market.spot WHERE date BETWEEN ...`.
-  // The handler uses this purely to map step indices → dates, and the
-  // original query returned every trading day with intraday coverage (i.e.
-  // every weekday in the range — SPX has dense coverage). `tradingDays()`
-  // from flatfile-importer is a pure Mon-Fri iterator that delivers the
-  // same set for the 2023+ range this handler operates over.
-  // Note: `conn` is still used above for the trade-row fetch; only this
-  // market-data probe migrated.
+  // Map step indices → dates via a pure Mon-Fri trading-day iterator.
+  // Replays operate over date ranges with dense intraday coverage, so the
+  // weekday iteration matches the set of dates the decomposition produced
+  // (one step per trading day). `conn` is still used above for the trade
+  // row fetch — only the date probe is store-free.
   const tradingDates = tradingDays(tradeDate, closeDate);
   const getStepDate = (i: number): string =>
     i < tradingDates.length ? tradingDates[i] : `day-${i}`;
@@ -468,7 +464,7 @@ function getStepValue(
 export function registerGreeksAttributionTools(
   server: McpServer,
   baseDir: string,
-  stores: MarketStores,   // Phase 4 CONSUMER-01 — threaded through for Wave 2+ rewrite.
+  stores: MarketStores,
 ): void {
   server.registerTool(
     "get_greeks_attribution",

--- a/packages/mcp-server/src/tools/market-data.ts
+++ b/packages/mcp-server/src/tools/market-data.ts
@@ -204,11 +204,6 @@ function recordsByTickerDate(
   return mapped;
 }
 
-// `buildRequestedPairsClause` was the SQL-builder for the enrich_trades intraday
-// JOIN against `WITH requested(ticker, date) AS (VALUES ...)`. Removed in
-// Phase 4 Plan 04-02 — the intraday read now flows through SpotStore.readBars
-// per (ticker, date) pair, which makes the VALUES clause unnecessary.
-
 /**
  * Get volatility regime label
  */
@@ -264,7 +259,7 @@ function getDayLabel(dow: number): string {
 export function registerMarketDataTools(
   server: McpServer,
   baseDir: string,
-  stores: MarketStores,   // Phase 4 — checkDataAvailability call sites + enrich_trades / compute_orb read via SpotStore.
+  stores: MarketStores,
 ): void {
   // ---------------------------------------------------------------------------
   // analyze_regime_performance - Break down performance by market regime
@@ -642,10 +637,10 @@ export function registerMarketDataTools(
           { name: "Skip Mondays", field: "Day_of_Week", operator: "==", value: 2, test: (m) => getNum(m, "Day_of_Week") === 2, lagged: false },
           // OPEX
           { name: "Skip OPEX days", field: "Is_Opex", operator: "==", value: 1, test: (m) => getNum(m, "Is_Opex") === 1, lagged: false },
-          // VIX_Open filters (new, BIAS-05)
+          // VIX_Open filters (open-known)
           { name: "Skip when VIX_Open > 25", field: "VIX_Open", operator: ">", value: 25, test: (m) => getNum(m, "VIX_Open") > 25, lagged: false },
           { name: "Skip when VIX_Open > 30", field: "VIX_Open", operator: ">", value: 30, test: (m) => getNum(m, "VIX_Open") > 30, lagged: false },
-          // VIX_Gap_Pct filters (new, BIAS-05)
+          // VIX_Gap_Pct filters (open-known)
           { name: "Skip when |VIX_Gap_Pct| > 10%", field: "VIX_Gap_Pct", operator: ">", value: 10, test: (m) => Math.abs(getNum(m, "VIX_Gap_Pct")) > 10, lagged: false },
           { name: "Skip when |VIX_Gap_Pct| > 15%", field: "VIX_Gap_Pct", operator: ">", value: 15, test: (m) => Math.abs(getNum(m, "VIX_Gap_Pct")) > 15, lagged: false },
 
@@ -978,11 +973,9 @@ export function registerMarketDataTools(
         let intradayBarsByKey: Map<string, Array<{time: string, open: number, high: number, low: number, close: number}>> | null = null;
 
         if (includeIntradayContext) {
-          // Phase 4 Plan 04-02: read intraday bars per (ticker, date) via SpotStore
-          // instead of a raw-SQL JOIN against the spot view.
-          // The store reads partitioned spot data and returns BarRow[] in (date, time)
-          // order; we group by ticker+date to preserve the prior shape used by the
-          // downstream consumer.
+          // Read intraday bars per (ticker, date) via SpotStore. The store
+          // returns BarRow[] in (date, time) order; we group by ticker+date
+          // so the downstream consumer can index by trade key.
           intradayBarsByKey = new Map<string, Array<{time: string, open: number, high: number, low: number, close: number}>>();
           for (const key of tradeKeys) {
             const bars = await stores.spot.readBars(key.ticker, key.date, key.date);
@@ -1187,11 +1180,9 @@ export function registerMarketDataTools(
         // Check data availability
         const availability = await checkDataAvailability(stores, normalizedTicker, { checkIntraday: true });
 
-        // Phase 4 Plan 04-02: data availability + bar reads now flow through SpotStore
-        // (replaces the prior `COUNT(*)` data-availability probe, the auto-detect
-        // distinct-time SQL, and the ORB CTE pair). The window aggregation &
-        // breakout-detection logic is computed in TypeScript over the BarRow[]
-        // returned by readBars.
+        // Data availability + bar reads flow through SpotStore; the window
+        // aggregation and breakout-detection logic runs in TypeScript over
+        // the BarRow[] returned by readBars.
 
         // Quick check: is there any spot data for this ticker over the requested range?
         // Use a wide bracket so the "no data at all" case is distinguishable from
@@ -1255,8 +1246,7 @@ export function registerMarketDataTools(
         }
 
         // Read all in-range bars and group by date for ORB computation. The
-        // `useHighLow` toggle picks raw high/low vs close-of-bar high/low — same
-        // semantics the previous SQL CTE used.
+        // `useHighLow` toggle picks raw high/low vs close-of-bar high/low.
         const allBars = await stores.spot.readBars(normalizedTicker, startDate, end);
 
         // Group by date, preserving (time)-ascending order from readBars.
@@ -1291,7 +1281,8 @@ export function registerMarketDataTools(
           entry_triggered: boolean;
         }
 
-        // Compute ORB window + breakouts per date (replaces the SQL CTE pair).
+        // Compute ORB window + breakouts per date in TypeScript over the
+        // grouped bars.
         const days: OrbDayResult[] = [];
         const sortedDates = [...barsByDate.keys()].sort();
         for (const date of sortedDates) {

--- a/packages/mcp-server/src/tools/market-enrichment.ts
+++ b/packages/mcp-server/src/tools/market-enrichment.ts
@@ -2,23 +2,26 @@
  * Market Enrichment Tools
  *
  * MCP tool for computing technical indicator fields from raw OHLCV data in
- * market.spot_daily (including VIX tickers) and writing derived fields to market.enriched_context.
+ * market.spot_daily (including VIX tickers) and writing derived fields to
+ * market.enriched + market.enriched_context.
  *
  * Tools registered:
- *   - enrich_market_data — Run three-tier enrichment pipeline for a ticker
+ *   - enrich_market_data — Run the three-tier enrichment pipeline for a ticker
  *
  * Follows the RW lifecycle:
  *   upgradeToReadWrite → enrichment → downgradeToReadOnly (in finally)
  *
- * Plan 04-05: handler now delegates to `stores.enriched.compute` (and
- * `stores.enriched.computeContext` for the VIX family) instead of calling
- * the enrichment runner directly. The store layer injects the JSON-backed
- * watermark IO (Phase 2 D-20) — no `market._sync_metadata` SQL is touched
- * from this file any more.
+ * Handler delegates to `stores.enriched.compute` (and
+ * `stores.enriched.computeContext` for the VIX family) — the store layer
+ * owns watermark IO via the JSON adapters in db/json-adapters.ts; no
+ * `market._sync_metadata` SQL is touched from this file.
  *
- * Tier 1: Computes ~20 fields from market.spot_daily OHLCV (RSI, ATR, EMA, SMA, realized vol, etc.) into market.enriched
- * Tier 2: Computes VIX IVR/IVP in market.enriched and derived fields (Vol_Regime, Term_Structure_State) in market.enriched_context
- * Tier 3: Intraday timing fields (High_Time, Low_Time, Reversal_Type) — always skipped until intraday CSV format is updated
+ * Tier 1: Computes ~20 fields from market.spot_daily OHLCV (RSI, ATR, EMA,
+ *   SMA, realized vol, etc.) into market.enriched.
+ * Tier 2: Computes VIX IVR/IVP in market.enriched and derived fields
+ *   (Vol_Regime, Term_Structure_State) in market.enriched_context.
+ * Tier 3: Intraday timing fields (High_Time, Low_Time, Reversal_Type) —
+ *   always skipped until intraday CSV format is updated.
  */
 
 import { z } from "zod";
@@ -34,7 +37,8 @@ const VIX_FAMILY = new Set(["VIX", "VIX9D", "VIX3M"]);
  *
  * @param server  - McpServer instance to register tools on
  * @param baseDir - Base data directory (used by the RW upgrade lifecycle)
- * @param stores  - MarketStores bundle (Phase 4 CONSUMER-01 — handler delegates to stores.enriched.{compute, computeContext})
+ * @param stores  - MarketStores bundle; the handler delegates to
+ *                  stores.enriched.{compute, computeContext}
  */
 export function registerMarketEnrichmentTools(
   server: McpServer,
@@ -63,7 +67,7 @@ export function registerMarketEnrichmentTools(
           .boolean()
           .default(false)
           .describe(
-            "(Currently a no-op against the store-backed compute path — see plan 04-05 SUMMARY.) " +
+            "Currently a no-op against the store-backed compute path. " +
             "Originally cleared the enriched_through watermark and recomputed all rows from scratch."
           ),
       }),
@@ -72,18 +76,19 @@ export function registerMarketEnrichmentTools(
       await upgradeToReadWrite(baseDir);
       try {
         const upperTicker = ticker.toUpperCase();
-        // Plan 04-05: from/to are informational only — ParquetEnrichedStore.compute
-        // ignores them and uses the watermark + 200-day lookback (D-14). Pass
-        // empty strings to satisfy the typed signature; downstream math is unchanged.
+        // from/to are informational only — ParquetEnrichedStore.compute
+        // ignores them and uses the persisted watermark + 200-day lookback
+        // window. Pass empty strings to satisfy the typed signature;
+        // downstream math is unchanged.
         await stores.enriched.compute(upperTicker, "", "");
         let contextComputed = false;
         if (VIX_FAMILY.has(upperTicker)) {
           await stores.enriched.computeContext("", "");
           contextComputed = true;
         }
-        // WR-07: force_full is a documented no-op against the store-backed compute
-        // path. Surface it explicitly in the response so MCP users see that the
-        // flag was ignored (silent acceptance was misleading).
+        // force_full is a documented no-op against the store-backed compute
+        // path. Surface it explicitly in the response so MCP users see that
+        // the flag was ignored (silent acceptance was misleading).
         const warning = force_full
           ? "force_full=true was ignored: the store-backed compute path is watermark-driven. To fully reseed, rerun import_market_csv with reset semantics, then re-run this tool."
           : undefined;

--- a/packages/mcp-server/src/tools/market-imports.ts
+++ b/packages/mcp-server/src/tools/market-imports.ts
@@ -1,25 +1,24 @@
 /**
- * Market Import Tools (Phase 4 Plan 04-07 — INGEST-01 / D-22 / D-23)
+ * Market Import Tools
  *
  * MCP tools for importing market data into the spot dataset via SpotStore.
- * Daily and date_context outputs are now DERIVED from EnrichedStore.compute()
- * + computeContext() — no more `target_table` branching at the tool surface.
+ * Daily and date_context outputs are derived from EnrichedStore.compute() and
+ * computeContext() — there is no `target_table` branching at the tool surface;
+ * the import always writes to spot, then derives downstream tables.
  *
  * Tools registered:
  *   - import_market_csv    — Import minute bars from CSV → SpotStore.writeBars
  *   - import_from_database — Import minute bars from external DuckDB → SpotStore.writeBars
  *
- * Lifecycle (Pitfall 9 — preserved exactly):
+ * RW lifecycle (preserved exactly — DuckDB requires the upgrade for write):
  *   await upgradeToReadWrite(baseDir);
  *   try { ...store writes + enrichment... }
  *   finally { await downgradeToReadOnly(baseDir); }
  *
- * D-22: import_market_csv + import_from_database drop `target_table` from their
- *       Zod schemas. Hard remove, no deprecation shim.
- * D-23: After every successful SpotStore.writeBars(), the tool handler calls
- *       stores.enriched.compute(ticker, minDate, maxDate). For the VIX family
- *       (VIX, VIX9D, VIX3M) it also calls stores.enriched.computeContext(...)
- *       to refresh the cross-ticker date_context output.
+ * After every successful SpotStore.writeBars(), the tool handler calls
+ * stores.enriched.compute(ticker, minDate, maxDate). For the VIX family
+ * (VIX, VIX9D, VIX3M) it also calls stores.enriched.computeContext(...) to
+ * refresh the cross-ticker date_context output.
  */
 
 import { z } from "zod";
@@ -37,7 +36,7 @@ import type { MarketStores } from "../market/stores/index.js";
 import type { BarRow } from "../market/stores/types.js";
 
 // ---------------------------------------------------------------------------
-// VIX family — used to gate stores.enriched.computeContext (D-23)
+// VIX family — used to gate stores.enriched.computeContext after a write
 // ---------------------------------------------------------------------------
 
 const VIX_FAMILY = new Set(["VIX", "VIX9D", "VIX3M"]);
@@ -59,7 +58,7 @@ function groupBarsByDate(bars: BarRow[]): Map<string, BarRow[]> {
 
 /**
  * Run `stores.enriched.compute(ticker, ...)` and (for VIX-family tickers)
- * `stores.enriched.computeContext(...)` AFTER a spot write completes (D-23).
+ * `stores.enriched.computeContext(...)` after a spot write completes.
  *
  * Loud failure: if compute() throws, the caller surfaces an error response
  * (so the user knows the spot write succeeded but the enrichment did not).
@@ -78,8 +77,8 @@ async function autoEnrichAfterWrite(
   if (VIX_FAMILY.has(ticker)) {
     await stores.enriched.computeContext(fromDate, toDate);
   }
-  // D-23: best-effort calendar-date count (one date per partition).
-  // We don't re-walk the calendar here — just span size.
+  // Best-effort calendar-date count (one date per partition). We don't
+  // re-walk the calendar here — just report the span size.
   return { datesEnriched: 1, from: fromDate, to: toDate };
 }
 
@@ -88,7 +87,7 @@ async function autoEnrichAfterWrite(
  *
  * @param server  - McpServer instance to register tools on
  * @param baseDir - Base data directory (passed to connection helpers)
- * @param stores  - MarketStores bundle (Phase 4 CONSUMER-01 — third positional arg)
+ * @param stores  - MarketStores bundle (used for spot writes and auto-enrichment)
  */
 export function registerMarketImportTools(
   server: McpServer,
@@ -96,7 +95,7 @@ export function registerMarketImportTools(
   stores: MarketStores,
 ): void {
   // ---------------------------------------------------------------------------
-  // Tool: import_market_csv (INGEST-01 — no target_table; auto-enrich; D-22/D-23)
+  // Tool: import_market_csv — write spot bars and auto-derive enrichment
   // ---------------------------------------------------------------------------
   server.registerTool(
     "import_market_csv",
@@ -139,8 +138,9 @@ export function registerMarketImportTools(
       }),
     },
     async ({ file_path, ticker, column_mapping, dry_run, skip_enrichment }) => {
-      // V5 input-validation control — preserve existing path resolution from
-      // the legacy handler so threat T-04-07-01 mitigation stays intact.
+      // Path normalization: expand `~` and resolve to absolute form before
+      // handing to the CSV parser. Keeps untrusted relative inputs out of
+      // the working-directory namespace.
       let resolvedPath = file_path;
       if (resolvedPath.startsWith("~")) {
         resolvedPath = path.join(os.homedir(), resolvedPath.slice(1));
@@ -186,7 +186,7 @@ export function registerMarketImportTools(
           rowsWritten += dayBars.length;
         }
 
-        // 3) Auto-enrich (D-23) — compose at handler level, NOT inside writeBars.
+        // 3) Auto-enrich — composed at the handler level, not inside writeBars.
         const enrichment = await autoEnrichAfterWrite(
           stores,
           normalizedTicker,
@@ -226,7 +226,7 @@ export function registerMarketImportTools(
   );
 
   // ---------------------------------------------------------------------------
-  // Tool: import_from_database (INGEST-01 — no target_table; auto-enrich; D-22/D-23)
+  // Tool: import_from_database — write spot bars from external DuckDB query
   // ---------------------------------------------------------------------------
   server.registerTool(
     "import_from_database",
@@ -271,8 +271,9 @@ export function registerMarketImportTools(
       }),
     },
     async ({ db_path, query, ticker, column_mapping, dry_run, skip_enrichment }) => {
-      // V5 input-validation control — preserve existing dbPath resolution from
-      // the legacy handler so threat T-04-07-02 mitigation stays intact.
+      // Path normalization: expand `~` and resolve to absolute form before
+      // handing to DuckDB ATTACH. Keeps untrusted relative inputs out of
+      // the working-directory namespace.
       let resolvedDbPath = db_path;
       if (resolvedDbPath.startsWith("~")) {
         resolvedDbPath = path.join(os.homedir(), resolvedDbPath.slice(1));
@@ -285,8 +286,8 @@ export function registerMarketImportTools(
       await upgradeToReadWrite(baseDir);
       try {
         // 1) ATTACH the external DB on the analytics conn so the user's query
-        //    can reference `ext_import_source.<table>`. Preserves the legacy
-        //    contract — query stability across the INGEST-01 migration.
+        //    can reference `ext_import_source.<table>`. The fixed alias
+        //    keeps caller queries portable across imports.
         const conn = await getConnection(baseDir);
         const escapedDbPath = resolvedDbPath.replace(/'/g, "''");
         await conn.run(`ATTACH '${escapedDbPath}' AS ${EXT_ALIAS} (READ_ONLY)`);

--- a/packages/mcp-server/src/tools/replay.ts
+++ b/packages/mcp-server/src/tools/replay.ts
@@ -150,7 +150,7 @@ export function resolveOODateRange(
 export async function handleReplayTrade(
   params: z.infer<typeof replayTradeSchema>,
   baseDir: string,
-  stores: MarketStores,   // Phase 4 Plan 04-02 — used for underlying spot reads + VIX IVP via EnrichedStore. Option-leg paths migrated by plan 04-04.
+  stores: MarketStores,
   injectedConn?: import("@duckdb/node-api").DuckDBConnection
 ): Promise<ReplayResult> {
   const {
@@ -273,12 +273,13 @@ export async function handleReplayTrade(
 
   // ----- Fetch minute quotes for each option leg via QuoteStore -----
   // Adapt QuoteRow → BarRow with mid = (bid+ask)/2 as open/high/low/close
-  // (D-14 mid-price contract).
+  // (mid-price is the canonical mark for option-leg pricing).
   //
-  // Pitfall — group OCC tickers by underlying before each readQuotes call
-  // because QuoteStore enforces a single-underlying invariant per call.
-  // Typical replays have all legs under one underlying (single SPX trade);
-  // multi-underlying replays issue one readQuotes per underlying.
+  // Group OCC tickers by underlying before each readQuotes call: the store
+  // enforces a single-underlying invariant per call so partitioned reads
+  // can be served from one parquet partition root. Typical replays have
+  // all legs under one underlying (single SPX trade); multi-underlying
+  // replays issue one readQuotes per underlying.
   //
   // Fallback root logic (SPX→SPXW etc.) is implicit: the QuoteStore's
   // tickers.resolve(extractRoot(...)) maps both SPX and SPXW to underlying
@@ -344,9 +345,10 @@ export async function handleReplayTrade(
   const underlyingTicker = REVERSE_ROOT_MAP[rawRoot] ?? rawRoot;
   const dividendYield = DIVIDEND_YIELDS[rawRoot] ?? 0;
 
-  // Phase 4 Plan 04-02: read underlying minute bars via SpotStore. Falls back
-  // to the daily aggregate (readDailyBars) when minute bars are absent — that
-  // replaces the prior direct daily-table SELECT.
+  // Read underlying minute bars via SpotStore, falling back to the daily
+  // aggregate (readDailyBars) when minute bars are absent. The daily
+  // fallback keeps greeks computable on dates with sparse intraday
+  // coverage.
   let underlyingBars: BarRow[] = await stores.spot.readBars(
     underlyingTicker,
     open_date!,
@@ -387,13 +389,16 @@ export async function handleReplayTrade(
     underlyingPrices.set(ts, markPrice(b));
   }
 
-  // Build sorted timestamps array for tolerant nearest-timestamp lookup (D-07/D-08)
+  // Build sorted timestamps for tolerant nearest-timestamp lookup: when a
+  // leg's quote timestamp doesn't have an exact underlying-price match
+  // (e.g. one source skipped a minute), greeks computation falls back to
+  // the nearest underlying timestamp within tolerance.
   const sortedTimestamps = Array.from(underlyingPrices.keys())
     .filter(k => k.includes(' '))  // Only intraday timestamps, not date-only keys
     .sort();
 
-  // Phase 4 Plan 04-02: VIX IVP lookup via EnrichedStore.read (replaces the
-  // prior raw `SELECT date, ivp ... WHERE ticker = 'VIX'` query).
+  // VIX IVP lookup via EnrichedStore.read — used as an optional input to
+  // the greeks model when implied-vol percentile context is available.
   let ivpByDate: Map<string, number> | undefined;
   try {
     const vixEnriched = await stores.enriched.read({
@@ -444,7 +449,9 @@ export async function handleReplayTrade(
     computeReplayMfeMae(fullPath);
   let totalPnl = fullPath.length > 0 ? fullPath[fullPath.length - 1].strategyPnl : 0;
 
-  // Compute greeks warning (D-12): warn when >50% of leg-timestamps have null greeks
+  // Surface a warning when >50% of leg-timestamps have null greeks — the
+  // most common cause is sparse IV data or 0DTE legs falling outside the
+  // pricing model's valid range.
   let greeksNullCount = 0;
   let greeksTotalCount = 0;
   for (const point of fullPath) {
@@ -518,7 +525,7 @@ export async function handleReplayTrade(
 export function registerReplayTools(
   server: McpServer,
   baseDir: string,
-  stores: MarketStores,   // Phase 4 Plan 04-02 — used by handleReplayTrade for SpotStore underlying reads + EnrichedStore VIX IVP.
+  stores: MarketStores,
 ): void {
   server.registerTool(
     "replay_trade",


### PR DESCRIPTION
Tier: 3 (public-repo, doc-only)

## Summary

Pure JSDoc/comment scrub across 6 files in `packages/mcp-server/src/tools/`. Part 2 of 4 for tradeblocks-org/enterprise#110. Follows precedent of tradeblocks#306, #307, #311.

## Files

- `packages/mcp-server/src/tools/{exit-analysis,greeks-attribution,market-data,market-enrichment,market-imports,replay}.ts`

+101 / −103 lines. Zero code-path changes; one user-facing `force_full` Zod `.describe` string rewritten for clarity (no behavior delta).

## What changed in wording

- **Schema-section comments** (`// Per D-02/D-03/D-05/D-06/D-08/D-11`): dropped as dangling pointers — surrounding Zod descriptors document each field's purpose self-sufficiently.
- **`market-imports.ts` security comments** (`T-04-07-01`, `T-04-07-02`): rewrote opaque threat IDs as explicit path-normalization rationale — "expand `~` and resolve to absolute form … keeps untrusted relative inputs out of the working-directory namespace." Posture preserved, reader-friendliness improved.
- **`market-data.ts` tombstone**: removed orphaned "we used to do X via `buildRequestedPairsClause`" pointer to a removed plan — the replacement store-backed path is self-documenting in the surrounding code.
- **`replay.ts` line-range pointers**: rewrote fragile line-number refs ("see lines 343-358") as pattern descriptions ("same pattern used in replay.ts for underlying fetches").
- **Misc CONSUMER-01 / Phase 4 / Plan 04-NN labels**: stripped from inline declarations; the surrounding type signatures and comments already describe the dataflow.

One soft spot worth flagging: `force_full` description now opens with "Originally cleared the enriched_through watermark and recomputed all rows." The word "Originally" implies prior history without explaining it. Reads fine as documented intent; a tighter rewrite could be a future polish.

## Verification

- Lint clean (`npm run lint -- --max-warnings=0`)
- Typecheck: 3 pre-existing errors in `utils/exit-triggers.ts` reproduce on `origin/feat/tradeblocks-3.0` baseline — unrelated, untouched
- Internal-vocab grep on the 6 target files: clean (no Phase/Wave/Plan/D-NN/T-N-NN/SEP/INGEST/RESOLVE/CONSUMER/Pitfall tokens; no CONTEXT.md/PATTERNS.md/RESEARCH.md/SUMMARY.md/ROADMAP.md dangling pointers)
- Public-boundary grep repo-wide: clean

## What I'm asking

Does the new prose read well to an external lib consumer? One pass through the 6 files; the technical substance and security posture are preserved.

## Test plan

- [x] Lint clean
- [x] Typecheck clean of new errors
- [x] Internal-vocab grep clean on target files
- [x] Public-boundary grep clean repo-wide
- [ ] Smith review

🤖 Generated with [Claude Code](https://claude.com/claude-code)