### PR TITLE
docs(utils+db): scrub internal-ticket vocab from public-lib docs

### DIFF
--- a/packages/mcp-server/src/db/json-adapters.ts
+++ b/packages/mcp-server/src/db/json-adapters.ts
@@ -6,12 +6,10 @@
  * 2. Sync metadata — per-block .sync-meta.json files
  * 3. Market import metadata — single aggregate file
  * 4. Flat import log — single aggregate file
- * 5. Enrichment watermarks — single aggregate file (Market Data 3.0 Phase 2)
+ * 5. Enrichment watermarks — single aggregate file
  *
- * All adapters use json-store.ts for atomic write-then-rename operations (D-03).
- * File paths follow REQUIREMENTS.md layout (D-02).
- *
- * Strategy definitions (backtest-only) are in json-adapters.ext.ts (D-04).
+ * All adapters use json-store.ts for atomic write-then-rename operations.
+ * File paths follow the canonical data-root layout.
  */
 
 import * as fs from "fs/promises";
@@ -407,13 +405,13 @@ export async function upsertFlatImportLogJson(
 }
 
 // =============================================================================
-// 5. Enrichment Watermarks Adapter (Market Data 3.0 — Phase 2 D-18 through D-21)
+// 5. Enrichment Watermarks Adapter
 //    Path: {dataRoot}/market-meta/enrichment-watermarks.json
 //
 //    Tracks per-ticker `enriched_through` watermark for the market enricher.
-//    Replaces `market._sync_metadata.enriched_through` reads/writes (Phase 5
-//    drops the column). Backend-independent per D-19 — the same JSON file is
-//    written whether Parquet mode is true or false.
+//    Replaces the legacy `market._sync_metadata.enriched_through` SQL
+//    reads/writes. Backend-independent — the same JSON file is written
+//    whether Parquet mode is true or false.
 //
 //    Storage shape:
 //      {
@@ -440,7 +438,7 @@ const TickerEntrySchema = z
 
 export const EnrichmentWatermarksSchema = z.object({
   version: z.literal(1),
-  // Defense-in-depth ticker whitelist (T-2-03): mirrors the TICKER_RE used by
+  // Defense-in-depth ticker whitelist: mirrors the TICKER_RE used by
   // src/market/tickers/schemas.ts and rejects anything not shaped like a ticker.
   watermarks: z.record(z.string().regex(/^[A-Z0-9._-]+$/), TickerEntrySchema),
 });
@@ -455,10 +453,10 @@ function watermarksFilePath(dataDir: string): string {
 /**
  * Load the enrichment watermarks file.
  *
- * Missing file resolves to an empty structure (D-18: absent means "nothing
- * enriched yet", not an error). Malformed JSON or schema violations throw a
- * clear error per D-21 — we never silently reset to empty, which would lose
- * data invisibly.
+ * Missing file resolves to an empty structure — absent means "nothing
+ * enriched yet", not an error. Malformed JSON or schema violations throw a
+ * clear error; we never silently reset to empty, which would lose data
+ * invisibly.
  */
 export async function loadEnrichmentWatermarks(
   dataDir: string,
@@ -495,10 +493,10 @@ export async function getEnrichedThrough(
  * Preserves other tickers' entries and any passthrough fields (e.g.,
  * `wilder_state`) already stored on the target ticker.
  *
- * Pitfall 5 note: atomic at the FS level (tmp+rename via writeJsonFile); this
- * is NOT read-modify-write atomic at the application level. Serial callers
- * (the current enricher flow) are safe. If concurrent enrichers of different
- * tickers become real, add an async-mutex in a follow-up plan.
+ * Concurrency note: atomic at the FS level (tmp+rename via writeJsonFile);
+ * this is NOT read-modify-write atomic at the application level. Serial
+ * callers (the current enricher flow) are safe. If concurrent enrichers of
+ * different tickers become real, add an async-mutex.
  */
 export async function upsertEnrichedThrough(
   ticker: string,

--- a/packages/mcp-server/src/db/market-views.ts
+++ b/packages/mcp-server/src/db/market-views.ts
@@ -19,9 +19,9 @@
  * View surface registered over these files: market.spot, market.spot_daily (RTH aggregation),
  * market.enriched, market.enriched_context, market.option_chain, market.option_quote_minutes.
  *
- * Phase 6 Wave D (SQL-02 closure): the legacy view-registration blocks for
- * the retired daily / date_context / intraday names have been DELETED; reads
- * against those names now fail with a DuckDB Binder/Catalog error by design.
+ * The legacy view-registration blocks for the retired daily / date_context /
+ * intraday names have been removed; reads against those names now fail with
+ * a DuckDB Binder/Catalog error by design.
  */
 
 import type { DuckDBConnection } from "@duckdb/node-api";
@@ -114,9 +114,9 @@ function hasEnrichedContextFile(dir: string): boolean {
  *   - If the Parquet file/directory exists: DROP any existing physical TABLE, then CREATE VIEW
  *   - If missing: record in tablesKept (caller should create physical table as fallback)
  *
- * Phase 6 Wave D retired the legacy single-file (daily, date_context) and
- * Hive-partitioned (intraday) view registrations; reads against those names
- * now fail with a DuckDB Binder/Catalog error by design.
+ * The legacy single-file (daily, date_context) and Hive-partitioned
+ * (intraday) view registrations have been retired; reads against those
+ * names now fail with a DuckDB Binder/Catalog error by design.
  *
  * @param conn - Active DuckDB connection with market catalog attached
  * @param dataDir - Base data directory (parent of market/ subdirectory)
@@ -132,9 +132,9 @@ export async function createMarketParquetViews(
   // --- Hive-partitioned views ---
 
   // `option_chain` accepts either the legacy date-only layout
-  // (`option_chain/date=Y/...`) or the Market Data 3.0 underlying-first layout
-  // (`option_chain/underlying=X/date=Y/...`) — the new store writers
-  // (Plan 02-03) produce the underlying-first layout.
+  // (`option_chain/date=Y/...`) or the canonical underlying-first layout
+  // (`option_chain/underlying=X/date=Y/...`) — the current store writers
+  // produce the underlying-first layout.
   const hiveViews: Array<{ name: string; subdir: string; partitionKey: string }> = [
     { name: "option_chain", subdir: resolveCanonicalMarketPartitionDir(dataDir, "option_chain"), partitionKey: "underlying" },
   ];
@@ -165,11 +165,11 @@ export async function createMarketParquetViews(
 
   // --- Option quote minutes view (moved from connection.ext.ts) ---
   //
-  // Accepts both the legacy date-only layout (`date=Y/...`) and the Market
-  // Data 3.0 underlying-first layout (`underlying=X/date=Y/...`) produced by
-  // Plan 02-03 Parquet writers. The view projects the canonical quote schema
-  // explicitly so older partitions without greeks columns still read with null
-  // greeks instead of failing at bind time.
+  // Accepts both the legacy date-only layout (`date=Y/...`) and the canonical
+  // underlying-first layout (`underlying=X/date=Y/...`) produced by the
+  // current Parquet writers. The view projects the canonical quote schema
+  // explicitly so older partitions without greeks columns still read with
+  // null greeks instead of failing at bind time.
 
   const optionMinuteQuoteDir = resolveCanonicalMarketPartitionDir(dataDir, "option_quote_minutes");
   const optionQuoteHasNewLayout = hasParquetPartitions(optionMinuteQuoteDir, "underlying");
@@ -207,10 +207,9 @@ export async function createMarketParquetViews(
   try { await conn.run("DROP TABLE IF EXISTS market.option_delta_index"); } catch { /* wrong type */ }
 
   // ============================================================================
-  // Market Data 3.0 — Phase 2 + Phase 6 new views (D-22 / Phase 6 D-01)
-  // Added alongside the existing view code. Old views stay active for Phase 4
-  // consumer migration; removal of legacy daily / intraday / date_context views
-  // is Phase 6 / EXT-01. No changes to connection.ext.ts (D-23).
+  // Canonical store views (spot, enriched, enriched_context, spot_daily).
+  // These coexist with legacy view registrations elsewhere while consumer
+  // migration is ongoing.
   // ============================================================================
 
   // market.spot — ticker-first Hive partitioning: spot/ticker=X/date=Y/data.parquet
@@ -258,20 +257,19 @@ export async function createMarketParquetViews(
     tablesKept.push("enriched_context");
   }
 
-  // market.spot_daily — view over market.spot with RTH aggregation. Bridge for
-  // SQL callers that need daily OHLCV after the legacy-daily-view retirement
-  // (Phase 6 D-01; see PATTERNS.md §market-views.ts for the exact SQL contract).
-  // Semantics match SpotStore.readDailyBars: first(open), max(high), min(low),
-  // last(close), first(bid), last(ask), RTH 09:30–16:00, GROUP BY ticker+date.
-  // Unconditional registration — DuckDB view over table-or-view works when
-  // market.spot exists as either a Parquet view or fallback table (Pitfall 3).
-  // However, CREATE VIEW binds the underlying reference immediately, so if
-  // market.spot exists in NEITHER form (empty dir AND no pre-existing fallback
-  // table — see Phase 2 "empty market/ dir" test), we skip the registration
-  // and push to tablesKept. In production, connection.ts calls
-  // ensureMarketDataTables() which creates a market.spot fallback table when
-  // the view is absent, so this skip branch applies only to unit-test fixtures
-  // that deliberately avoid BOTH paths.
+  // market.spot_daily — view over market.spot with RTH aggregation. Bridge
+  // for SQL callers that need daily OHLCV after the legacy-daily-view
+  // retirement. Semantics match SpotStore.readDailyBars: first(open),
+  // max(high), min(low), last(close), first(bid), last(ask),
+  // RTH 09:30–16:00, GROUP BY ticker+date.
+  //
+  // CREATE VIEW binds the underlying reference immediately, so if
+  // market.spot exists in NEITHER form (empty dir AND no pre-existing
+  // fallback table) we skip the registration and push to tablesKept. In
+  // production, connection.ts calls ensureMarketDataTables() which creates
+  // a market.spot fallback table when the view is absent, so this skip
+  // branch applies only to unit-test fixtures that deliberately avoid
+  // BOTH paths.
   const spotExists = await (async () => {
     try {
       await conn.run("SELECT * FROM market.spot WHERE 1=0");

--- a/packages/mcp-server/src/test-exports.ts
+++ b/packages/mcp-server/src/test-exports.ts
@@ -17,7 +17,7 @@ export {
   type ImportCsvOptions,
 } from './utils/block-loader.js';
 
-// Export CSV discovery utilities for unit testing (Phase 63)
+// Export CSV discovery utilities for unit testing
 export { detectCsvType, discoverCsvFiles, logCsvDiscoveryWarning, type CsvType } from './utils/csv-discovery.js';
 
 // Export PortfolioStatsCalculator for testing block_diff logic
@@ -84,7 +84,7 @@ export {
   type CoverageResult,
 } from './utils/data-quality.js';
 
-// Export intraday timing utilities for testing (Plan 64-03)
+// Export intraday timing utilities for testing
 export { computeIntradayTimingFields } from './utils/market-enricher.js';
 
 // Export schema metadata for classification completeness tests
@@ -103,14 +103,14 @@ export {
   type ImportSpotResult,
 } from './utils/market-importer.js';
 
-// Export Phase 60 market import metadata helpers for integration testing
+// Export market import metadata helpers for integration testing
 export {
   type MarketImportMetadata,
   getMarketImportMetadata,
   upsertMarketImportMetadata,
 } from './sync/metadata.js';
 
-// Export Phase 62 market enricher indicator functions for unit testing
+// Export market enricher indicator functions for unit testing
 export {
   computeRSI,
   computeATR,
@@ -139,7 +139,7 @@ export {
   type TierStatus,
 } from './utils/market-enricher.js';
 
-// Export strategy profile types and CRUD functions for integration testing (Phase 60)
+// Export strategy profile types and CRUD functions for integration testing
 export type {
   StrategyProfile,
   StrategyProfileRow,
@@ -157,11 +157,11 @@ export {
   deleteProfile,
 } from './db/profile-schemas.js';
 
-// Export Phase 62 analysis utility modules for unit testing
+// Export analysis utility modules for unit testing
 export { computeSliceStats, type SliceStats } from './utils/analysis-stats.js';
 export { buildFilterPredicate, type FilterPredicate } from './utils/filter-predicates.js';
 
-// Export Phase 61 profile tool handlers and schemas for integration testing
+// Export profile tool handlers and schemas for integration testing
 export {
   handleProfileStrategy,
   handleGetStrategyProfile,
@@ -173,7 +173,7 @@ export {
   deleteProfileSchema,
 } from './tools/profiles.js';
 
-// Export Phase 62 profile analysis tool handlers and schemas for integration testing
+// Export profile analysis tool handlers and schemas for integration testing
 export {
   handleAnalyzeStructureFit,
   handleValidateEntryFilters,
@@ -183,7 +183,7 @@ export {
   portfolioStructureMapSchema,
 } from './tools/profile-analysis.js';
 
-// Export Phase 65 regime advisor tool handler and schema for integration testing
+// Export regime advisor tool handler and schema for integration testing
 export {
   handleRegimeAllocationAdvisor,
   regimeAllocationAdvisorSchema,
@@ -230,7 +230,7 @@ export {
   type MassiveQuotesResponse,
 } from './utils/providers/massive.js';
 
-// Export trade replay utilities for unit testing (Phase 68)
+// Export trade replay utilities for unit testing
 export {
   parseLegsString,
   buildOccTicker,
@@ -246,14 +246,14 @@ export {
   type GreeksConfig,
 } from './utils/trade-replay.js';
 
-// Export trade replay tool handler and schema for integration testing (Phase 68)
+// Export trade replay tool handler and schema for integration testing
 export {
   handleReplayTrade,
   replayTradeSchema,
   resolveOODateRange,
 } from './tools/replay.js';
 
-// Export Black-Scholes and Bachelier greeks computation for unit testing (Phase 69 / Phase 73-01)
+// Export Black-Scholes and Bachelier greeks computation for unit testing
 export {
   pdf,
   cdf,
@@ -288,10 +288,10 @@ export {
   readParquetFilesSql,
 } from './utils/quote-parquet-projection.js';
 
-// Export parquet-writer utility functions for unit testing (Phase 02-01)
+// Export parquet-writer utility functions for unit testing
 export { isParquetMode, writeParquetAtomic, writeParquetPartition, resolveMarketDir } from './db/parquet-writer.js';
 
-// Export json-store utility for unit testing (Phase 03-01)
+// Export json-store utility for unit testing
 export {
   readJsonFile,
   writeJsonFile,
@@ -300,19 +300,19 @@ export {
   toFileSlug,
 } from './db/json-store.js';
 
-// Export Massive snapshot schemas for unit testing (Phase 70)
+// Export Massive snapshot schemas for unit testing
 export {
   MassiveSnapshotResponseSchema,
   MassiveSnapshotContractSchema,
 } from './utils/providers/massive.js';
 
-// Export snapshot tool handler and schema for integration testing (Phase 70)
+// Export snapshot tool handler and schema for integration testing
 export {
   handleGetOptionSnapshot,
   getOptionSnapshotSchema,
 } from './tools/snapshot.js';
 
-// Export greeks decomposition utilities for unit testing (Phase 71)
+// Export greeks decomposition utilities for unit testing
 export {
   decomposeGreeks,
   computeTimeDeltaDays,
@@ -324,7 +324,7 @@ export {
   type FactorName,
 } from './utils/greeks-decomposition.js';
 
-// Export exit trigger analysis utilities for unit testing (Phase 71)
+// Export exit trigger analysis utilities for unit testing
 export {
   evaluateTrigger,
   analyzeExitTriggers,
@@ -336,7 +336,7 @@ export {
   type LegGroupResult,
 } from './utils/exit-triggers.js';
 
-// Export exit analysis tool handlers and schemas for integration testing (Phase 71)
+// Export exit analysis tool handlers and schemas for integration testing
 export {
   handleAnalyzeExitTriggers,
   handleDecomposeGreeks,
@@ -344,7 +344,7 @@ export {
   decomposeGreeksSchema,
 } from './tools/exit-analysis.js';
 
-// Export batch exit analysis engine for unit testing (Phase 72)
+// Export batch exit analysis engine for unit testing
 export {
   analyzeBatch,
   computeAggregateStats,
@@ -358,7 +358,7 @@ export {
   type BaselineMode,
 } from './utils/batch-exit-analysis.js';
 
-// Export batch exit analysis tool handler and schema for integration testing (Phase 72)
+// Export batch exit analysis tool handler and schema for integration testing
 export {
   handleBatchExitAnalysis,
   batchExitAnalysisSchema,
@@ -457,7 +457,7 @@ export {
   filterSparseSteps,
 } from './tools/greeks-attribution.js';
 
-// Export json-adapters for integration testing (Phase 03-01)
+// Export json-adapters for integration testing
 export {
   upsertProfileJson,
   getProfileJson,
@@ -474,16 +474,16 @@ export {
 } from './db/json-adapters.js';
 export type { FlatImportLogEntry } from './db/json-adapters.js';
 
-// Export json-migration for integration testing (Phase 03-03)
+// Export json-migration for integration testing
 export { migrateMetadataToJson, type MigrationResult } from './db/json-migration.js';
 
 // ============================================================================
-// Market Data 3.0 — Phase 1 exports
+// Market Data — store interfaces, registry, datasets
 //
-// Per CONTEXT.md D-19: all Phase 1 modules are SHARED code; they re-export here.
+// All modules below are shared code, re-exported here for test access.
 // ============================================================================
 
-// Store interfaces + factory (Plan 01)
+// Store interfaces + factory
 export {
   SpotStore,
   EnrichedStore,
@@ -500,7 +500,7 @@ export type {
 } from './market/stores/index.js';
 export type { BarRow as MarketStoreBarRow, ContractRow } from './market/stores/index.js';
 
-// Ticker registry + resolver + loader + schemas (Plan 02)
+// Ticker registry + resolver + loader + schemas
 export { extractRoot, rootToUnderlying } from './market/tickers/resolver.js';
 export { TickerRegistry } from './market/tickers/registry.js';
 export type { TickerEntry, EntrySource } from './market/tickers/registry.js';
@@ -514,13 +514,13 @@ export {
   TICKER_RE,
 } from './market/tickers/schemas.js';
 
-// Parquet writer new multi-level options type (Plan 03)
-// Note: the existing value-level parquet-writer re-exports above at line ~277
-// already cover the runtime symbols; here we only add the new type alias for
-// the multi-level overload so tests can type-check against the V3 shape.
+// Parquet writer multi-level options type
+// Note: the value-level parquet-writer re-exports above already cover the
+// runtime symbols; this line adds the type alias for the multi-level
+// overload so tests can type-check against the V3 shape.
 export type { WriteParquetPartitionOptsV3 } from './db/parquet-writer.js';
 
-// 3.0 Dataset registry + per-dataset helpers (Plan 04)
+// Dataset registry + per-dataset helpers
 export {
   DATASETS_V3,
   writeSpotPartition,
@@ -531,7 +531,7 @@ export {
 } from './db/market-datasets.js';
 export type { DatasetDef } from './db/market-datasets.js';
 
-// Ticker MCP tool handlers (Plan 05) — schemas re-exported from tickers/schemas.ts above
+// Ticker MCP tool handlers — schemas re-exported from tickers/schemas.ts above
 export {
   registerTickerTools,
   handleRegisterUnderlying,
@@ -541,18 +541,13 @@ export {
 } from './tools/tickers.js';
 
 // ============================================================================
-// End of Phase 1 block
-// ============================================================================
-
-// ============================================================================
-// Market Data 3.0 — Phase 2 Wave 1 exports (pure helpers + watermark adapter)
+// Pure helpers + watermark adapter
 //
-// Wave 1 deliverables: pure SQL builders, RTH aggregation helper, partition
-// enumerator, and the enrichment watermark JSON adapter. Concrete store
-// classes ship in Waves 2-3 and will re-export below in later plans.
+// Pure SQL builders, RTH aggregation helper, partition enumerator, and the
+// enrichment watermark JSON adapter.
 // ============================================================================
 
-// Pure SQL builders (Plan 02-01)
+// Pure SQL builders
 export {
   buildReadBarsSQL,
   buildReadDailyBarsSQL,
@@ -566,10 +561,10 @@ export { buildReadQuotesSQL } from './market/stores/quote-sql.js';
 export { rthDailyAggregateSubquery } from './market/stores/rth-aggregation.js';
 export type { RthWindowOpts } from './market/stores/rth-aggregation.js';
 
-// Shared coverage helper (Plan 02-01)
+// Shared coverage helper
 export { listPartitionValues } from './market/stores/coverage.js';
 
-// Enrichment watermark adapter (Plan 02-01)
+// Enrichment watermark adapter
 export {
   EnrichmentWatermarksSchema,
   loadEnrichmentWatermarks,
@@ -578,64 +573,47 @@ export {
 } from './db/json-adapters.js';
 export type { EnrichmentWatermarks } from './db/json-adapters.js';
 
-// Schema ensure functions (consumed by Plan 02-02 schemas.test.ts and views.test.ts).
-// These functions exist today in src/db/market-schemas.ts; Plan 02-02 modifies their
-// bodies (removes data_coverage CREATE, adds spot/enriched tables, drops+recreates
-// option_quote_minutes). They are already re-exported earlier in this file (see
-// the `ensureMutableMarketTables, ensureMarketDataTables` line near the top); we
-// intentionally do NOT re-export them here to avoid duplicate-export errors. Plan
-// 02-02 will rely on the existing top-of-file export.
+// Schema ensure functions are re-exported earlier in this file via
+// `ensureMutableMarketTables, ensureMarketDataTables` near the top; do NOT
+// re-export them here to avoid duplicate-export errors.
 
 // ============================================================================
-// End of Phase 2 Wave 1 block
-// ============================================================================
-
-// ============================================================================
-// Market Data 3.0 — Phase 2 Wave 2 exports (concrete Spot/Chain/Quote stores)
+// Concrete Spot/Chain/Quote stores
 //
-// Concrete classes ship one task at a time per Plan 02-03. Each task's
-// subset of exports is added here so tests can import the concrete class
-// names directly via `../../../src/test-exports.js`.
+// Tests import the concrete class names directly via
+// `../../../src/test-exports.js`.
 // ============================================================================
 
-// Concrete Spot store pair (Plan 02-03 Task 1)
+// Concrete Spot store pair
 export { ParquetSpotStore } from './market/stores/parquet-spot-store.js';
 export { DuckdbSpotStore } from './market/stores/duckdb-spot-store.js';
 
-// Concrete Chain store pair (Plan 02-03 Task 2)
+// Concrete Chain store pair
 export { ParquetChainStore } from './market/stores/parquet-chain-store.js';
 export { DuckdbChainStore } from './market/stores/duckdb-chain-store.js';
 
-// Concrete Quote store pair (Plan 02-03 Task 3)
+// Concrete Quote store pair
 export { ParquetQuoteStore } from './market/stores/parquet-quote-store.js';
 export { DuckdbQuoteStore } from './market/stores/duckdb-quote-store.js';
 
 // ============================================================================
-// End of Phase 2 Wave 2 block
-// ============================================================================
-
-// ============================================================================
-// Market Data 3.0 — Phase 2 Wave 3 exports (concrete Enriched stores)
+// Concrete Enriched stores
 //
-// Plan 02-04 delivers the EnrichedStore pair as thin wrappers around the
-// existing runEnrichment pipeline (D-14 / D-15). Both classes extend the
-// Phase 1 abstract EnrichedStore and accept an injected SpotStore in their
-// constructors so that the enricher's IO boundaries (minute-bar reads,
-// watermark get/upsert) are satisfied without reimplementing the math.
+// Thin wrappers around the existing runEnrichment pipeline. Both classes
+// extend the abstract EnrichedStore and accept an injected SpotStore so
+// that the enricher's IO boundaries (minute-bar reads, watermark
+// get/upsert) are satisfied without reimplementing the math.
 // ============================================================================
 
-// Concrete Enriched store pair (Plan 02-04 Task 2)
+// Concrete Enriched store pair
 export { ParquetEnrichedStore } from './market/stores/parquet-enriched-store.js';
 export { DuckdbEnrichedStore } from './market/stores/duckdb-enriched-store.js';
 
 // ============================================================================
-// End of Phase 2 Wave 3 block
-// ============================================================================
-
-// ============================================================================
-// Market Data 3.0 — Ingestor exports (Plan 01-06)
+// Ingestor exports
 //
-// Market ingestor class + types exposed for integration tests that import from dist/
+// Market ingestor class + types exposed for integration tests that import
+// from dist/.
 // ============================================================================
 
 // Market ingestor — exposed for integration tests that import from dist/
@@ -654,16 +632,12 @@ export type {
 } from "./market/ingestor/index.js";
 
 // ============================================================================
-// End of Ingestor block
-// ============================================================================
-
-// ============================================================================
-// Market Data 3.0 — Phase 3 exports (migration helpers)
+// Option-data migration helpers
 //
-// Plan 03-01 delivers pure helpers for the in-place option-data migration script.
-// The .mjs script itself is NOT re-exported (CONTEXT.md D-26 — scripts with
-// filesystem effects cannot be unit-tested cleanly via test-exports; unit tests
-// target the pure helpers).
+// Pure helpers for the in-place option-data migration script. The .mjs
+// script itself is NOT re-exported — scripts with filesystem effects
+// cannot be unit-tested cleanly via test-exports; unit tests target these
+// pure helpers.
 // ============================================================================
 
 export {
@@ -675,22 +649,15 @@ export {
 export type { GroupResult } from './utils/migrate-option-data-helpers.js';
 
 // ============================================================================
-// End of Phase 3 block
-// ============================================================================
-
-// ============================================================================
-// Market Data 3.0 — Phase 4 exports (Consumer Migration)
-//
-// RESOLVE-02: Tool Dependency Registry
-// SEP-01: pipeline-side backfill helper (plan 04-06)
+// Tool dependency registry
 // ============================================================================
 export { TOOL_TICKER_DEPS, unionTickerDeps } from './utils/tool-ticker-deps.js';
 // ============================================================================
 
 // ============================================================================
-// Market Data 3.0 — Phase 5 exports (Spot Backfill + Enrichment Rebuild)
+// Spot backfill + enrichment-rebuild support
 //
-// D-17/D-19: verification helper, sample-date selector, calibration probe.
+// Verification helper, sample-date selector, calibration probe.
 // ============================================================================
 export {
   selectVerificationSampleDates,

--- a/packages/mcp-server/src/utils/calibration-probe.ts
+++ b/packages/mcp-server/src/utils/calibration-probe.ts
@@ -1,22 +1,20 @@
 /**
- * calibration-probe.ts — Wave 0 operator helper that de-risks RESEARCH Pitfall 1
- * (provider-refetch drift vs. the 1e-9 D-09 tolerance).
+ * calibration-probe.ts — operator helper that de-risks provider-refetch drift
+ * against the 1e-9 tolerance used by the enrichment verifier.
  *
- * Invoke BEFORE starting Plan 05-01 (Wave A spot backfill). The probe fetches
- * minute bars for a set of sample dates from the active provider and compares
- * their close prices against whatever is already in `market.spot` for the
- * same (ticker, date). The operator reads the returned `maxCloseDelta` and
- * decides:
+ * Invoke before starting a spot-bar backfill. The probe fetches minute bars
+ * for a set of sample dates from the active provider and compares their close
+ * prices against whatever is already in `market.spot` for the same
+ * (ticker, date). The operator reads the returned `maxCloseDelta` and decides:
  *
- *   maxCloseDelta < 1e-6      → proceed; D-09 is achievable as stated.
- *   1e-6 ≤ delta < 1e-3       → proceed only with Wave C baseline shift OR
- *                               `05-DRIFT-ACK.md` raising tolerance.
- *   maxCloseDelta ≥ 1e-3      → escalate to user; D-09 unachievable without
- *                               design change.
+ *   maxCloseDelta < 1e-6      → proceed; 1e-9 tolerance is achievable.
+ *   1e-6 ≤ delta < 1e-3       → proceed only with an explicit tolerance bump
+ *                               or a documented baseline shift.
+ *   maxCloseDelta ≥ 1e-3      → escalate; the tolerance is unachievable
+ *                               without a design change.
  *
- * This module is manual-only per VALIDATION.md §Manual-Only. It has no unit
- * test — it is purposefully side-effectful (opens a live DuckDB, calls the
- * singleton provider) and exists for operator inspection.
+ * Manual-only — purposefully side-effectful (opens a live DuckDB, calls the
+ * singleton provider). No unit test; exists for operator inspection.
  */
 import * as path from "path";
 import { DuckDBInstance } from "@duckdb/node-api";
@@ -79,8 +77,8 @@ export async function calibrateProviderFetch(
         assetClass: "index",
       });
 
-      // Phase 6 Wave D: legacy minute-bar view rewritten to market.spot
-      // (v3.0 canonical minute-bar view; schema unchanged).
+      // Canonical minute-bar view is market.spot — same schema as the
+      // earlier intraday view it replaced.
       const oldReader = await conn.runAndReadAll(
         `SELECT time, close FROM market.spot WHERE ticker = $1 AND date = $2 ORDER BY time`,
         [ticker, date],

--- a/packages/mcp-server/src/utils/data-quality.ts
+++ b/packages/mcp-server/src/utils/data-quality.ts
@@ -13,25 +13,24 @@
  *
  * Design principles:
  *   - scoreDataQuality and formatCoverageReport are pure functions (no I/O)
- *   - queryCoverage handles all store access (Phase 4 / CONSUMER-02 — flows
- *     through `stores.spot.getCoverage` + `stores.quote.getCoverage` only;
- *     no raw `FROM market.*` SQL remains)
+ *   - queryCoverage handles all store access — flows through
+ *     `stores.spot.getCoverage` + `stores.quote.getCoverage` only; no raw
+ *     `FROM market.*` SQL remains.
  *   - Confidence scoring uses avgBarsPerDay as proxy for data density:
  *       >= 200 bars/day = dense quotes (high confidence)
  *       50-199 bars/day = sparse trade bars (medium confidence)
  *       < 50 bars/day  = very sparse data (low confidence)
  *   - Missing data (> 10% of trading days) caps confidence at medium
  *
- * Note on `barCount` post-Phase-4:
- *   The legacy `queryCoverage` returned per-date `COUNT(*)` row counts from
- *   the pre-Phase-6 intraday view / `market.option_quote_minutes`. The Phase 2 store layer
- *   exposes coverage as `{ earliest, latest, totalDates }` — date-level
- *   granularity only. We map "covered date" → `barCount = 1` so downstream
- *   `scoreDataQuality` consumers continue to see a non-zero density signal,
- *   and `hasQuotes` reflects whether the date is covered by the quote store
- *   (which is the new "dense data" signal in Market Data 3.0). True per-date
- *   density is no longer exposed by the store layer; Plan 04-06 will rewire
- *   the data-quality consumer fully.
+ * Note on `barCount`:
+ *   The earlier `queryCoverage` returned per-date `COUNT(*)` row counts from
+ *   the legacy intraday view / `market.option_quote_minutes`. The current
+ *   store layer exposes coverage as `{ earliest, latest, totalDates }` —
+ *   date-level granularity only. We map "covered date" → `barCount = 1` so
+ *   downstream `scoreDataQuality` consumers continue to see a non-zero
+ *   density signal, and `hasQuotes` reflects whether the date is covered by
+ *   the quote store (the current "dense data" signal). True per-date
+ *   density is no longer exposed by the store layer.
  */
 
 import type { MarketStores } from "../market/stores/index.js";
@@ -146,7 +145,7 @@ export function scoreDataQuality(input: DataQualityInput): DataQuality {
 /**
  * Aggregate spot + quote store coverage for an underlying over a date range.
  *
- * Phase 4 / CONSUMER-02: all reads flow through `stores.spot.getCoverage` and
+ * All reads flow through `stores.spot.getCoverage` and
  * `stores.quote.getCoverage`. The pre-migration LIKE pattern (e.g., 'SPX%') is
  * gone — callers pass the underlying ticker directly. Quote-store coverage
  * already aggregates over every OCC chain under the underlying.
@@ -166,7 +165,7 @@ export async function queryCoverage(
   const spotCov = await stores.spot.getCoverage(underlying, fromDate, toDate);
 
   // Quote coverage — every OCC quote-minute under this underlying. The store
-  // returns date-level coverage; "covered = dense" in the post-Phase-4 model.
+  // returns date-level coverage; "covered = dense" in the current model.
   const quoteCov = await stores.quote.getCoverage(underlying, fromDate, toDate);
 
   // Build covered-date set.
@@ -191,7 +190,7 @@ export async function queryCoverage(
     // Per-date row counts are no longer exposed by the store; treat each
     // covered date as 1 unit of "bars" so callers that compute density still
     // see a positive signal. hasQuotes flips when the quote store covers the
-    // date (the post-Phase-4 "dense data" predicate).
+    // date (the current "dense data" predicate).
     const barCount = 1;
     totalBars += barCount;
     dateBreakdown.push({ date, barCount, hasQuotes: quoteDateSet.has(date) });
@@ -209,7 +208,8 @@ export async function queryCoverage(
 
 /**
  * Enumerate the inclusive date range between two ISO dates. Returns [] when
- * either bound is null (the D-09 silent-empty contract). Pure function — no IO.
+ * either bound is null — coverage probes use null bounds to signal "no
+ * data found" without throwing. Pure function — no IO.
  */
 function enumerateCoveredDates(from: string | null, to: string | null): string[] {
   if (!from || !to) return [];

--- a/packages/mcp-server/src/utils/enrichment-verification.ts
+++ b/packages/mcp-server/src/utils/enrichment-verification.ts
@@ -1,15 +1,17 @@
 /**
- * enrichment-verification.ts — pure diff helper for Phase 5 Wave C.
+ * enrichment-verification.ts — pure diff helper for enrichment-rebuild
+ * verification.
  *
- * Compares two enriched rows (old from legacy `daily.parquet` / `date_context`,
- * new from rebuilt `market.enriched` / `market.enriched_context`) with per-field
- * tolerance rules and returns a structured diff — not a boolean. The Wave C
- * verification harness consumes the diff, aggregates across the ~15–20 sample
- * dates per ticker, and emits `05-verification-report.{md,json}`.
+ * Compares two enriched rows (old from the legacy
+ * `daily.parquet` / `date_context` files, new from the rebuilt
+ * `market.enriched` / `market.enriched_context` views) with per-field
+ * tolerance rules and returns a structured diff — not a boolean. The
+ * verification harness consumes the diff, aggregates across ~15–20 sample
+ * dates per ticker, and emits a report (markdown + JSON).
  *
  * Pure module — no filesystem, no DuckDB, no provider imports.
  *
- * Tolerance rules (CONTEXT.md §D-09):
+ * Tolerance rules:
  *   - DOUBLE: `|a - b| <= 1e-9` (boundary INCLUSIVE); NaN-vs-NaN passes;
  *             NaN-vs-non-NaN fails.
  *   - INTEGER: strict `Number(a) === Number(b)`.
@@ -17,13 +19,14 @@
  *   - null vs null / undefined vs undefined → pass.
  *   - null vs value (or undefined vs value) → fail.
  *
- * Failure aggregation (D-11): `compareRow(...).anyFailure === true` whenever
- * any field in the row failed its tolerance test. The Wave D deletion commit
- * is blocked unless every compared row returns `anyFailure === false`.
+ * Failure aggregation: `compareRow(...).anyFailure === true` whenever any
+ * field in the row failed its tolerance test. The deletion of the legacy
+ * enriched files is gated on every compared row returning
+ * `anyFailure === false`.
  */
 
 /**
- * Tolerance epsilon for DOUBLE fields (D-09). Locked at 1e-9 — the enrichment
+ * Tolerance epsilon for DOUBLE fields. Locked at 1e-9 — the enrichment
  * math is deterministic on identical OHLCV input, so anything above machine
  * precision is a real semantic change.
  */
@@ -34,10 +37,10 @@ export type FieldType = "double" | "integer" | "varchar";
 
 /**
  * Per-field type classification for rows materialized from
- * `market.enriched` (ticker-first enriched store, Phase 2 D-14/D-15).
+ * `market.enriched` (the ticker-first enriched store).
  *
- * Source: market-enricher.ts::DAILY_ENRICHMENT_COLUMNS (lines 578-611) + D-09
- * classification.
+ * Source: market-enricher.ts::DAILY_ENRICHMENT_COLUMNS + the tolerance-rule
+ * classification documented in the file header.
  *
  * INTEGER fields (exact match): Gap_Filled, Consecutive_Days, High_Before_Low,
  * Reversal_Type, Day_of_Week, Month, Is_Opex.
@@ -86,7 +89,7 @@ export const ENRICHED_FIELD_TYPES: Record<string, FieldType> = {
 
 /**
  * Per-field type classification for rows materialized from
- * `market.enriched_context` (global cross-ticker context, Phase 2 D-14).
+ * `market.enriched_context` (the global cross-ticker context view).
  *
  * Vol_Regime / Term_Structure_State are integers (classification codes per
  * classifyVolRegime / classifyTermStructure).
@@ -119,7 +122,8 @@ export interface FieldDiff {
 
 /**
  * Row-level diff with a precomputed `anyFailure` flag for fast aggregation
- * across many sample rows (D-11: failure blocks the Wave D deletion commit).
+ * across many sample rows — any failure blocks deletion of the legacy
+ * enriched files.
  */
 export interface RowDiff {
   ticker: string;
@@ -209,9 +213,9 @@ export function compareFields(
  * `kind: 'enriched'` uses `ENRICHED_FIELD_TYPES` (per-ticker enriched row).
  * `kind: 'context'` uses `CONTEXT_FIELD_TYPES` (global cross-ticker context row).
  *
- * The resulting `RowDiff.anyFailure` is the aggregation signal Wave D's
- * deletion gate reads — single `true` anywhere in the sample blocks deletion
- * (D-11).
+ * The resulting `RowDiff.anyFailure` is the aggregation signal the deletion
+ * gate reads — a single `true` anywhere in the sample blocks deletion of
+ * the legacy enriched files.
  */
 export function compareRow(
   oldRow: Record<string, unknown>,

--- a/packages/mcp-server/src/utils/market-enricher.ts
+++ b/packages/mcp-server/src/utils/market-enricher.ts
@@ -463,7 +463,7 @@ export function classifyTermStructure(
  * Implied Volatility Rank (IVR) over a rolling window.
  * IVR[i] = (current - min) / (max - min) * 100
  * Returns array same length as input; first `period-1` entries are NaN.
- * Per D-10: Shows where current value sits in its 252-day range.
+ * Shows where the current value sits in its 252-day range.
  * When range is 0 (all values identical), returns 50 (middle).
  */
 export function computeIVR(values: number[], period = 252): number[] {
@@ -485,7 +485,7 @@ export function computeIVR(values: number[], period = 252): number[] {
  * Implied Volatility Percentile (IVP) over a rolling window.
  * IVP[i] = count(prior 251 days where value <= current) / 251 * 100
  * Returns array same length as input; first `period-1` entries are NaN.
- * Per D-10: Shows what percentage of past year was at or below current.
+ * Shows what percentage of the past year was at or below the current value.
  * Note: divides by (period - 1) = 251 because we compare against prior days only.
  */
 export function computeIVP(values: number[], period = 252): number[] {
@@ -513,19 +513,18 @@ export interface EnrichmentOptions {
 }
 
 /**
- * IO abstraction for runEnrichment (Market Data 3.0 — Plan 02-04, D-14 / D-15).
+ * IO abstraction for runEnrichment.
  *
  * When provided, routes specific IO operations through injected stores:
  *   - spotStore:      Tier 2 VIX RTH open, Tier 3 hasData check, Tier 3 minute bars
- *   - watermarkStore: read/write the enrichment watermark via the JSON adapter (D-20)
+ *   - watermarkStore: read/write the enrichment watermark via the JSON adapter
  *
- * Plan 04-05: the legacy SQL watermark path on the metadata sync table is GONE.
- * When `io.watermarkStore` is not supplied, the runner falls back to
+ * The legacy SQL watermark path on the metadata sync table is gone. When
+ * `io.watermarkStore` is not supplied, the runner falls back to
  * `getEnrichedThrough` / `upsertEnrichedThrough` (the same JSON adapter the
  * store wrappers wire) directly using `opts.dataDir`. The fallback is kept
- * optional to support the few transitional callers (market-importer
- * `triggerEnrichment`) that have not been refactored to construct an IO; plan
- * 04-06 / Phase 5 makes `io` required outright.
+ * optional to support transitional callers (e.g. market-importer
+ * `triggerEnrichment`) that have not been refactored to construct an IO.
  */
 export interface EnrichmentIO {
   spotStore?: SpotStore;
@@ -633,21 +632,23 @@ async function alignDailyWorkingTableColumns(
 /**
  * In Parquet mode, create working temp tables from Parquet files.
  * The enricher operates on these temp tables, then copies back to Parquet.
- * Uses timestamp suffix for uniqueness (no user input in table names per T-02-07).
+ * Uses a timestamp suffix for uniqueness — no user input in table names.
  *
- * Seed source priority (Plan 05-04 — post Wave-D deletion safety):
- *   1. Legacy `daily.parquet` / `date_context.parquet` — pre-deletion path
+ * Seed source priority (in order of preference):
+ *   1. Legacy `daily.parquet` / `date_context.parquet` — the pre-migration
+ *      single-file layout, still supported for data roots that have not yet
+ *      been rebuilt.
  *   2. New `enriched/ticker=*\/data.parquet` + `enriched/context/data.parquet`
- *      — post-deletion fallback. After Plan 05-04 retires daily.parquet, the
- *      working table is seeded from the per-ticker enriched layout (UNION ALL
- *      across the 4 Phase 5 tickers); OHLCV columns are NULL in the seed (the
- *      working table only needs OHLCV for legacy callers without io.spotStore;
- *      Tier 2 with io.spotStore reads VIX OHLCV from a separate temp seeded
- *      from spot/, so SPX historical Return_20D is the only enrichment field
- *      the SPX JOIN actually needs from the working table — and that lives
- *      in enriched/ticker=SPX/data.parquet).
- *   3. Empty fallback (`market.enriched WHERE 1=0`) when neither source exists
- *      — preserves the public-repo / fresh-clone behavior unchanged.
+ *      — the canonical per-ticker enriched layout. The working table is
+ *      seeded from a UNION ALL across the existing per-ticker files; OHLCV
+ *      columns are NULL in the seed (the working table only needs OHLCV
+ *      for legacy callers without io.spotStore; Tier 2 with io.spotStore
+ *      reads VIX OHLCV from a separate temp seeded from spot/, so SPX
+ *      historical Return_20D is the only enrichment field the SPX JOIN
+ *      actually needs from the working table — and that lives in
+ *      enriched/ticker=SPX/data.parquet).
+ *   3. Empty fallback (`market.enriched WHERE 1=0`) when neither source
+ *      exists — preserves fresh-clone behavior unchanged.
  */
 async function setupParquetWorkingTables(
   conn: DuckDBConnection,
@@ -665,20 +666,21 @@ async function setupParquetWorkingTables(
 
   // ---- Daily working table seed ---------------------------------------------
   if (existsSync(dailyPath)) {
-    // Legacy seed (pre-Wave-D)
+    // Legacy single-file seed
     await conn.run(`CREATE TEMP TABLE "${dailyTable}" AS SELECT * FROM read_parquet('${dailyPath}')`);
     // Parquet files from fresh imports may lack enrichment columns — add them
     await alignDailyWorkingTableColumns(conn, dailyTable);
   } else if (hasEnrichedTickerFiles(enrichedDir)) {
-    // Post-Wave-D seed: union per-ticker enriched/ticker=*/data.parquet files.
+    // Per-ticker seed: union the existing enriched/ticker=*/data.parquet files.
     // These contain (ticker, date, 28 enrichment cols) — no OHLCV. We add NULL
     // OHLCV columns via ALTER TABLE below so that:
     //   - Callers without io.spotStore reading OHLCV from the working table get
     //     schema-compatible NULLs rather than a SQL error.
-    //   - The io.spotStore canonical path (post-Phase-5) reads OHLCV from spot/
-    //     directly and never touches the working table's OHLCV columns.
-    //   - Tier 2 SPX JOIN reads Return_20D (enrichment, already present from
-    //     the seed) from the working table — the SPX JOIN does NOT use OHLCV.
+    //   - The io.spotStore canonical path reads OHLCV from spot/ directly and
+    //     never touches the working table's OHLCV columns.
+    //   - The Tier 2 SPX JOIN reads Return_20D (enrichment, already present
+    //     from the seed) from the working table — the SPX JOIN does NOT use
+    //     OHLCV.
     await conn.run(
       `CREATE TEMP TABLE "${dailyTable}" AS
        SELECT * FROM read_parquet('${enrichedTickerGlob}', hive_partitioning=true)`,
@@ -695,10 +697,10 @@ async function setupParquetWorkingTables(
     // ALTER TABLE ADD COLUMN is wrapped in try/catch, so idempotent).
     await alignDailyWorkingTableColumns(conn, dailyTable);
   } else {
-    // Phase 6 Wave D: fresh-clone / public-repo seed path. Legacy daily-view
-    // was dropped in this wave; seed the working table from market.enriched
-    // (the v3.0 per-ticker computed-fields view) and ALTER-ADD the OHLCV
-    // columns the Tier 1 math expects. Matches the shape used by the
+    // Fresh-clone seed path. The legacy daily-view no longer exists in the
+    // catalog; seed the working table from `market.enriched` (the canonical
+    // per-ticker computed-fields view) and ALTER-ADD the OHLCV columns the
+    // Tier 1 math expects. Matches the shape used by the
     // enriched-ticker-files branch above.
     await conn.run(
       `CREATE TEMP TABLE "${dailyTable}" AS SELECT * FROM market.enriched WHERE 1=0`,
@@ -713,24 +715,24 @@ async function setupParquetWorkingTables(
     await alignDailyWorkingTableColumns(conn, dailyTable);
   }
 
-  // quick-260421-l63 Rule 2: backfill missing (ticker, date) identity rows from
-  // market.spot_daily so batchUpdateDaily has rows to UPDATE. Applies to ALL
-  // seed paths above:
-  //   - Legacy daily.parquet branch: daily.parquet is historical; any new (ticker,date)
-  //     in market.spot_daily that isn't in the seed needs to be inserted before
-  //     enrichment. Usually a no-op (pre-deletion inventories agreed).
-  //   - Enriched-ticker-files branch: the seed only contains tickers with an
-  //     enriched/ticker=X/data.parquet file. Tickers that have spot data but
-  //     no enriched file yet (e.g. after partial delete — which is the L63
-  //     re-enrichment scenario) will be missed.
-  //   - Fresh branch: working table is empty, so every (ticker, date) in
+  // Backfill missing (ticker, date) identity rows from market.spot_daily so
+  // batchUpdateDaily has rows to UPDATE. Applies to ALL seed paths above:
+  //   - Legacy daily.parquet branch: any new (ticker, date) in
+  //     market.spot_daily that isn't in the seed needs to be inserted before
+  //     enrichment. Usually a no-op when inventories already agree.
+  //   - Per-ticker enriched-files branch: the seed only contains tickers with
+  //     an enriched/ticker=X/data.parquet file. Tickers that have spot data
+  //     but no enriched file yet (e.g. after a partial re-enrichment delete)
+  //     would otherwise be missed.
+  //   - Fresh branch: the working table is empty, so every (ticker, date) in
   //     market.spot_daily is new.
   //
-  // Without this backfill, UPDATE ... WHERE (ticker,date) matches 0 rows and
-  // the enricher silently writes an empty enriched/ticker=X/data.parquet file —
-  // corrupting historical enrichment on the first run after enriched/ is
-  // deleted. OHLCV columns stay NULL (io.spotStore is the canonical OHLCV
-  // source post-Phase-5; Tier 2 SPX JOIN uses enrichment fields, not OHLCV).
+  // Without this backfill, UPDATE ... WHERE (ticker, date) matches 0 rows and
+  // the enricher silently writes an empty enriched/ticker=X/data.parquet
+  // file — corrupting historical enrichment on the first run after
+  // enriched/ is deleted. OHLCV columns stay NULL (io.spotStore is the
+  // canonical OHLCV source; the Tier 2 SPX JOIN uses enrichment fields,
+  // not OHLCV).
   try {
     // CAST date to VARCHAR — market.spot_daily.date is inferred as DATE by
     // DuckDB (hive partition type inference); the working table's date column
@@ -755,10 +757,10 @@ async function setupParquetWorkingTables(
 
   // ---- Date-context working table seed -------------------------------------
   if (existsSync(dateContextPath)) {
-    // Legacy seed (pre-Wave-D)
+    // Legacy single-file seed
     await conn.run(`CREATE TEMP TABLE "${dateContextTable}" AS SELECT * FROM read_parquet('${dateContextPath}')`);
   } else if (existsSync(enrichedContextPath)) {
-    // Post-Wave-D seed from the new MDATA-03 layout
+    // Seed from the per-ticker enriched/context/data.parquet file
     await conn.run(
       `CREATE TEMP TABLE "${dateContextTable}" AS SELECT * FROM read_parquet('${enrichedContextPath}')`,
     );
@@ -800,29 +802,27 @@ function hasEnrichedTickerFiles(dir: string): boolean {
 }
 
 /**
- * Phase 5 Wave B (Plan 05-02 rewrite): write working table contents to the
- * `enriched/` partition layout — `enriched/ticker={ticker}/data.parquet` for
- * per-ticker enrichment columns and `enriched/context/data.parquet` for the
- * cross-ticker context.
+ * Write working-table contents to the `enriched/` partition layout —
+ * `enriched/ticker={ticker}/data.parquet` for per-ticker enrichment columns
+ * and `enriched/context/data.parquet` for the cross-ticker context.
  *
- * Behavior change vs pre-Phase-5: this function NO LONGER writes
- * `daily.parquet` or `date_context.parquet`. Those legacy files retire here;
- * Plan 05-04 deleted them. The `market.enriched` and `market.enriched_context`
- * views are the canonical read surfaces over the per-ticker enriched layout.
+ * This function does NOT write `daily.parquet` or `date_context.parquet`;
+ * those legacy single-file outputs are retired. The `market.enriched` and
+ * `market.enriched_context` views are the canonical read surfaces over the
+ * per-ticker enriched layout.
  *
- * MDATA-02 / D-25: the per-ticker enriched file contains ONLY computed
- * enrichment columns plus (ticker, date) — NO OHLCV. Raw OHLCV stays in spot/.
- *
- * MDATA-03: the context file contains the cross-ticker derived fields written
- * by runTier2 (Vol_Regime, Term_Structure_State, Trend_Direction, VIX_Spike_Pct,
- * VIX_Gap_Pct).
+ * Storage split: the per-ticker enriched file contains ONLY computed
+ * enrichment columns plus (ticker, date) — NO OHLCV. Raw OHLCV stays in
+ * spot/. The context file contains the cross-ticker derived fields written
+ * by runTier2 (Vol_Regime, Term_Structure_State, Trend_Direction,
+ * VIX_Spike_Pct, VIX_Gap_Pct).
  *
  * Filtered to `WHERE ticker = $ticker` so each per-ticker enrichment call only
- * touches its own partition. Other tickers' rows in the working table (carried
- * over from the daily.parquet seed) are not republished here.
+ * touches its own partition. Other tickers' rows in the working table
+ * (carried over from the legacy seed) are not republished here.
  *
- * Paths constructed from dataDir + hardcoded suffixes (T-02-09 — no
- * user-controlled path components; ticker is whitelisted upstream).
+ * Paths constructed from dataDir + hardcoded suffixes — no user-controlled
+ * path components; ticker is whitelisted upstream.
  */
 async function flushEnrichedToParquet(
   conn: DuckDBConnection,
@@ -897,20 +897,19 @@ async function runTier2(
   const dailyTarget = targets?.daily ?? "market.enriched";
   const dateContextTarget = targets?.dateContext ?? "market.enriched_context";
 
-  // Phase 5 Wave B rewire (A8 — Tier 2 part): when `spotStore` is provided,
-  // seed a TEMP table with VIX-family daily OHLCV from spot/ minute bars
-  // (aggregated via SpotStore.readDailyBars). The Tier 2 SQL below reads
-  // VIX/VIX9D/VIX3M from `effectiveDailyTarget` (the TEMP) instead of the
-  // working `dailyTarget` view — which after Plan 05-04 deletes daily.parquet
-  // would no longer contain VIX-family rows.
+  // When `spotStore` is provided, seed a TEMP table with VIX-family daily
+  // OHLCV from spot/ minute bars (aggregated via SpotStore.readDailyBars).
+  // The Tier 2 SQL below reads VIX/VIX9D/VIX3M from `effectiveDailyTarget`
+  // (the TEMP) instead of the working `dailyTarget` view, which after the
+  // legacy daily.parquet retirement no longer contains VIX-family rows.
   //
   // The SPX JOIN (for `Return_20D`) keeps reading from `dailyTarget` because
   // SPX Return_20D is a Tier 1 enriched field written to the working table
   // earlier in the runEnrichment pipeline — spot/ never holds enriched columns.
   //
   // IVR/IVP UPDATEs continue to target `dailyTarget` (legacy write path
-  // unchanged per plan). After Wave D those writes hit a temp table that is
-  // never persisted; Phase 6 will remove the legacy write path.
+  // unchanged). Post-retirement, those writes hit a temp table that is never
+  // persisted; the legacy write path is scheduled for removal.
   let effectiveDailyTarget = dailyTarget;
   let vixTempTable: string | null = null;
   if (spotStore) {
@@ -938,7 +937,7 @@ async function runTier2(
   }
 
   try {
-  // Step 1: Discover VIX-family tickers dynamically (per D-06)
+  // Step 1: Discover VIX-family tickers dynamically
   const tickerResult = await conn.runAndReadAll(
     `SELECT DISTINCT ticker FROM ${effectiveDailyTarget} WHERE ticker LIKE 'VIX%' ORDER BY ticker`
   );
@@ -948,9 +947,9 @@ async function runTier2(
   }
 
   // Step 2: Compute IVR/IVP for each VIX-family ticker and write to daily table.
-  // Phase 6 Wave D: market.enriched has no OHLCV columns (D-25 split). Read
-  // close from the OHLCV source: the spotStore-seeded TEMP table when
-  // io.spotStore is present, else market.spot_daily (RTH-aggregated view).
+  // `market.enriched` no longer carries OHLCV columns (raw bars live in spot/);
+  // read close from the OHLCV source: the spotStore-seeded TEMP table when
+  // io.spotStore is present, else `market.spot_daily` (RTH-aggregated view).
   const closeSource = spotStore ? effectiveDailyTarget : "market.spot_daily";
   for (const ticker of vixTickers) {
     const closeResult = await conn.runAndReadAll(
@@ -997,12 +996,12 @@ async function runTier2(
   // Step 3: Build ContextRow objects from daily VIX tickers for derived fields
   // Query VIX close/open/high, VIX9D close/open, VIX3M close/open, plus Return_20D for Trend_Direction.
   //
-  // Phase 6 Wave D: the VIX-family OHLCV source is `effectiveDailyTarget`
-  // (spotStore-seeded TEMP when io.spotStore is present) or market.spot_daily
-  // when io.spotStore is absent — market.enriched has no OHLCV columns
-  // (D-25 split). The SPX JOIN keeps `dailyTarget` because Return_20D is a
-  // Tier 1 enriched column written to the working table earlier in the
-  // runEnrichment pipeline; spot/ never holds enriched fields.
+  // The VIX-family OHLCV source is `effectiveDailyTarget` (the
+  // spotStore-seeded TEMP when io.spotStore is present) or
+  // `market.spot_daily` when io.spotStore is absent — `market.enriched` no
+  // longer carries OHLCV columns. The SPX JOIN keeps `dailyTarget` because
+  // Return_20D is a Tier 1 enriched column written to the working table
+  // earlier in the runEnrichment pipeline; spot/ never holds enriched fields.
   const vixOhlcvSource = spotStore ? effectiveDailyTarget : "market.spot_daily";
   const contextQuery = `
     SELECT
@@ -1028,10 +1027,10 @@ async function runTier2(
   if (rawRows.length === 0) return { status: "complete", fieldsWritten: 0 };
 
   // Query VIX RTH open from intraday bars.
-  // Plan 02-04 Call Site 5: when spotStore provided, route through
-  // SpotStore.readBars('VIX', ...) and filter to the 09:30–09:32 RTH window
-  // in TypeScript. Result is bit-exact: same ticker filter, same time window,
-  // same "first seen per date" selection (readBars sorts by (date, time)).
+  // When spotStore is provided, route through SpotStore.readBars('VIX', ...)
+  // and filter to the 09:30–09:32 RTH window in TypeScript. Result is
+  // bit-exact: same ticker filter, same time window, same "first seen per
+  // date" selection (readBars sorts by (date, time)).
   const rthOpenByDate = new Map<string, number>();
   if (spotStore) {
     try {
@@ -1058,8 +1057,8 @@ async function runTier2(
     }
   } else {
     try {
-      // Phase 6 Wave D: legacy minute-bar view rewritten to market.spot
-      // (v3.0 canonical minute-bar view; schema preserves ticker/time/open).
+      // Canonical minute-bar view is `market.spot` — same ticker/time/open
+      // schema as the earlier intraday view it replaced.
       // Defense-in-depth: skip zero/null open bars so a 09:30 provider gap
       // doesn't get cached as the day's VIX_RTH_Open. The first non-zero
       // bar in 09:30-09:32 wins.
@@ -1130,9 +1129,9 @@ async function runTier2(
 
   return { status: "complete", fieldsWritten: derivedCols.length - 1 }; // -1 for date
   } finally {
-    // Phase 5 Wave B rewire: drop the spotStore-seeded TEMP unconditionally so
-    // it cannot leak across runEnrichment calls (each call gets a fresh ts-suffixed
-    // table name, but DROP-on-finally keeps DuckDB's TEMP catalog clean).
+    // Drop the spotStore-seeded TEMP unconditionally so it cannot leak across
+    // runEnrichment calls (each call gets a fresh ts-suffixed table name, but
+    // DROP-on-finally keeps DuckDB's TEMP catalog clean).
     if (vixTempTable) {
       try { await conn.run(`DROP TABLE IF EXISTS "${vixTempTable}"`); } catch { /* */ }
     }
@@ -1142,8 +1141,8 @@ async function runTier2(
 /**
  * Check if any intraday data exists for a ticker.
  *
- * Plan 02-04 Call Site 6: when `spotStore` is provided, routes through
- * `SpotStore.getCoverage` instead of a SQL probe against market.spot.
+ * When `spotStore` is provided, routes through `SpotStore.getCoverage`
+ * instead of a SQL probe against `market.spot`.
  */
 async function hasTier3Data(
   conn: DuckDBConnection,
@@ -1154,8 +1153,8 @@ async function hasTier3Data(
     const cov = await spotStore.getCoverage(ticker, "1970-01-01", "9999-12-31");
     return cov.totalDates > 0;
   }
-  // Phase 6 Wave D: legacy minute-bar view rewritten to market.spot
-  // (v3.0 canonical minute-bar view; schema preserves ticker filter).
+  // Canonical minute-bar view is `market.spot` — same ticker-filter schema
+  // as the earlier intraday view it replaced.
   const r = await conn.runAndReadAll(
     `SELECT COUNT(*) FROM market.spot WHERE ticker = $1 LIMIT 1`,
     [ticker]
@@ -1201,8 +1200,8 @@ export async function runContextEnrichment(
  *
  * The watermark is upserted via the JSON adapter (`upsertEnrichedThrough` from
  * `db/json-adapters.ts`) — either the supplied `io.watermarkStore` or, when
- * absent, a direct call using `opts.dataDir`. Plan 04-05 removed the legacy
- * SQL watermark path on the metadata sync table entirely.
+ * absent, a direct call using `opts.dataDir`. The legacy SQL watermark path
+ * on the metadata sync table has been removed.
  *
  * Note: wilder_state column exists but is NOT written (superseded by 200-day lookback).
  *
@@ -1232,8 +1231,8 @@ export async function runEnrichment(
 
   try {
   // 1. Get the persisted enrichment watermark.
-  // Plan 04-05: every read goes through the JSON adapter (D-20). The legacy
-  // SQL SELECT against the metadata sync table is GONE — when callers
+  // Every watermark read goes through the JSON adapter. The legacy SQL
+  // SELECT against the metadata sync table has been removed — when callers
   // don't supply `io.watermarkStore` we fall back to the same JSON adapter
   // the store wrappers wire (`getEnrichedThrough(ticker, dataDir)`).
   let watermark: string | null = null;
@@ -1255,14 +1254,14 @@ export async function runEnrichment(
 
   // 3. Fetch OHLCV rows.
   //
-  // Phase 5 Wave B rewire (A8 closure): when `io.spotStore` is provided, read
-  // daily OHLCV via `SpotStore.readDailyBars` (aggregated from spot/ minute
-  // bars). After Plan 05-04 deletes daily.parquet, this remains functional
-  // because readDailyBars aggregates from spot/ticker=X/date=Y/data.parquet.
+  // When `io.spotStore` is provided, read daily OHLCV via
+  // `SpotStore.readDailyBars` (aggregated from spot/ minute bars). This path
+  // remains functional after the legacy `daily.parquet` retirement because
+  // readDailyBars aggregates from spot/ticker=X/date=Y/data.parquet.
   //
   // Fallback: when `io.spotStore` is absent (legacy callers), retain a SQL
-  // path against `market.enriched`. Phase 6 may remove the fallback entirely
-  // once all callers pass io.
+  // path against `market.spot_daily`. The fallback may be removed once all
+  // callers pass io.
   let rawRows: Array<Array<unknown>>;
   if (io?.spotStore) {
     const startDate = lookbackStart ?? "1970-01-01";
@@ -1270,10 +1269,10 @@ export async function runEnrichment(
     const dailyBars = await io.spotStore.readDailyBars(ticker, startDate, endDate);
     rawRows = dailyBars.map((b) => [b.ticker, b.date, b.open, b.high, b.low, b.close]);
   } else {
-    // Phase 6 Wave D: the legacy daily-view SQL fallback path is gone — the
-    // view no longer exists in the catalog post-cut. Route OHLCV reads through
-    // the v3.0 market.spot_daily view (RTH-aggregated from market.spot). This
-    // bridges callers that have not yet migrated to io.spotStore; post-Wave-D
+    // The legacy daily-view SQL fallback path is gone — the view no longer
+    // exists in the catalog. Route OHLCV reads through the canonical
+    // `market.spot_daily` view (RTH-aggregated from `market.spot`). This
+    // bridges callers that have not yet migrated to io.spotStore; new
     // callers SHOULD pass io.spotStore for parity with the Parquet-direct path.
     let fetchSql = `SELECT ticker, date, open, high, low, close FROM market.spot_daily WHERE ticker = $1`;
     const fetchParams: unknown[] = [ticker];
@@ -1300,12 +1299,12 @@ export async function runEnrichment(
     };
   }
 
-  // 3b. Defensive zero-OHLC filter (quick-260421-l63). Partitions should already
-  // be clean after the L63 cleanup + ParquetSpotStore.writeBars guard, but this
-  // second line of defense catches any future provider-outage bleed and prevents
-  // RSI/ATR/EMA/SMA/RealizedVol from being poisoned by zero closes. Filter at
-  // the rawRows level so date/OHLC alignment is preserved across all five arrays
-  // (dates/opens/highs/lows/closes) constructed below.
+  // 3b. Defensive zero-OHLC filter. Partitions should already be clean after
+  // the ParquetSpotStore.writeBars guard, but this second line of defense
+  // catches any future provider-outage bleed and prevents
+  // RSI/ATR/EMA/SMA/RealizedVol from being poisoned by zero closes. Filter
+  // at the rawRows level so date/OHLC alignment is preserved across all
+  // five arrays (dates/opens/highs/lows/closes) constructed below.
   const filteredRawRows = rawRows.filter((r) => {
     const o = Number(r[2]);
     const h = Number(r[3]);
@@ -1513,16 +1512,17 @@ export async function runEnrichment(
   } : undefined;
   const tier2Result = await runTier2(conn, tier2Targets, io?.spotStore);
 
-  // 10. Tier 3 — intraday timing fields (Plan 02-04: route through io.spotStore when provided)
+  // 10. Tier 3 — intraday timing fields (routes through io.spotStore when provided)
   const tier3Result = await runTier3(conn, ticker, dates, dailyTarget, io?.spotStore);
 
   // 11. Persist the new watermark.
-  // Plan 04-05: every write goes through the JSON adapter (D-20). The legacy
-  // SQL UPSERT against the metadata sync table is GONE — when callers don't
-  // supply `io.watermarkStore` we fall back to `upsertEnrichedThrough(ticker,
-  // val, dataDir)` directly. If neither io nor dataDir is supplied the
-  // watermark simply isn't persisted (math still runs); callers that need
-  // watermark continuity must supply one of the two.
+  // Every watermark write goes through the JSON adapter. The legacy SQL
+  // UPSERT against the metadata sync table has been removed — when callers
+  // don't supply `io.watermarkStore` we fall back to
+  // `upsertEnrichedThrough(ticker, val, dataDir)` directly. If neither io
+  // nor dataDir is supplied the watermark simply isn't persisted (math
+  // still runs); callers that need watermark continuity must supply one of
+  // the two.
   const newWatermark = dates[dates.length - 1];
   if (io?.watermarkStore) {
     await io.watermarkStore.upsert(ticker, newWatermark);
@@ -1530,7 +1530,8 @@ export async function runEnrichment(
     await upsertEnrichedThrough(ticker, newWatermark, opts.dataDir);
   }
 
-  // 12. Parquet mode: write enrichment to enriched/ partition layout (Plan 05-02 rewrite — daily.parquet retired)
+  // 12. Parquet mode: write enrichment to the enriched/ partition layout
+  //     (legacy daily.parquet output retired)
   if (parquetMode && workingTables && opts.dataDir) {
     await flushEnrichedToParquet(conn, opts.dataDir, ticker, workingTables);
   }
@@ -1682,7 +1683,7 @@ async function runTier3(
   spotStore?: SpotStore,
 ): Promise<TierStatus> {
   // Check if intraday data exists for this ticker
-  // Plan 02-04 Call Site 6: routed through spotStore.getCoverage when provided
+  // Routes through spotStore.getCoverage when provided
   const hasData = await hasTier3Data(conn, ticker, spotStore);
   if (!hasData) {
     return {
@@ -1692,7 +1693,7 @@ async function runTier3(
   }
 
   // Query intraday bars for all dates in the enrichment range.
-  // Plan 02-04 Call Site 7: when spotStore provided, route through
+  // When spotStore is provided, route through
   // SpotStore.readBars(ticker, from, to). The downstream group-by-date math
   // is unchanged — we just reshape BarRow[] into the same tuple-index shape
   // the existing math consumes (date, time, open, high, low, close).
@@ -1715,8 +1716,8 @@ async function runTier3(
     lowIdx = 4;
     closeIdx = 5;
   } else {
-    // Phase 6 Wave D: legacy minute-bar view rewritten to market.spot
-    // (v3.0 canonical minute-bar view; schema unchanged for ticker/date/time/ohlcv).
+    // Canonical minute-bar view is `market.spot` — same
+    // ticker/date/time/ohlcv schema as the earlier intraday view it replaced.
     // Defense-in-depth: filter out zero/null minute bars at the SQL layer so
     // Tier 3 timing fields (High_Time, Low_Time, Opening_Drive_Strength) are
     // never seeded with provider-gap timestamps.

--- a/packages/mcp-server/src/utils/market-importer.ts
+++ b/packages/mcp-server/src/utils/market-importer.ts
@@ -1,10 +1,10 @@
 /**
- * Market Data Importer — Stores-based path (Phase 4 INGEST-01 / D-22 / D-23).
+ * Market Data Importer — stores-based ingest surface.
  *
- * This file is the new ingest surface introduced in Plan 04-07. Every spot-bar
- * write flows through `SpotStore.writeBars(ticker, date, BarRow[])`. The
- * `target_table` parameter is GONE — daily / date_context outputs are derived
- * by `EnrichedStore.compute()` + `computeContext()` invoked at the tool-handler
+ * Every spot-bar write flows through `SpotStore.writeBars(ticker, date,
+ * BarRow[])`. The `target_table` parameter from the earlier ingest API has
+ * been removed — daily / date_context outputs are derived by
+ * `EnrichedStore.compute()` + `computeContext()` invoked at the tool-handler
  * layer (see `tools/market-imports.ts`).
  *
  * Exports:
@@ -322,7 +322,7 @@ export function parseDatabaseRowsToBars(
  * Import a CSV file by parsing it into BarRow[] and writing per-date
  * partitions through `stores.spot.writeBars`. Pure orchestration — does NOT
  * call `EnrichedStore.compute()`; the tool-handler layer composes enrichment
- * after the spot write per D-23.
+ * after the spot write.
  */
 export async function importMarketCsvFile(
   stores: MarketStores,

--- a/packages/mcp-server/src/utils/migrate-option-data-helpers.ts
+++ b/packages/mcp-server/src/utils/migrate-option-data-helpers.ts
@@ -1,13 +1,13 @@
 /**
- * Pure helpers for migrate-option-data.mjs (Phase 3).
+ * Pure helpers for the option-data migration script.
  *
- * No IO, no DuckDB, no filesystem — these functions are the unit-test target
- * for Phase 3 (CONTEXT.md D-24). The .mjs script that consumes them is not
- * unit-testable due to filesystem effects; these helpers carry the safety net.
+ * No IO, no DuckDB, no filesystem — these functions are the unit-test
+ * target. The .mjs script that consumes them is not unit-testable due to
+ * filesystem effects; these helpers carry the safety net.
  */
 import type { TickerRegistry } from "../market/tickers/registry.js";
 
-/** Hardcoded skip list for leveraged-ETF roots (CONTEXT.md D-09 — verbatim list, audit-friendly). */
+/** Hardcoded skip list for leveraged-ETF roots — verbatim list, audit-friendly. */
 export const LEVERAGED_ETFS = new Set(["SPXL", "SPXS", "SPXU", "SPXC"]);
 
 export interface GroupResult {
@@ -42,8 +42,9 @@ export function groupTickersByUnderlying(
 
 /**
  * Build the SELECT for option_chain rewrite. Uses `* EXCLUDE (underlying)`
- * per CONTEXT.md D-05 — the underlying lives in the partition path post-migration.
- * sourceGlob is interpolated raw; caller must pass a trusted, migrator-composed path.
+ * because the underlying lives in the partition path post-migration, not in
+ * a row-level column. sourceGlob is interpolated raw; caller must pass a
+ * trusted, migrator-composed path.
  */
 export function buildOptionChainSelectQuery(
   sourceGlob: string,
@@ -55,8 +56,8 @@ export function buildOptionChainSelectQuery(
 }
 
 /**
- * Build the SELECT for option_quote_minutes rewrite. NO EXCLUDE — body has no
- * `underlying` column (CONTEXT.md D-08). Filters by root via regexp_extract.
+ * Build the SELECT for option_quote_minutes rewrite. NO EXCLUDE — the body
+ * has no `underlying` column. Filters by root via regexp_extract.
  */
 export function buildOptionQuoteSelectQuery(
   sourceGlob: string,

--- a/packages/mcp-server/src/utils/providers/massive.ts
+++ b/packages/mcp-server/src/utils/providers/massive.ts
@@ -6,11 +6,11 @@
  * (option chain snapshots) into a single provider adapter.
  *
  * Key design decisions:
- * - D-01/D-02/D-03: API key read at call site via process.env.MASSIVE_API_KEY
- * - D-05: Pagination loop guard with seen-cursor Set + MAX_PAGES=500 safety net
- * - D-06: adjusted=false and limit=50000 in all aggregate API calls
- * - D-07: 429 retry with Retry-After header or exponential backoff
- * - D-09/D-10/D-11: Ticker prefixes (I: for indices, O: for options)
+ * - API key read at call site via process.env.MASSIVE_API_KEY
+ * - Pagination loop guard with seen-cursor Set + MAX_PAGES=500 safety net
+ * - adjusted=false and limit=50000 in all aggregate API calls
+ * - 429 retry with Retry-After header or exponential backoff
+ * - Ticker prefixes: I: for indices, O: for options
  * - Timestamps are Unix milliseconds from the Massive aggregates API
  */
 

--- a/packages/mcp-server/src/utils/sample-date-selector.ts
+++ b/packages/mcp-server/src/utils/sample-date-selector.ts
@@ -1,17 +1,17 @@
 /**
- * sample-date-selector.ts — deterministic sample-date generator for Phase 5
- * enrichment verification.
+ * sample-date-selector.ts — deterministic sample-date generator for
+ * enrichment-rebuild verification.
  *
- * Phase 5 Wave 0 / VALIDATION task 5-00-01. Produces a reproducible list of
- * ~15–20 dates per D-08 sizing. The same seed always yields the same sample
- * so re-runs of Wave C verification produce comparable drift reports.
+ * Produces a reproducible list of ~15–20 dates (sized for fast verification
+ * runs across the supported tickers). The same seed always yields the same
+ * sample so re-runs of the verification harness produce comparable drift
+ * reports.
+ *
+ * Pattern: known-event dates + structural calendar-edge dates + N
+ * pseudo-random weekday draws from a Mulberry32 PRNG.
  *
  * Pure module — no filesystem, no DuckDB, no provider imports. Safe to import
  * from unit tests, operator scripts, and verification harnesses alike.
- *
- * See .planning/phases/05-spot-backfill-enrichment-rebuild/05-RESEARCH.md
- * §Example 2 for the full pattern (Mulberry32 PRNG + known-event + structural +
- * random).
  */
 
 /**
@@ -25,15 +25,16 @@ export interface SampleDate {
 }
 
 /**
- * Phase 5 PRNG seed. Pinned to the Phase 5 kickoff date (2026-04-18 → 20260418)
- * so every invocation of `selectVerificationSampleDates` with default args
- * yields the committed fixture.
+ * PRNG seed. Pinned to a fixed integer so every invocation of
+ * `selectVerificationSampleDates` with default args yields the committed
+ * fixture.
  */
 export const PHASE_5_FIXTURE_SEED = 20260418;
 
 /**
  * Known-event dates — always included in the sample regardless of seed.
- * See 05-CONTEXT.md §Enrichment Verification D-08.
+ * Each is a real high-volatility or calendar-significant trading day used
+ * to stress the enrichment math.
  */
 export const PHASE_5_KNOWN_EVENTS: SampleDate[] = [
   { date: "2024-08-05", category: "known_event", note: "VIX spike, ~65% gap, Japan carry unwind" },
@@ -99,7 +100,7 @@ function enumerateWeekdays(fromDate: string, toDate: string): string[] {
  *
  * Same `(fromDate, toDate, seed, randomCount)` → same output, always.
  *
- * @param fromDate - inclusive lower bound, default Phase 5 floor 2022-01-01
+ * @param fromDate - inclusive lower bound, default 2022-01-01
  * @param toDate - inclusive upper bound, typically "yesterday" at call time
  * @param seed - Mulberry32 PRNG seed, default PHASE_5_FIXTURE_SEED
  * @param randomCount - number of random dates to draw (default 9 → total ~18)

--- a/packages/mcp-server/src/utils/tool-ticker-deps.ts
+++ b/packages/mcp-server/src/utils/tool-ticker-deps.ts
@@ -1,17 +1,16 @@
 /**
- * Tool Dependency Registry (RESOLVE-02).
+ * Tool Dependency Registry.
  *
  * Maps each MCP tool name to its required spot tickers. A `[]` entry means
  * "target ticker is dynamic" — the caller passes `targetTicker` to
  * `unionTickerDeps(...)` and the registry substitutes it in.
  *
- * Intentionally static (Phase 4 CONTEXT D-21): adding a new tool means editing
- * this file. Consistent with how MCP tools are registered in src/index.ts /
- * src/index.ext.ts.
+ * Intentionally static: adding a new tool means editing this file,
+ * consistent with how MCP tools are registered.
  *
- * Downstream: Phase 4 Wave D (`utils/data-pipeline.ts::buildFetchPlan`)
- * replaces the hardcoded `SPX -> ['SPX','VIX','VIX9D']` branch with
- * `unionTickerDeps(requestedTools, strategy.underlying)`.
+ * Consumed by `utils/data-pipeline.ts::buildFetchPlan` —
+ * `unionTickerDeps(requestedTools, strategy.underlying)` replaces the
+ * hardcoded per-underlying branch in the fetch planner.
  */
 export const TOOL_TICKER_DEPS: Record<string, string[]> = {
   backtester:         ['SPX', 'VIX', 'VIX9D'],


### PR DESCRIPTION
Tier: 3 (public-repo, doc-only)

## Summary

Pure JSDoc/comment scrub across 12 files in `packages/mcp-server/src/` (9 `utils/`, 2 `db/`, 1 `test-exports.ts`). Part 3 of 4 for tradeblocks-org/enterprise#110. Rolls in the originally-planned PR 5 (test-exports.ts) and adds the 2 `db` files that #110's inventory listed but no recommended PR claimed.

+340 / −373 lines. Zero behavior change.

## Files

- `packages/mcp-server/src/utils/{calibration-probe,data-quality,enrichment-verification,market-enricher,market-importer,migrate-option-data-helpers,sample-date-selector,tool-ticker-deps}.ts`
- `packages/mcp-server/src/utils/providers/massive.ts`
- `packages/mcp-server/src/db/{json-adapters,market-views}.ts`
- `packages/mcp-server/src/test-exports.ts`

## Three runtime identifiers explicitly preserved (not scrubbed)

- **`PHASE_5_FIXTURE_SEED`, `PHASE_5_KNOWN_EVENTS`, `PHASE_5_STRUCTURAL_DATES`** exported via `test-exports.ts` — identifiers, not comments. Rename would break consumers; out of scope here.
- **`_phase5_tier2_daily_${Date.now()}`** runtime SQL temp-table prefix in `market-enricher.ts:~916` — runtime identifier, not a comment. Untouched.
- **`backtester:` MCP tool key** in `tool-ticker-deps.ts:16` — registered tool name, load-bearing identifier on the public MCP surface. Untouched.

If a future cleanup wants to retire those prefixes, it'll need to rename the symbols and update all callers — a separate initiative.

## `test-exports.ts` symbol parity check

102 exports on base ↔ 102 on head, diff-confirmed identical sorted set. Section dividers ("End of Phase N block" etc.) collapsed to a single descriptive header per group. **Zero symbols dropped or reordered.**

## What changed in wording

- **`market-enricher.ts` (largest file, 263 lines touched)**: `Plan 04-05`, `Phase 6 Wave D`, `D-14/D-15/D-20`, `T-02-07`, `quick-260421-l63` ticket refs stripped. Each substantive comment (seed-source priority, watermark transitional-callers rationale, identity-row backfill logic) keeps its *why* — only the labels go.
- **`test-exports.ts` (163 lines)**: section-divider noise collapsed. Per-symbol docstrings rewritten to convey purpose to a public consumer.
- **`db/json-adapters.ts:14`**: dropped the sentence pairing `D-04` internal vocab with the `.ext.ts` mention — the cleanest rewrite removed both naturally (consistent with #107 spec note that natural drops are fine).
- **`db/market-views.ts:213`**: similar — `D-23 connection.ext.ts` block-comment rewrite. Retained the parenthetical `(moved from connection.ext.ts)` at line 166 as a useful historical-provenance breadcrumb for readers tracing why the view registration lives where it does. A follow-up could decide whether to drop that breadcrumb once #107 closes.
- **`utils/market-enricher.ts:917`** runtime SQL string `_phase5_tier2_daily_${Date.now()}`: unchanged (runtime identifier, see above).

## Verification

- Lint clean (`npm run lint -- --max-warnings=0`)
- Typecheck: 3 pre-existing errors in `utils/exit-triggers.ts` on `origin/feat/tradeblocks-3.0` baseline — unrelated, untouched. **(Geordi flagged these as real production bugs reading missing properties — opening a follow-up card.)**
- Internal-vocab grep on the 12 target files: clean
- Public-boundary grep repo-wide: clean
- `test-exports.ts` symbol-set parity: 102 = 102, identical

## What I'm asking

Does the new prose read well to an external lib consumer? Heaviest of the four sweep PRs by line count — biggest single file is `market-enricher.ts` (263 lines). Substance preserved across the seed-source priority docstrings, watermark rationale, and identity-row backfill explanations.

## Test plan

- [x] Lint clean
- [x] Typecheck clean of new errors
- [x] Internal-vocab grep clean on target files
- [x] Public-boundary grep clean repo-wide
- [x] test-exports.ts symbol parity verified
- [x] Three runtime identifiers explicitly preserved
- [ ] Smith review

🤖 Generated with [Claude Code](https://claude.com/claude-code)