### PR TITLE
docs(tests): scrub internal-ticket vocab from public-lib test docs

### DIFF
--- a/packages/mcp-server/tests/fixtures/enrichment-verification-dates.ts
+++ b/packages/mcp-server/tests/fixtures/enrichment-verification-dates.ts
@@ -1,16 +1,16 @@
 /**
- * Phase 5 sample-date canonical fixture.
+ * Canonical sample-date fixture for enrichment verification.
  *
- * This is the committed reference list Wave C verification consumes. It was
- * generated once by running:
+ * This is the committed reference list the verification path consumes. It
+ * was generated once by running:
  *
  *   selectVerificationSampleDates('2022-01-01', '2026-04-17', 20260418, 9)
  *
- * and pasted verbatim below. Wave C re-runs the selector to produce a fresh
- * list and then compares against this constant — any drift here would mean
- * the PRNG implementation (or one of the hardcoded known/structural date sets)
- * changed, which is a real regression that requires operator ACK before
- * proceeding.
+ * and pasted verbatim below. The verification path re-runs the selector to
+ * produce a fresh list and then compares against this constant — any drift
+ * here would mean the PRNG implementation (or one of the hardcoded
+ * known/structural date sets) changed, which is a real regression that
+ * requires operator ACK before proceeding.
  *
  * Regenerate via:
  *

--- a/packages/mcp-server/tests/integration/greeks-attribution.test.ts
+++ b/packages/mcp-server/tests/integration/greeks-attribution.test.ts
@@ -62,11 +62,11 @@ describe("get_greeks_attribution integration", () => {
       )
     `);
 
-    // Phase 4 Plan 04-02: handleReplayTrade (called by greeks-attribution)
-    // now reads underlying bars via stores.spot.readBars + VIX IVP via
-    // stores.enriched.read. Create the minimal market schema in this in-memory
-    // DuckDB so the migrated handler-body store calls succeed (empty data
-    // matches the prior-fetch-based behavior since the test mocks fetch).
+    // handleReplayTrade (called by greeks-attribution) reads underlying bars
+    // via stores.spot.readBars + VIX IVP via stores.enriched.read. Create the
+    // minimal market schema in this in-memory DuckDB so the store-backed
+    // handler calls succeed (empty data matches the prior fetch-based
+    // behavior since the test mocks fetch).
     await conn.run(`CREATE SCHEMA IF NOT EXISTS market`);
     await conn.run(`
       CREATE TABLE market.spot (
@@ -91,9 +91,9 @@ describe("get_greeks_attribution integration", () => {
       )
     `);
 
-    // Phase 4 Plan 04-04: option-leg reads now flow through
-    // stores.quote.readQuotes → market.option_quote_minutes. Schema mirrors
-    // production market-schemas.ts (PK underlying, date, ticker, time).
+    // Option-leg reads flow through stores.quote.readQuotes →
+    // market.option_quote_minutes. Schema mirrors production market-schemas.ts
+    // (PK underlying, date, ticker, time).
     await conn.run(`
       CREATE TABLE market.option_quote_minutes (
         underlying      VARCHAR NOT NULL,
@@ -120,10 +120,10 @@ describe("get_greeks_attribution integration", () => {
     conn.closeSync();
   });
 
-  // Phase 4 Plan 04-02: seed SPY underlying bars directly into market.spot
-  // since handleReplayTrade now reads underlying via stores.spot (not fetch).
-  // ET wallclock: 2025-01-17 is in EST (UTC-5). SPY_UNDERLYING_DAY1_BARS use
-  // UTC ms aligned to 14:30 UTC = 09:30 ET.
+  // Seed SPY underlying bars directly into market.spot since handleReplayTrade
+  // reads underlying via stores.spot (not fetch). ET wallclock: 2025-01-17 is
+  // in EST (UTC-5). SPY_UNDERLYING_DAY1_BARS use UTC ms aligned to
+  // 14:30 UTC = 09:30 ET.
   const seedSpyUnderlying = async (
     bars: Array<{ t: number; o: number; h: number; l: number; c: number }>,
   ) => {
@@ -141,9 +141,9 @@ describe("get_greeks_attribution integration", () => {
     }
   };
 
-  // Phase 4 Plan 04-04: seed option_quote_minutes for the unskipped option-leg
-  // tests. Mirrors trade-replay.test.ts seedOptionQuotes (HL2-anchored
-  // bid/ask split with 0.05 spread → mid = bar.close).
+  // Seed option_quote_minutes for the option-leg tests. Mirrors
+  // trade-replay.test.ts seedOptionQuotes (HL2-anchored bid/ask split with
+  // 0.05 spread → mid = bar.close).
   const seedOptionQuotes = async (
     occTicker: string,
     underlying: string,
@@ -167,8 +167,8 @@ describe("get_greeks_attribution integration", () => {
     }
   };
 
-  // Phase 4 Plan 04-04 — un-skipped: option-leg quotes seeded directly into
-  // market.option_quote_minutes via seedOptionQuotes (replaces mockFetch).
+  // Option-leg quotes seeded directly into market.option_quote_minutes via
+  // seedOptionQuotes (replaces mockFetch).
   test("summary mode keeps raw factor P&Ls and reports execution edge separately", async () => {
     await conn.run(`
       INSERT INTO trades.trade_data
@@ -230,8 +230,8 @@ describe("get_greeks_attribution integration", () => {
     `);
 
     await seedSpyUnderlying([...SPY_UNDERLYING_DAY1_BARS, ...SPY_UNDERLYING_DAY2_BARS]);
-    // Phase 4 Plan 04-04: option-leg quotes seeded directly into
-    // market.option_quote_minutes (replaces mockFetch on option tickers).
+    // Option-leg quotes seeded directly into market.option_quote_minutes
+    // (replaces mockFetch on option tickers).
     await seedOptionQuotes("SPY250117C00470000", "SPY", SPY_470C_BARS);
     await seedOptionQuotes("SPY250118C00475000", "SPY", SPY_475C_BARS);
 

--- a/packages/mcp-server/tests/integration/market-import.test.ts
+++ b/packages/mcp-server/tests/integration/market-import.test.ts
@@ -1,12 +1,11 @@
 /**
- * Integration tests for `validateColumnMapping` (Plan 04-07 boundary).
+ * Integration tests for `validateColumnMapping`.
  *
- * Pre-Phase-4 this file also tested `importMarketCsvFile(conn, options)` and
- * `importFromDatabase(conn, options)` — both signatures were DELETED in
- * Plan 04-07 Task 2 alongside the legacy `target_table`-driven write path.
- * The new contract (stores-based, no `target_table`) is exercised by the
- * companion `market-imports-v2.test.ts` integration suite + the
- * `tests/unit/market-imports.test.ts` unit suite (both per D-27).
+ * Earlier iterations of this file also tested `importMarketCsvFile(conn, ...)`
+ * and `importFromDatabase(conn, ...)` directly, but both signatures were
+ * removed alongside the legacy `target_table`-driven write path. The new
+ * stores-based contract is exercised by `market-imports-v2.test.ts`
+ * (integration) and `tests/unit/market-imports.test.ts` (unit).
  *
  * `validateColumnMapping` survives unchanged — pure helper, still useful for
  * any future caller that wants to fail fast on a missing schema field.

--- a/packages/mcp-server/tests/integration/market-imports-v2.test.ts
+++ b/packages/mcp-server/tests/integration/market-imports-v2.test.ts
@@ -1,9 +1,9 @@
 /**
- * Wave D Plan 04-07 — INGEST-01 integration test scaffold.
+ * Integration tests for the `import_market_csv` and `import_from_database`
+ * MCP tool handlers (stores-backed contract).
  *
- * Exercises the rewritten `import_market_csv` and `import_from_database` MCP
- * tool handlers after `target_table` is dropped from the Zod schema (D-22) and
- * the auto-enrich composition (D-23) is wired at the tool-handler level.
+ * The Zod input schemas no longer accept `target_table`; auto-enrichment is
+ * composed into the tool handlers themselves.
  *
  * Pattern (mirrors tests/integration/wave-c-enrichment-contract.test.ts):
  *   - `buildStoreFixture({ parquetMode: false })` — builds an in-memory
@@ -14,10 +14,10 @@
  *   - Tool-handler capture via `makeServer()` mirrors the harness in
  *     `tests/integration/data-pipeline-tools.test.ts:21-31`.
  *
- * The legacy test at `tests/integration/market-import.test.ts` calls the
- * importer functions directly (`importMarketCsvFile(conn, ...)`); this file
- * exercises the MCP tool surface end-to-end so we catch handler-level
- * regressions (RW lifecycle, Zod rejection, auto-enrich composition).
+ * The sibling test at `tests/integration/market-import.test.ts` exercises
+ * `validateColumnMapping` directly; this file exercises the MCP tool surface
+ * end-to-end so we catch handler-level regressions (RW lifecycle, Zod
+ * rejection, auto-enrich composition).
  */
 import * as fs from "fs/promises";
 import * as path from "path";
@@ -114,10 +114,10 @@ const COLUMN_MAPPING_FULL: Record<string, string> = {
 };
 
 // ---------------------------------------------------------------------------
-// 1. import_market_csv (INGEST-01)
+// 1. import_market_csv
 // ---------------------------------------------------------------------------
 
-describe("import_market_csv (INGEST-01)", () => {
+describe("import_market_csv", () => {
   let fixture: FixtureHandle;
   let stores: MarketStores;
   let csvPath: string;
@@ -135,7 +135,7 @@ describe("import_market_csv (INGEST-01)", () => {
     fixture.cleanup();
   });
 
-  it("Test 1.1 — writes SPX bars via stores.spot (no target_table)", async () => {
+  it("writes SPX bars via stores.spot (no target_table)", async () => {
     const { server, tools } = makeServer();
     registerMarketImportTools(server as never, fixture.ctx.dataDir, stores);
 
@@ -150,7 +150,7 @@ describe("import_market_csv (INGEST-01)", () => {
       skip_enrichment: true, // isolate the spot-write assertion
     });
     if (out.isError) {
-      console.error("Test 1.1 unexpected isError:", out.content);
+      console.error("import_market_csv unexpected isError:", out.content);
     }
     expect(out.isError).toBeFalsy();
 
@@ -167,7 +167,7 @@ describe("import_market_csv (INGEST-01)", () => {
     expect(bars.length).toBe(3);
   });
 
-  it("Test 1.2 — auto-enrich SPX after import (skip_enrichment=false)", async () => {
+  it("auto-enriches SPX after import when skip_enrichment=false", async () => {
     const { server, tools } = makeServer();
     registerMarketImportTools(server as never, fixture.ctx.dataDir, stores);
     const captured = tools.get("import_market_csv")!;
@@ -180,7 +180,7 @@ describe("import_market_csv (INGEST-01)", () => {
       skip_enrichment: false,
     });
     if (out.isError) {
-      console.error("Test 1.2 unexpected isError:", out.content);
+      console.error("import_market_csv unexpected isError:", out.content);
     }
     expect(out.isError).toBeFalsy();
 
@@ -196,7 +196,7 @@ describe("import_market_csv (INGEST-01)", () => {
     expect(data.enrichment).not.toBeNull();
   });
 
-  it("Test 1.3 — VIX ticker triggers enriched.computeContext", async () => {
+  it("triggers enriched.computeContext for the VIX ticker", async () => {
     const { server, tools } = makeServer();
     registerMarketImportTools(server as never, fixture.ctx.dataDir, stores);
     const captured = tools.get("import_market_csv")!;
@@ -217,7 +217,7 @@ describe("import_market_csv (INGEST-01)", () => {
       skip_enrichment: false,
     });
     if (out.isError) {
-      console.error("Test 1.3 unexpected isError:", out.content);
+      console.error("import_market_csv unexpected isError:", out.content);
     }
     expect(out.isError).toBeFalsy();
 
@@ -227,10 +227,10 @@ describe("import_market_csv (INGEST-01)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 2. import_market_csv rejects target_table (Zod schema D-22)
+// 2. import tools reject the removed `target_table` field
 // ---------------------------------------------------------------------------
 
-describe("import_market_csv rejects target_table (D-22)", () => {
+describe("import tools reject target_table", () => {
   let fixture: FixtureHandle;
   let stores: MarketStores;
 
@@ -245,7 +245,7 @@ describe("import_market_csv rejects target_table (D-22)", () => {
     fixture.cleanup();
   });
 
-  it("Test 2.1 — Zod schema has no `target_table` field for import_market_csv", () => {
+  it("import_market_csv Zod schema has no `target_table` field", () => {
     const { server, tools } = makeServer();
     registerMarketImportTools(server as never, fixture.ctx.dataDir, stores);
 
@@ -254,7 +254,7 @@ describe("import_market_csv rejects target_table (D-22)", () => {
     expect(Object.keys(shapeOf(captured!))).not.toContain("target_table");
   });
 
-  it("Test 2.2 — import_from_database also drops target_table", () => {
+  it("import_from_database Zod schema has no `target_table` field", () => {
     const { server, tools } = makeServer();
     registerMarketImportTools(server as never, fixture.ctx.dataDir, stores);
 
@@ -266,10 +266,10 @@ describe("import_market_csv rejects target_table (D-22)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 3. import_from_database (INGEST-01)
+// 3. import_from_database
 // ---------------------------------------------------------------------------
 
-describe("import_from_database (INGEST-01)", () => {
+describe("import_from_database", () => {
   let fixture: FixtureHandle;
   let stores: MarketStores;
   let extDbPath: string;
@@ -301,7 +301,7 @@ describe("import_from_database (INGEST-01)", () => {
     fixture.cleanup();
   });
 
-  it("Test 3.1 — writes via stores.spot (no target_table)", async () => {
+  it("writes via stores.spot (no target_table)", async () => {
     const { server, tools } = makeServer();
     registerMarketImportTools(server as never, fixture.ctx.dataDir, stores);
 
@@ -325,7 +325,7 @@ describe("import_from_database (INGEST-01)", () => {
       skip_enrichment: true,
     });
     if (out.isError) {
-      console.error("Test 3.1 unexpected isError:", out.content);
+      console.error("import_from_database unexpected isError:", out.content);
     }
     expect(out.isError).toBeFalsy();
 
@@ -337,7 +337,7 @@ describe("import_from_database (INGEST-01)", () => {
     expect(coverage.totalDates).toBe(1);
   });
 
-  it("Test 3.2 — auto-enrich runs after a database import", async () => {
+  it("auto-enrich runs after a database import", async () => {
     const { server, tools } = makeServer();
     registerMarketImportTools(server as never, fixture.ctx.dataDir, stores);
     const captured = tools.get("import_from_database")!;
@@ -359,7 +359,7 @@ describe("import_from_database (INGEST-01)", () => {
       skip_enrichment: false,
     });
     if (out.isError) {
-      console.error("Test 3.2 unexpected isError:", out.content);
+      console.error("import_from_database unexpected isError:", out.content);
     }
     expect(out.isError).toBeFalsy();
 
@@ -391,7 +391,7 @@ describe("dry_run preserves behavior", () => {
     fixture.cleanup();
   });
 
-  it("Test 4.1 — dry_run=true writes nothing; coverage remains empty", async () => {
+  it("dry_run=true writes nothing; coverage remains empty", async () => {
     const { server, tools } = makeServer();
     registerMarketImportTools(server as never, fixture.ctx.dataDir, stores);
     const captured = tools.get("import_market_csv")!;
@@ -404,7 +404,7 @@ describe("dry_run preserves behavior", () => {
       skip_enrichment: false,
     });
     if (out.isError) {
-      console.error("Test 4.1 unexpected isError:", out.content);
+      console.error("import_market_csv unexpected isError:", out.content);
     }
     expect(out.isError).toBeFalsy();
 

--- a/packages/mcp-server/tests/integration/parquet-views.test.ts
+++ b/packages/mcp-server/tests/integration/parquet-views.test.ts
@@ -2,9 +2,9 @@
  * Unit-level integration tests for createMarketParquetViews()
  *
  * Tests the view creation function directly (not through getConnection).
- * Post Phase 6 Wave D: covers the v3.0 canonical market data views
- * (spot, spot_daily, enriched, enriched_context, option_chain, option_quote_minutes).
- * Also tests partial file availability, tablesKept tracking, and parquetActive flag.
+ * Covers the canonical market data views (spot, spot_daily, enriched,
+ * enriched_context, option_chain, option_quote_minutes), plus partial file
+ * availability, tablesKept tracking, and the parquetActive flag.
  */
 import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import { mkdirSync, rmSync } from "fs";
@@ -31,10 +31,10 @@ describe("createMarketParquetViews", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  // NOTE: Phase 6 Wave D retired the legacy single-file daily/date_context
-  // views and the legacy intraday Hive-partitioned view. v3.0 views (spot,
-  // spot_daily, enriched, enriched_context, option_chain, option_quote_minutes)
-  // are exercised by other tests in this file and by Phase 2 unit tests.
+  // NOTE: the legacy single-file daily/date_context views and the legacy
+  // intraday Hive-partitioned view have been retired. The current canonical
+  // views (spot, spot_daily, enriched, enriched_context, option_chain,
+  // option_quote_minutes) are covered here and in unit tests.
   it("creates views for option_chain and option_quote_minutes Hive-partitioned Parquet", async () => {
     const marketDir = join(tmpDir, "market");
 
@@ -146,9 +146,8 @@ describe("createMarketParquetViews", () => {
 
     expect(result.parquetActive).toBe(false);
     expect(result.viewsCreated).toEqual([]);
-    // Post Phase 6 Wave D: the legacy 3 registration blocks are gone. tablesKept
-    // has 6 entries on an empty market dir: option_chain, option_quote_minutes,
-    // spot, enriched, enriched_context, spot_daily.
+    // tablesKept has 6 entries on an empty market dir: option_chain,
+    // option_quote_minutes, spot, enriched, enriched_context, spot_daily.
     expect(result.tablesKept.length).toBe(6);
   });
 
@@ -159,11 +158,11 @@ describe("createMarketParquetViews", () => {
     expect(result.parquetActive).toBe(false);
     expect(result.viewsCreated).toEqual([]);
     expect(result.tablesKept).toEqual([
-      // Remaining Hive-partitioned views after Wave D hard-cut
+      // Hive-partitioned chain + quote views
       "option_chain", "option_quote_minutes",
-      // Phase 2 new names (D-22, D-24, D-25)
+      // Canonical spot/enriched view names
       "spot", "enriched", "enriched_context",
-      // Phase 6 Plan 06-00 Task 1 — spot_daily bridge view
+      // Daily-bar bridge view backed by spot
       "spot_daily",
     ]);
   });

--- a/packages/mcp-server/tests/integration/phase-05-round-trip.test.ts
+++ b/packages/mcp-server/tests/integration/phase-05-round-trip.test.ts
@@ -1,22 +1,23 @@
 /**
- * Phase 5 round-trip integration test (VALIDATION task 5-00-04).
+ * Round-trip integration test for spot backfill → enriched layout →
+ * verification.
  *
  * Drives a small-scale backfill-compute-verify cycle end-to-end against a
- * tmp Parquet fixture with a mocked provider. Asserts:
- *   - MDATA-01: spot/ticker=X/date=Y/data.parquet exists after SpotStore.writeBars
- *   - MDATA-02: enriched/ticker=X/data.parquet exists, no OHLCV columns
- *               (via writeEnrichedTickerFile — the V3 target write primitive
- *                Wave B will wire `EnrichedStore.compute` into; the current
- *                thin wrapper still writes to legacy daily.parquet per
- *                RESEARCH Pitfall 2, a state Plan 05-02 fixes)
- *   - MDATA-03: enriched/context/data.parquet exists with cross-ticker fields
- *               (via writeEnrichedContext — same rationale)
- *   - D-11: compareRow.anyFailure=true when Gap_Pct drift exceeds 1e-9
- *   - MIG-03 in-process: MockProvider.fetchBars → SpotStore.writeBars end-to-end
+ * tmp Parquet fixture with a mocked provider. Asserts that:
+ *   - spot/ticker=X/date=Y/data.parquet exists after SpotStore.writeBars
+ *   - enriched/ticker=X/data.parquet exists, no OHLCV columns (via
+ *     writeEnrichedTickerFile — the canonical write primitive that the
+ *     stores-based `EnrichedStore.compute` is wired through; some legacy
+ *     daily.parquet plumbing remains and is exercised separately)
+ *   - enriched/context/data.parquet exists with cross-ticker fields (via
+ *     writeEnrichedContext)
+ *   - compareRow.anyFailure=true when Gap_Pct drift exceeds 1e-9
+ *   - In-process round-trip: MockProvider.fetchBars → SpotStore.writeBars
+ *     surfaces as coverage and via the canonical view
  *
  * Pattern adapted from tests/unit/quote-backfill.test.ts (MockProvider +
- * buildStoreFixture) and tests/integration/parquet-read-layer.test.ts (Parquet
- * COPY / DESCRIBE verification).
+ * buildStoreFixture) and tests/integration/parquet-read-layer.test.ts
+ * (Parquet COPY / DESCRIBE verification).
  */
 import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import { existsSync } from "fs";
@@ -102,7 +103,7 @@ class MockProvider implements MarketDataProvider {
 // Test suite
 // ---------------------------------------------------------------------------
 
-describe("Phase 5 round-trip — spot backfill → enriched layout → verification", () => {
+describe("market data round-trip — spot backfill → enriched layout → verification", () => {
   let handle: FixtureHandle;
   let stores: MarketStores;
   const mockProvider = new MockProvider();
@@ -110,7 +111,7 @@ describe("Phase 5 round-trip — spot backfill → enriched layout → verificat
   beforeEach(async () => {
     handle = await buildStoreFixture({ parquetMode: true });
     stores = createMarketStores(handle.ctx);
-    // Phase 2 D-22: register views so market.spot / market.enriched /
+    // Register views so market.spot / market.enriched /
     // market.enriched_context resolve when their partitions exist.
     await createMarketParquetViews(handle.ctx.conn, handle.ctx.dataDir);
   });
@@ -119,7 +120,7 @@ describe("Phase 5 round-trip — spot backfill → enriched layout → verificat
     handle.cleanup();
   });
 
-  it("MDATA-01: spot layout — spot/ticker=X/date=Y/data.parquet exists after writeBars", async () => {
+  it("spot layout — spot/ticker=X/date=Y/data.parquet exists after writeBars", async () => {
     const bars = await mockProvider.fetchBars({
       ticker: "SPX",
       from: "2024-08-05",
@@ -136,19 +137,18 @@ describe("Phase 5 round-trip — spot backfill → enriched layout → verificat
     );
     expect(existsSync(expected)).toBe(true);
 
-    // Coverage reflects the write (MIG-03 proof).
+    // Coverage reflects the write end-to-end.
     const cov = await stores.spot.getCoverage("SPX", "2024-08-05", "2024-08-05");
     expect(cov.totalDates).toBe(1);
     expect(cov.earliest).toBe("2024-08-05");
     expect(cov.latest).toBe("2024-08-05");
   });
 
-  it("MDATA-02: enriched layout — enriched/ticker=X/data.parquet exists, no OHLCV columns", async () => {
-    // Stage an enriched row via the V3 write primitive. Wave B (Plan 05-02)
-    // rewires `stores.enriched.compute` to call this helper; in Wave 0 we
-    // exercise the helper directly to prove the target layout is buildable
-    // (RESEARCH Pitfall 2 — the thin-wrapper `compute()` still writes to the
-    // legacy daily.parquet path).
+  it("enriched layout — enriched/ticker=X/data.parquet exists, no OHLCV columns", async () => {
+    // Stage an enriched row via the canonical write primitive. Eventually
+    // `stores.enriched.compute` calls this helper directly; here we exercise
+    // it on its own to prove the target layout is buildable independent of
+    // any legacy daily.parquet plumbing.
     await handle.ctx.conn.run(
       `CREATE TEMP TABLE _enriched_stage AS
         SELECT 'SPX' AS ticker, '2024-08-05' AS date,
@@ -169,8 +169,8 @@ describe("Phase 5 round-trip — spot backfill → enriched layout → verificat
     );
     expect(existsSync(expected)).toBe(true);
 
-    // Assert the enriched file schema does NOT include OHLCV (Phase 2 D-14 /
-    // MDATA-02: enriched holds computed fields only).
+    // Assert the enriched file schema does NOT include OHLCV — enriched
+    // holds computed fields only.
     const schema = await handle.ctx.conn.runAndReadAll(
       `DESCRIBE SELECT * FROM read_parquet('${expected}')`,
     );
@@ -184,7 +184,7 @@ describe("Phase 5 round-trip — spot backfill → enriched layout → verificat
     expect(cols).toContain("gap_pct");
   });
 
-  it("MDATA-03: context layout — enriched/context/data.parquet exists with cross-ticker fields", async () => {
+  it("context layout — enriched/context/data.parquet exists with cross-ticker fields", async () => {
     await handle.ctx.conn.run(
       `CREATE TEMP TABLE _context_stage AS
         SELECT '2024-08-05' AS date,
@@ -214,7 +214,7 @@ describe("Phase 5 round-trip — spot backfill → enriched layout → verificat
     expect(cols).toContain("Trend_Direction");
   });
 
-  it("D-11: drift detection — Gap_Pct delta 5e-8 exceeds 1e-9 tolerance", () => {
+  it("drift detection — Gap_Pct delta 5e-8 exceeds 1e-9 tolerance", () => {
     const oldRow = { Gap_Pct: 0.01 };
     const newRow = { Gap_Pct: 0.01 + 5e-8 };
     const diff = compareRow(
@@ -232,7 +232,7 @@ describe("Phase 5 round-trip — spot backfill → enriched layout → verificat
     expect(ENRICHED_FIELD_TYPES.Gap_Pct).toBe("double");
   });
 
-  it("MIG-03 in-process: backfill via MockProvider writes spot/ partition and coverage reports it", async () => {
+  it("in-process backfill via MockProvider writes spot/ partition and coverage reports it", async () => {
     // Small 3-date backfill — first 3 sample dates that are ≥ 2024 so MockProvider's
     // deterministic close values are reasonable.
     const allSamples = selectVerificationSampleDates(

--- a/packages/mcp-server/tests/integration/trade-replay.test.ts
+++ b/packages/mcp-server/tests/integration/trade-replay.test.ts
@@ -3,14 +3,10 @@ import { jest } from "@jest/globals";
 /**
  * Integration tests for replay_trade MCP tool (handleReplayTrade)
  *
- * Tests both hypothetical and tradelog replay modes with:
- *   - Real in-memory DuckDB seeded via stores.spot.writeBars +
- *     in-memory option_quote_minutes INSERTs (Phase 4 Plan 04-04 — option-leg
- *     reads now flow through stores.quote.readQuotes; the legacy mockFetch
- *     pattern only remains for non-option side effects, e.g., decompose_greeks
- *     option-leg fetches that haven't yet been migrated).
- *
- * Requirements: TST-04, RPL-01, RPL-05, RPL-06
+ * Tests both hypothetical and tradelog replay modes with a real in-memory
+ * DuckDB seeded via stores.spot.writeBars and direct option_quote_minutes
+ * INSERTs; option-leg reads flow through stores.quote.readQuotes so the
+ * full path is store-backed.
  */
 
 import { DuckDBInstance, DuckDBConnection } from "@duckdb/node-api";
@@ -105,11 +101,10 @@ describe("replay_trade integration", () => {
       )
     `);
 
-    // Phase 4 Plan 04-04: handleReplayTrade reads option-leg quotes via
-    // stores.quote.readQuotes which queries market.option_quote_minutes.
-    // Schema mirrors the production market-schemas.ts shape (PK underlying,
-    // date, ticker, time + bid/ask/mid columns). Tests seed via
-    // seedOptionQuotes() below.
+    // handleReplayTrade reads option-leg quotes via stores.quote.readQuotes
+    // which queries market.option_quote_minutes. Schema mirrors the
+    // production market-schemas.ts shape (PK underlying, date, ticker, time
+    // + bid/ask/mid columns). Tests seed via seedOptionQuotes() below.
     await conn.run(`
       CREATE TABLE market.option_quote_minutes (
         underlying      VARCHAR NOT NULL,
@@ -137,11 +132,11 @@ describe("replay_trade integration", () => {
     conn.closeSync();
   });
 
-  // Phase 4 Plan 04-04: seed option_quote_minutes for the 4 unskipped tests.
-  // Bar inputs come from the existing SPY_470C_BARS / SPY_475C_BARS fixtures
-  // (UTC-millisecond timestamps); we convert to ET wallclock and persist as
-  // (bid, ask) so the (bid+ask)/2 mid in handleReplayTrade matches the
-  // pre-04-04 close-based marks within rounding tolerance.
+  // Seed option_quote_minutes for the option-leg tests. Bar inputs come from
+  // the SPY_470C_BARS / SPY_475C_BARS fixtures (UTC-millisecond timestamps);
+  // we convert to ET wallclock and persist as (bid, ask) so the (bid+ask)/2
+  // mid in handleReplayTrade matches the bar close within rounding
+  // tolerance.
   const seedOptionQuotes = async (
     occTicker: string,
     underlying: string,
@@ -174,9 +169,8 @@ describe("replay_trade integration", () => {
   // ---------------------------------------------------------------------------
 
   describe("hypothetical mode", () => {
-    // Phase 4 Plan 04-04 — un-skipped: option-leg path migrated to
-    // stores.quote.readQuotes; option quotes seeded via seedOptionQuotes()
-    // (replaces the prior mockFetch on option tickers).
+    // Option-leg path is store-backed via stores.quote.readQuotes; option
+    // quotes are seeded via seedOptionQuotes() (no provider fetch).
     test("single-leg replay returns P&L path with MFE/MAE", async () => {
       await seedOptionQuotes("SPY250117C00470000", "SPY", SPY_470C_BARS);
 
@@ -219,8 +213,7 @@ describe("replay_trade integration", () => {
       expect(typeof result.totalPnl).toBe("number");
     });
 
-    // Phase 4 Plan 04-04 — un-skipped: option-leg quotes seeded directly into
-    // market.option_quote_minutes (replaces mockFetch on option tickers).
+    // Option-leg quotes seeded directly into market.option_quote_minutes.
     test("multi-leg spread replay combines legs correctly", async () => {
       await seedOptionQuotes("SPY250117C00470000", "SPY", SPY_470C_BARS);
       await seedOptionQuotes("SPY250117C00475000", "SPY", SPY_475C_BARS);
@@ -263,8 +256,8 @@ describe("replay_trade integration", () => {
 
       // Verify spread P&L combines both legs (not just one)
       // Entry: long 470C at 5.0, short 475C at 3.0 → net debit 2.0
-      // Phase 4 Plan 04-04: mark = (bid+ask)/2 where bid=c-0.05, ask=c+0.05
-      // (per seedOptionQuotes spread anchor) → mid = c (the bar close).
+      // mark = (bid+ask)/2 where bid=c-0.05, ask=c+0.05 (per
+      // seedOptionQuotes spread anchor) → mid = c (the bar close).
       // At minute 0: 470C mid=5.1 (c=5.1); 475C mid=3.05 (c=3.05)
       // Long leg: (5.1-5.0)*1*100=10, Short leg: (3.05-3.0)*-1*100=-5
       // Combined: 5
@@ -294,11 +287,11 @@ describe("replay_trade integration", () => {
       ).rejects.toThrow("open_date and close_date are required");
     });
 
-    // Phase 4 Plan 04-04 — un-skipped: handleReplayTrade reads option-leg
-    // quotes via stores.quote.readQuotes; seed both underlying spot bars
-    // (for greeks underlying-price map) and option_quote_minutes (for the
-    // 470C option leg) directly into the in-memory DuckDB. No provider
-    // fetch is issued at all — the path is fully store-backed end-to-end.
+    // handleReplayTrade reads option-leg quotes via stores.quote.readQuotes;
+    // seed both underlying spot bars (for the greeks underlying-price map)
+    // and option_quote_minutes (for the 470C option leg) directly into the
+    // in-memory DuckDB. No provider fetch is issued at all — the path is
+    // fully store-backed end-to-end.
     test("decompose_greeks reuses replay underlying prices and honors skip_quotes", async () => {
       process.env.MASSIVE_DATA_TIER = "quotes";
 
@@ -346,7 +339,7 @@ describe("replay_trade integration", () => {
 
       expect(result.totalPnlChange).not.toBeNaN();
       // No provider fetches should occur — replay.ts and the underlying
-      // path both flow through stores now (D-05 / SEP-01).
+      // path both flow through stores now.
       expect(fetchSpy).not.toHaveBeenCalled();
     });
   });
@@ -356,8 +349,8 @@ describe("replay_trade integration", () => {
   // ---------------------------------------------------------------------------
 
   describe("tradelog mode", () => {
-    // Phase 4 Plan 04-04 — un-skipped: option-leg quotes seeded directly into
-    // market.option_quote_minutes via seedOptionQuotes (replaces mockFetch).
+    // Option-leg quotes seeded directly into market.option_quote_minutes via
+    // seedOptionQuotes.
     test("resolves trade from block and replays it", async () => {
       // Insert a test trade
       await conn.run(`

--- a/packages/mcp-server/tests/integration/wave-a-spot-consumer-contract.test.ts
+++ b/packages/mcp-server/tests/integration/wave-a-spot-consumer-contract.test.ts
@@ -1,5 +1,5 @@
 /**
- * Wave A spot-consumer contract tests.
+ * Spot-consumer contract tests.
  *
  * Exercises the `checkDataAvailability`, `queryCoverage`, and
  * `importFlatFileDay` consumers against a real `MarketStores` bundle backed by
@@ -46,7 +46,7 @@ async function seedEnriched(
   });
 }
 
-describe("Wave A spot-consumer contract: checkDataAvailability", () => {
+describe("spot-consumer contract: checkDataAvailability", () => {
   let fixture: FixtureHandle;
   let stores: MarketStores;
 
@@ -87,7 +87,7 @@ describe("Wave A spot-consumer contract: checkDataAvailability", () => {
   });
 });
 
-describe("Wave A spot-consumer contract: queryCoverage", () => {
+describe("spot-consumer contract: queryCoverage", () => {
   let fixture: FixtureHandle;
   let stores: MarketStores;
 
@@ -127,7 +127,7 @@ describe("Wave A spot-consumer contract: queryCoverage", () => {
   });
 });
 
-describe("Wave A spot-consumer contract: importFlatFileDay (parsed-row write path)", () => {
+describe("spot-consumer contract: importFlatFileDay (parsed-row write path)", () => {
   let fixture: FixtureHandle;
   let stores: MarketStores;
 
@@ -141,9 +141,10 @@ describe("Wave A spot-consumer contract: importFlatFileDay (parsed-row write pat
   });
 
   it("writes parsed rows through stores.spot.writeBars and round-trips via readBars", async () => {
-    // Direct write-bars round-trip — the importFlatFileDay flow groups by ticker/date
-    // and calls stores.spot.writeBars under the hood. This contract test simulates
-    // the post-parse step (the parse step is unit-tested separately).
+    // Direct write-bars round-trip — importFlatFileDay groups by ticker/date
+    // and calls stores.spot.writeBars under the hood. This contract test
+    // simulates the post-parse step (the parse step is unit-tested
+    // separately).
     const bars = makeBars("SPX", "2025-01-06");
     await stores.spot.writeBars("SPX", "2025-01-06", bars);
     await createMarketParquetViews(fixture.ctx.conn, fixture.ctx.dataDir);
@@ -154,8 +155,8 @@ describe("Wave A spot-consumer contract: importFlatFileDay (parsed-row write pat
   });
 
   it("getCoverage skip-check returns totalDates>0 once a date is written", async () => {
-    // The migrated importFlatFileDay uses stores.spot.getCoverage(ticker, date, date)
-    // as the per-day "already imported" skip check. Verify that contract directly.
+    // importFlatFileDay uses stores.spot.getCoverage(ticker, date, date) as
+    // the per-day "already imported" skip check. Verify that contract directly.
     await stores.spot.writeBars("SPX", "2025-01-06", makeBars("SPX", "2025-01-06"));
     await createMarketParquetViews(fixture.ctx.conn, fixture.ctx.dataDir);
 
@@ -165,9 +166,8 @@ describe("Wave A spot-consumer contract: importFlatFileDay (parsed-row write pat
   });
 });
 
-// Sanity reference — keep the concrete classes referenced in this file so they
-// remain part of the migration's public test surface and ts-jest does not
-// drop them as unused.
+// Sanity reference — keep the concrete classes referenced in this file so
+// ts-jest does not drop them as unused.
 void ParquetSpotStore;
 void ParquetQuoteStore;
 void ParquetEnrichedStore;

--- a/packages/mcp-server/tests/integration/wave-a-tool-consumer-contract.test.ts
+++ b/packages/mcp-server/tests/integration/wave-a-tool-consumer-contract.test.ts
@@ -1,22 +1,22 @@
 /**
- * Wave-A Tool Consumer Contract Tests (Phase 4 Plan 04-02).
+ * Tool/consumer contract tests for the stores-backed spot/enriched reads.
  *
- * Per CONTEXT.md D-28: each migrated consumer gets a contract-style integration
- * test that runs the consumer against a fixture and asserts its output matches
- * pre-migration behavior. This file covers the four files migrated in plan 04-02:
+ * Each migrated consumer gets a contract-style integration test that runs
+ * the consumer against a fixture and asserts its output matches expected
+ * post-migration behavior. This file covers four consumers:
  *
- *   1. tools/market-data.ts        — ORB + regime + enrich_trades raw SQL → stores
+ *   1. tools/market-data.ts        — ORB + regime + enrich_trades reads
  *   2. tools/replay.ts             — underlying bar read + VIX IVP via stores
  *   3. backtest/loading/data-prep.ts        — spot bar reads via stores
  *   4. backtest/loading/market-data-loader.ts — spot portion + filter intraday
  *
- * Pattern (PATTERNS.md §Pattern 7):
+ * Pattern:
  *   - Tmp data dir + getConnection (registers schemas including market.spot)
  *   - buildTestStores → MarketStores bundle
  *   - Seed fixture via stores.spot.writeBars / stores.enriched.compute
  *   - Register the tool / call the handler / assert shape against golden
  *
- * Plan 04-00 Task 3 created the shared fixture helper at
+ * The shared fixture helper lives at
  * tests/fixtures/market-stores/build-stores.ts — used here unchanged.
  */
 import * as fs from "fs/promises";
@@ -38,7 +38,7 @@ import type { MarketStores } from "../../src/market/stores/index.js";
 // ---------------------------------------------------------------------------
 
 /**
- * Seed a deterministic SPX fixture for the wave-A consumers.
+ * Seed a deterministic SPX fixture for the stores-backed consumers.
  *
  * SPX 2025-01-02 spot bars:
  *   09:30 → open=5800 high=5810 low=5795 close=5805
@@ -110,13 +110,13 @@ async function seedSpxFixture(stores: MarketStores): Promise<void> {
 // `market.spot` table that ensureMarketDataTables created at getConnection().
 // ---------------------------------------------------------------------------
 
-describe("wave-a tool/consumer contract — Phase 4 Plan 04-02", () => {
+describe("tool/consumer contract — stores-backed spot/enriched reads", () => {
   let tempDir: string;
   let stores: MarketStores;
 
   beforeEach(async () => {
     await closeConnection();
-    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "tb-phase4-wave-a-"));
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "tb-tool-consumer-"));
     // Initial getConnection registers schemas (market.spot etc.) and downgrades
     // to RO. We need RW for the writeBars seeding step.
     await getConnection(tempDir);
@@ -142,8 +142,8 @@ describe("wave-a tool/consumer contract — Phase 4 Plan 04-02", () => {
   // 1. tools/market-data.ts — ORB + regime
   // -----------------------------------------------------------------------
   describe("tools/market-data.ts — ORB + regime", () => {
-    it("stores.spot.readBars returns the fixture bars used by the migrated ORB path", async () => {
-      // Underlying-store contract that calculate_orb depends on after migration.
+    it("stores.spot.readBars returns the fixture bars used by the ORB path", async () => {
+      // Underlying-store contract that calculate_orb depends on.
       const bars = await stores.spot.readBars(
         "SPX",
         "2025-01-02",
@@ -155,16 +155,16 @@ describe("wave-a tool/consumer contract — Phase 4 Plan 04-02", () => {
       expect(bars[0].low).toBe(5795);
     });
 
-    it("ORB computation logic (post-migration TypeScript aggregation) computes the right window/range", async () => {
-      // The migrated calculate_orb handler reads bars via stores.spot.readBars
-      // and aggregates the ORB high/low/range + breakout times in TypeScript
-      // (replacing the prior `WITH orb_range / breakout_events` SQL CTEs).
-      // We verify the aggregation here by replicating the in-memory math over
+    it("ORB computation logic computes the right window/range", async () => {
+      // The calculate_orb handler reads bars via stores.spot.readBars and
+      // aggregates the ORB high/low/range + breakout times in TypeScript. We
+      // verify the aggregation here by replicating the in-memory math over
       // the fixture bars — the handler-internal logic is byte-identical.
-      // (Direct handler invocation is gated by withFullSync's connection-mode
-      // upgrade lifecycle, which is incompatible with the test's captured
-      // `stores` reference; the contract-style test is sufficient because the
-      // SQL→TS migration semantics are deterministic over readBars output.)
+      // (Direct handler invocation is gated by withFullSync's
+      // connection-mode upgrade lifecycle, which is incompatible with the
+      // test's captured `stores` reference; the contract-style test is
+      // sufficient because the aggregation is deterministic over readBars
+      // output.)
       const bars = await stores.spot.readBars(
         "SPX",
         "2025-01-02",
@@ -221,11 +221,10 @@ describe("wave-a tool/consumer contract — Phase 4 Plan 04-02", () => {
   // -----------------------------------------------------------------------
   describe("backtest/loading/data-prep.ts — spot window read", () => {
     it("stores.spot.readBars returns the full 3-bar fixture for the entry-date range", async () => {
-      // Task 3 migrates data-prep.ts:119 + :165 (legacy minute-bar view spot
-      // SELECTs) onto stores.spot.readBars. The handler-level test would
-      // require constructing a full StrategyDefinition + chain map; here we
-      // assert the underlying store-call shape that the migrated function
-      // depends on.
+      // data-prep.ts now reads spot windows via stores.spot.readBars. The
+      // handler-level test would require constructing a full
+      // StrategyDefinition + chain map; here we assert the underlying
+      // store-call shape that the function depends on.
       const bars = await stores.spot.readBars(
         "SPX",
         "2025-01-02",
@@ -233,7 +232,7 @@ describe("wave-a tool/consumer contract — Phase 4 Plan 04-02", () => {
       );
       expect(bars.length).toBe(3);
       // data-prep.ts uses the bars to find the entry-time bar — assert the
-      // open/high/low/close shape stays intact through readBars.
+      // OHLC shape stays intact through readBars.
       const opens = bars.map((b) => b.open);
       expect(opens).toEqual([5800, 5805, 5808]);
     });
@@ -243,12 +242,10 @@ describe("wave-a tool/consumer contract — Phase 4 Plan 04-02", () => {
   // 4. backtest/loading/market-data-loader.ts — spot portion
   // -----------------------------------------------------------------------
   describe("backtest/loading/market-data-loader.ts — spot portion", () => {
-    it("stores.spot.readBars provides the underlying-bars source (replaces legacy minute-bar SELECT at line 687)", async () => {
-      // Task 4 migrates market-data-loader.ts:687 (underlying bulk query) +
-      // :989 (filter intraday CTE) + :1036/:1070 (daily OHLC + RSI CTE) onto
-      // stores. The duplicated helpers `intradayDateSource` (~241) get deleted
-      // (only `optionQuoteMinuteSource` stays — plan 04-04 deletes it). Here
-      // we assert the readBars contract the migrated loader depends on.
+    it("stores.spot.readBars provides the underlying-bars source for the loader", async () => {
+      // The loader reads underlying bulk bars, filter-intraday windows, and
+      // daily OHLC + RSI inputs through stores.spot. Here we assert the
+      // readBars contract the loader depends on.
       const bars = await stores.spot.readBars(
         "SPX",
         "2025-01-02",

--- a/packages/mcp-server/tests/integration/wave-b-option-consumer-contract.test.ts
+++ b/packages/mcp-server/tests/integration/wave-b-option-consumer-contract.test.ts
@@ -1,29 +1,20 @@
 /**
- * Wave B option-consumer contract tests (Phase 4 Plan 04-04).
+ * Option-consumer contract tests.
  *
- * Exercises the migrated option-quote read paths after the surgical
- * cutover to `stores.quote.readQuotes` / `stores.chain.readChain` /
+ * Exercises the option-quote read paths that flow through
+ * `stores.quote.readQuotes` / `stores.chain.readChain` /
  * `stores.quote.writeQuotes` in:
  *
- *   - tools/replay.ts                     (option-leg reads)
- *   - tools/greeks-attribution.ts         (SELECT DISTINCT date)
- *   - utils/sql-pnl.ts                    (market.option_quote_minutes
- *                                          with `mid` fallback + underlying filter)
+ *   - tools/replay.ts                         (option-leg reads)
+ *   - tools/greeks-attribution.ts             (trading-days coverage)
  *   - backtest/loading/market-data-loader.ts  (per-date option-quote bulk read)
- *   - utils/quote-minute-cache.ts         (chain read + queue-drain writes)
+ *   - utils/quote-minute-cache.ts             (chain read + queue-drain writes)
  *
- * Pattern (PATTERNS.md §Pattern 7):
- *   - parquet-mode store fixture so chain.writeChain/readChain + quote.writeQuotes
- *     hit a real Parquet directory and createMarketParquetViews registers a
- *     market.option_chain / market.option_quote_minutes view backed by it.
- *
- * Pre-migration external consumers of the symbols touched by this plan:
- *   - tools/replay.ts:284,302         option-leg reads
- *   - tools/greeks-attribution.ts:382 SELECT DISTINCT date FROM the retired legacy minute-bar view
- *   - utils/sql-pnl.ts:103            retired legacy minute-bar SELECT + close fallback
- *   - backtest/loading/market-data-loader.ts:498-523  optionQuoteMinuteSource(date)
- *   - utils/quote-minute-cache.ts:210 SELECT DISTINCT ticker FROM market.option_chain UNION retired legacy minute-bar view
- *   - utils/quote-minute-cache.ts:535 upsertQuoteRowsForDate (writeParquetPartition direct)
+ * Pattern:
+ *   - parquet-mode store fixture so chain.writeChain/readChain +
+ *     quote.writeQuotes hit a real Parquet directory and
+ *     createMarketParquetViews registers a market.option_chain /
+ *     market.option_quote_minutes view backed by it.
  */
 import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import {
@@ -129,8 +120,8 @@ describe("tools/replay.ts — option-leg reads", () => {
     const lastMid = (quotes[4].bid + quotes[4].ask) / 2;
     expect(lastMid).toBeCloseTo(4.60, 2);
 
-    // Per replay.ts target shape — each QuoteRow adapts to BarRow with
-    // mid as open/high/low/close. Verify the timestamp split works.
+    // Per replay.ts: each QuoteRow adapts to BarRow with mid as
+    // open/high/low/close. Verify the timestamp split works.
     for (const q of quotes) {
       const [date, time] = q.timestamp.split(" ");
       expect(date).toBe(SPX_DATE);
@@ -145,7 +136,7 @@ describe("tools/replay.ts — option-leg reads", () => {
       SPX_DATE,
       SPX_DATE,
     );
-    // No partitions exist → empty Map (the new D-09 silent-empty signal).
+    // No partitions exist → empty Map (silent-empty signal).
     expect(result.size).toBe(0);
   });
 });
@@ -168,9 +159,9 @@ describe("tools/greeks-attribution.ts — trading-days coverage", () => {
   });
 
   it("stores.spot.getCoverage returns the seeded date as coverage", async () => {
-    // greeks-attribution post-migration sources trading dates from spot
-    // coverage (or pure tradingDays() weekday iteration). Seed two SPX bars
-    // on different dates and assert coverage reports both.
+    // greeks-attribution sources trading dates from spot coverage (or pure
+    // tradingDays() weekday iteration). Seed two SPX bars on different
+    // dates and assert coverage reports both.
     await stores.spot.writeBars("SPX", "2025-01-02", [
       { ticker: "SPX", date: "2025-01-02", time: "09:30",
         open: 5800, high: 5810, low: 5795, close: 5805,
@@ -243,7 +234,7 @@ describe("backtest/loading/market-data-loader.ts — per-date option-quote bulk 
     expect(result.get(SPX_5100C_OCC)!.length).toBe(1);
   });
 
-  it("Pitfall 4: mixed-underlying batch throws a clear error", async () => {
+  it("mixed-underlying batch throws a clear error", async () => {
     // QQQ vs SPX in the same batch should fail loudly with both tickers named.
     await expect(
       stores.quote.readQuotes(
@@ -272,7 +263,7 @@ describe("utils/quote-minute-cache.ts — chain read + quote write via stores", 
     fixture.cleanup();
   });
 
-  it("chain.readChain returns the seeded contracts (replaces SELECT DISTINCT ticker FROM market.option_chain)", async () => {
+  it("chain.readChain returns the seeded contracts", async () => {
     const seed = await seedSpxChain(stores);
     await createMarketParquetViews(fixture.ctx.conn, fixture.ctx.dataDir);
 
@@ -284,7 +275,7 @@ describe("utils/quote-minute-cache.ts — chain read + quote write via stores", 
     expect(tickers.has(SPX_5100C_OCC)).toBe(true);
   });
 
-  it("quote.writeQuotes round-trips via quote.readQuotes (replaces upsertQuoteRowsForDate Parquet write)", async () => {
+  it("quote.writeQuotes round-trips via quote.readQuotes", async () => {
     const quotes: QuoteRow[] = [
       { occ_ticker: SPX_5000C_OCC, timestamp: `${SPX_DATE} 09:30`, bid: 4.20, ask: 4.40 },
       { occ_ticker: SPX_5000C_OCC, timestamp: `${SPX_DATE} 09:31`, bid: 4.30, ask: 4.50 },

--- a/packages/mcp-server/tests/integration/wave-c-enrichment-contract.test.ts
+++ b/packages/mcp-server/tests/integration/wave-c-enrichment-contract.test.ts
@@ -1,26 +1,18 @@
 /**
- * Wave C enrichment-consumer contract tests (Phase 4 Plan 04-05).
+ * Enrichment-consumer contract tests.
  *
- * Exercises the migrated enrichment surface after the surgical cutover to:
+ * Exercises the enrichment surface that flows through:
  *   - utils/market-enricher.ts: enrichment-watermark read/write goes through
  *     `io.watermarkStore` (backed by `getEnrichedThrough` /
- *     `upsertEnrichedThrough` from `db/json-adapters.ts`); the legacy
- *     `market._sync_metadata.enriched_through` SQL read is GONE.
+ *     `upsertEnrichedThrough` from `db/json-adapters.ts`); the tool layer no
+ *     longer reads `market._sync_metadata.enriched_through` directly.
  *   - tools/market-enrichment.ts: `enrich_market_data` handler delegates to
- *     `stores.enriched.compute(...)` and (for VIX family) `computeContext(...)`
- *     instead of calling `runEnrichment(conn, ...)` directly.
+ *     `stores.enriched.compute(...)` and (for the VIX family)
+ *     `computeContext(...)` instead of calling `runEnrichment(conn, ...)`.
  *
- * Math (Tier 1/2/3 indicator computation) is UNCHANGED per Phase 2 D-17.
- *
- * Pre-migration consumers of the symbols touched by this plan (verified at
- * the start of plan 04-05):
- *
- *   src/utils/market-enricher.ts:990         SELECT enriched_through FROM market._sync_metadata
- *   src/tools/market-enrichment.ts:67-68     await runEnrichment(conn, ticker, ...)
- *
- * The plan keeps the enrichment math + the `runEnrichment` export untouched —
- * the wrapper `stores.enriched.compute` injects the JSON-backed watermark IO
- * so the tool layer doesn't reach into `market._sync_metadata` any more.
+ * Tier 1/2/3 indicator math is preserved verbatim — the wrapper
+ * `stores.enriched.compute` injects the JSON-backed watermark IO so the
+ * tool layer doesn't reach into `market._sync_metadata` directly.
  */
 import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import {
@@ -75,10 +67,9 @@ async function seedSpotBars(
 }
 
 /**
- * Seed OHLCV rows for the enricher to consume. Post Phase 6 Wave D, the
- * legacy daily-view is gone; `runEnrichment` reads OHLCV from the v3.0
- * market.spot_daily view (aggregated from market.spot minute bars), or
- * from the injected `io.spotStore`. This helper writes synthetic 09:30
+ * Seed OHLCV rows for the enricher to consume. `runEnrichment` reads OHLCV
+ * from the market.spot_daily view (aggregated from market.spot minute bars)
+ * or from the injected `io.spotStore`. This helper writes synthetic 09:30
  * bars into market.spot so market.spot_daily aggregates one row per date.
  * Deterministic linear ramp guarantees stable Tier 1 indicator outputs
  * (no NaN propagation through the warmup window).
@@ -160,7 +151,7 @@ describe("stores.enriched.compute — Tier 1/2/3 output shape", () => {
     expect(watermark).toBe(to);
 
     // === Assert: market._sync_metadata was NOT touched for enrichment ===
-    // (the legacy path used source='enrichment', target_table='daily')
+    // (the legacy path wrote source='enrichment', target_table='daily')
     const metaRows = await fixture.ctx.conn.runAndReadAll(
       `SELECT COUNT(*) FROM market._sync_metadata
        WHERE source = 'enrichment' AND ticker = 'SPX'`,
@@ -349,11 +340,11 @@ describe("tools/market-enrichment.ts handler — delegates to stores", () => {
   });
 
   it("exports only the registerMarketEnrichmentTools entry point", () => {
-    // After the migration, the tools layer no longer touches enrichment math
-    // directly — every call goes through stores.enriched.{compute, computeContext}.
-    // The runEnrichment / runContextEnrichment exports remain in market-enricher.ts
-    // (the store wrappers call them internally), but the tool module should not
-    // re-export them.
+    // The tools layer no longer touches enrichment math directly — every
+    // call goes through stores.enriched.{compute, computeContext}. The
+    // runEnrichment / runContextEnrichment exports remain in
+    // market-enricher.ts (the store wrappers call them internally), but the
+    // tool module should not re-export them.
     const exportNames = Object.keys(marketEnrichmentTool).filter(
       (k) => k !== "default" && k !== "__esModule",
     );
@@ -368,11 +359,11 @@ describe("tools/market-enrichment.ts handler — delegates to stores", () => {
 // 3. market-enricher module shape — io threading + watermark refactor
 // =============================================================================
 
-describe("market-enricher module shape — post-migration invariants", () => {
+describe("market-enricher module shape — store-wrapper invariants", () => {
   it("runEnrichment + runContextEnrichment are still exported (math preserved)", () => {
-    // The math stays in market-enricher.ts per Phase 2 D-17. We assert the
-    // public exports exist; the wrappers in EnrichedStore.compute call them
-    // with an injected EnrichmentIO.
+    // The math stays in market-enricher.ts. We assert the public exports
+    // exist; the wrappers in EnrichedStore.compute call them with an
+    // injected EnrichmentIO.
     expect(typeof marketEnricher.runEnrichment).toBe("function");
     expect(typeof marketEnricher.runContextEnrichment).toBe("function");
   });

--- a/packages/mcp-server/tests/unit/market-enricher.test.ts
+++ b/packages/mcp-server/tests/unit/market-enricher.test.ts
@@ -810,7 +810,7 @@ describe('computeIVP', () => {
 });
 
 // =============================================================================
-// runEnrichment injected IO path (Plan 02-04 Task 1)
+// runEnrichment injected IO path
 //
 // Tests that runEnrichment accepts an optional `io` parameter and routes the
 // 5 IO call sites (watermark get/upsert, Tier 2 VIX RTH open, Tier 3 hasData
@@ -819,15 +819,15 @@ describe('computeIVP', () => {
 // =============================================================================
 
 /**
- * Seed the minimal fixture required to drive runEnrichment (post Phase 6
- * Wave D). Writes daily OHLCV rows into market.spot (one synthetic 09:30 bar
- * per date); the v3.0 legacy-fallback path in runEnrichment reads from
- * market.spot_daily which aggregates market.spot. For IO-routing tests we
- * seed a short window and assert on routing, not math correctness — the
- * pure-function tests above already cover the math.
+ * Seed the minimal fixture required to drive runEnrichment. Writes daily
+ * OHLCV rows into market.spot (one synthetic 09:30 bar per date); the
+ * fallback path in runEnrichment reads from market.spot_daily which
+ * aggregates market.spot. For IO-routing tests we seed a short window and
+ * assert on routing, not math correctness — the pure-function tests above
+ * already cover the math.
  *
- * The enrichment write-target table (dailyTarget) defaults to market.enriched
- * in the v3.0 codepath, so ensureMarketDataTables provides the write surface.
+ * The enrichment write-target table (dailyTarget) defaults to
+ * market.enriched, so ensureMarketDataTables provides the write surface.
  * No watermark row — runEnrichment treats this as a fresh ticker.
  */
 async function seedDailyFixture(conn: DuckDBConnection, ticker: string, dates: string[]): Promise<void> {
@@ -848,7 +848,7 @@ async function seedDailyFixture(conn: DuckDBConnection, ticker: string, dates: s
   }
 }
 
-describe('runEnrichment injected IO path (Plan 02-04)', () => {
+describe('runEnrichment injected IO path', () => {
   let tmpDir: string;
   let db: DuckDBInstanceType;
   let conn: DuckDBConnection;
@@ -861,9 +861,9 @@ describe('runEnrichment injected IO path (Plan 02-04)', () => {
     await conn.run(`ATTACH ':memory:' AS market`);
     await ensureMutableMarketTables(conn);
     await ensureMarketDataTables(conn);
-    // Phase 6 Wave D: the no-spotStore fallback path in runEnrichment reads
-    // from market.spot_daily (the RTH-aggregated v3.0 view). Register the
-    // view locally over the fixture's market.spot table so tests that do not
+    // The no-spotStore fallback path in runEnrichment reads from
+    // market.spot_daily (the RTH-aggregated view). Register the view
+    // locally over the fixture's market.spot table so tests that do not
     // inject io.spotStore still have a readable daily OHLCV source.
     await conn.run(`
       CREATE OR REPLACE VIEW market.spot_daily AS
@@ -924,10 +924,10 @@ describe('runEnrichment injected IO path (Plan 02-04)', () => {
   test('with io.spotStore provided, Tier 3 hasData check routes through spotStore.getCoverage', async () => {
     const coverageCalls: string[] = [];
     const readBarsCalls: string[] = [];
-    // Plan 05-02 Wave B rewire (A8): Tier 1 now reads via spotStore.readDailyBars
-    // when io.spotStore is provided. To drive Tier 1 to completion (so Tier 3
-    // gets dates and the hasData/getCoverage check runs), the fake spotStore
-    // must return non-empty daily bars — matching the new read path.
+    // Tier 1 reads via spotStore.readDailyBars when io.spotStore is
+    // provided. To drive Tier 1 to completion (so Tier 3 gets dates and
+    // the hasData/getCoverage check runs), the fake spotStore must return
+    // non-empty daily bars — matching that read path.
     const fakeSpot: FakeSpotStore = {
       readBars: async (t: string) => { readBarsCalls.push(t); return []; },
       readDailyBars: async (t: string) => {
@@ -963,9 +963,9 @@ describe('runEnrichment injected IO path (Plan 02-04)', () => {
        VALUES ('SPX', '2025-01-06', '09:30', 100, 101, 99, 100, NULL, NULL)`,
     );
     let receivedReadBarsTicker: string | null = null;
-    // Plan 05-02 Wave B rewire (A8): Tier 1 now reads via spotStore.readDailyBars
-    // when io.spotStore is provided. Provide non-empty daily bars so Tier 1 completes
-    // and Tier 3 gets driven to call readBars.
+    // Tier 1 reads via spotStore.readDailyBars when io.spotStore is
+    // provided. Provide non-empty daily bars so Tier 1 completes and Tier 3
+    // gets driven to call readBars.
     const fakeSpot: FakeSpotStore = {
       readBars: async (t: string) => { receivedReadBarsTicker = t; return []; },
       readDailyBars: async (t: string) => {
@@ -988,11 +988,10 @@ describe('runEnrichment injected IO path (Plan 02-04)', () => {
     expect(receivedReadBarsTicker).toBe('SPX');
   });
 
-  test('without io but with dataDir, runEnrichment completes and writes watermark via JSON adapter (Plan 04-05)', async () => {
-    // Plan 04-05: the legacy `market._sync_metadata.enriched_through` SQL path
-    // is GONE. When `io` is not supplied, runEnrichment falls back to the JSON
+  test('without io but with dataDir, runEnrichment completes and writes watermark via JSON adapter', async () => {
+    // When `io` is not supplied, runEnrichment falls back to the JSON
     // adapter (`getEnrichedThrough` / `upsertEnrichedThrough`) directly,
-    // keyed off `opts.dataDir`. Verify the new fallback writes the watermark
+    // keyed off `opts.dataDir`. Verify the fallback writes the watermark
     // there and does NOT touch market._sync_metadata for enrichment.
     const { getEnrichedThrough } = await import('../../src/db/json-adapters.js');
     await seedDailyFixture(conn, 'SPX', ['2025-01-06', '2025-01-07', '2025-01-08']);
@@ -1002,11 +1001,11 @@ describe('runEnrichment injected IO path (Plan 02-04)', () => {
     // Result should be defined (not error) and reference the seeded ticker.
     expect(result.ticker).toBe('SPX');
     expect(result.tier1.status).toBe('complete');
-    // New JSON-adapter watermark was written (D-20)
+    // JSON-adapter watermark was written
     const watermark = await getEnrichedThrough('SPX', tmpDir);
     expect(watermark).toBe('2025-01-08');
-    // Legacy market._sync_metadata path is GONE — no enrichment row should
-    // have been written by the runner.
+    // No market._sync_metadata enrichment row should have been written by
+    // the runner — the legacy SQL watermark path is retired.
     const metaRows = await conn.runAndReadAll(
       `SELECT source FROM market._sync_metadata
        WHERE source = 'enrichment' AND ticker = 'SPX' AND target_table = 'daily'`,
@@ -1030,20 +1029,17 @@ describe('runEnrichment injected IO path (Plan 02-04)', () => {
 });
 
 // =============================================================================
-// Phase 5 Wave B rewire (A8) — io.spotStore is the canonical read path
+// io.spotStore as the canonical OHLCV read path
 //
-// Plan 05-02 closes RESEARCH §Assumption A8: after Wave D deletes daily.parquet,
-// runEnrichment must be able to read OHLCV from spot/ via io.spotStore.readDailyBars
-// (Tier 1) and via a TEMP table seeded from spotStore (Tier 2 VIX-family joins).
-//
-// Phase 6 Wave D: the legacy daily-view SQL fallback is retired. Callers MUST
-// pass io.spotStore (or rely on the spot_daily Parquet view resolved via
-// createMarketParquetViews). The "falls back to legacy SQL when io is undefined"
-// test has been DELETED here accordingly.
+// runEnrichment reads OHLCV from spot/ via io.spotStore.readDailyBars (Tier
+// 1) and via a TEMP table seeded from spotStore (Tier 2 VIX-family joins).
+// Callers MUST pass io.spotStore (or rely on the spot_daily Parquet view
+// resolved via createMarketParquetViews); the legacy daily-view SQL
+// fallback is retired.
 //
 // These tests prove the io.spotStore path works:
-//   - io.spotStore present → Tier 1 reads via readDailyBars, Tier 2 VIX-family
-//     reads via the TEMP seeded from spotStore
+//   - io.spotStore present → Tier 1 reads via readDailyBars, Tier 2
+//     VIX-family reads via the TEMP seeded from spotStore
 // =============================================================================
 
 /** Build a fake SpotStore that returns the given daily-bar map (ticker → BarRow[]). */
@@ -1117,7 +1113,7 @@ function syntheticDailyBars(
   return bars;
 }
 
-describe('Phase 5 Wave B rewire (A8) — io.spotStore is the canonical OHLCV read path', () => {
+describe('io.spotStore is the canonical OHLCV read path', () => {
   let tmpDir: string;
   let db: DuckDBInstanceType;
   let conn: DuckDBConnection;
@@ -1130,9 +1126,9 @@ describe('Phase 5 Wave B rewire (A8) — io.spotStore is the canonical OHLCV rea
     await conn.run(`ATTACH ':memory:' AS market`);
     await ensureMutableMarketTables(conn);
     await ensureMarketDataTables(conn);
-    // Phase 6 Wave D: the no-spotStore fallback path in runEnrichment reads
-    // from market.spot_daily (the RTH-aggregated v3.0 view). Register the
-    // view locally over the fixture's market.spot table so tests that do not
+    // The no-spotStore fallback path in runEnrichment reads from
+    // market.spot_daily (the RTH-aggregated view). Register the view
+    // locally over the fixture's market.spot table so tests that do not
     // inject io.spotStore still have a readable daily OHLCV source.
     await conn.run(`
       CREATE OR REPLACE VIEW market.spot_daily AS
@@ -1174,9 +1170,9 @@ describe('Phase 5 Wave B rewire (A8) — io.spotStore is the canonical OHLCV rea
     expect(result.enrichedThrough).toBe(spxBars[spxBars.length - 1].date);
   });
 
-  // Phase 6 Wave D: the "Tier 1 falls back to legacy daily-view SQL when io is
-  // undefined" test has been DELETED. The legacy daily-view fallback no longer
-  // exists in the catalog; io.spotStore is the canonical read path.
+  // The "Tier 1 falls back to legacy daily-view SQL when io is undefined"
+  // case is intentionally absent — that fallback no longer exists in the
+  // catalog; io.spotStore is the canonical read path.
 
   test('Tier 2: uses spotStore for VIX-family daily when io.spotStore is provided (no daily.parquet)', async () => {
     // Synthesize VIX/VIX9D/VIX3M daily bars in the fake spotStore. market.spot has no VIX data.

--- a/packages/mcp-server/tests/unit/market-importer-helpers.test.ts
+++ b/packages/mcp-server/tests/unit/market-importer-helpers.test.ts
@@ -1,16 +1,14 @@
 /**
- * Unit tests for the new pure helpers in src/utils/market-importer.ts:
+ * Unit tests for the pure helpers in src/utils/market-importer.ts:
  *
  *   - parseCsvToBars(filePath, ticker, columnMapping)  → Promise<BarRow[]>
  *   - parseDatabaseRowsToBars(rows, ticker, mapping)   → BarRow[]
  *   - validateColumnMapping(mapping, targetTable)      → { valid, missingFields }
  *
- * These helpers form the input edge of INGEST-01 (D-22). Coverage here
- * complements the integration suite (`tests/integration/market-imports-v2`)
- * + the auto-enrich composition suite (`tests/unit/market-imports.test.ts`).
- *
- * Plan 04-07 Task 2 adds these helpers; the project's testing rule requires
- * unit tests for every exported pure function.
+ * These helpers form the input edge of the market-import tools. Coverage
+ * here complements the integration suite
+ * (`tests/integration/market-imports-v2`) and the auto-enrich composition
+ * suite (`tests/unit/market-imports.test.ts`).
  */
 import * as fs from "fs/promises";
 import * as os from "os";

--- a/packages/mcp-server/tests/unit/market-imports.test.ts
+++ b/packages/mcp-server/tests/unit/market-imports.test.ts
@@ -1,9 +1,9 @@
 /**
- * Unit tests for tools/market-imports.ts auto-enrich composition (W5 / D-27).
+ * Unit tests for tools/market-imports.ts auto-enrich composition.
  *
- * Plan 04-07 Task 4 — covers the tool-handler-level composition contract that
- * the integration suite at `tests/integration/market-imports-v2.test.ts`
- * exercises end-to-end:
+ * Covers the tool-handler-level composition contract that the integration
+ * suite at `tests/integration/market-imports-v2.test.ts` exercises
+ * end-to-end:
  *
  *   1. spot.writeBars BEFORE enriched.compute (composition order)
  *   2. VIX-family triggers enriched.computeContext AFTER compute (compose order)
@@ -14,16 +14,15 @@
  *   7. Error propagation: compute throws AFTER writeBars succeeds → isError:true
  *      (loud failure — spot data was written but enrichment failed)
  *
- * Both this unit suite AND the integration suite are required per D-27.
- *
  * Mocking strategy: every store method is replaced with a jest.fn() spy that
  * appends a typed marker into a shared `calls` array. We assert composition by
  * inspecting the array — no real DuckDB I/O.
  *
- * The tool handler still calls `upgradeToReadWrite(baseDir)` / `downgradeToReadOnly`
- * which act on a real `<baseDir>/analytics.duckdb` file. We give it a tmp baseDir
- * so the lifecycle is harmless. The store conns are independent (mocked) so the
- * RW lifecycle does not invalidate them.
+ * The tool handler still calls `upgradeToReadWrite(baseDir)` /
+ * `downgradeToReadOnly` which act on a real `<baseDir>/analytics.duckdb`
+ * file. We give it a tmp baseDir so the lifecycle is harmless. The store
+ * conns are independent (mocked) so the RW lifecycle does not invalidate
+ * them.
  */
 import * as fs from "fs/promises";
 import * as os from "os";
@@ -123,7 +122,7 @@ const COLUMN_MAPPING: Record<string, string> = {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("tools/market-imports — auto-enrich composition (W5 / D-27)", () => {
+describe("tools/market-imports — auto-enrich composition", () => {
   let baseDir: string;
   let csvPath: string;
 
@@ -139,7 +138,7 @@ describe("tools/market-imports — auto-enrich composition (W5 / D-27)", () => {
     await fs.rm(baseDir, { recursive: true, force: true });
   });
 
-  it("Test 1 — calls writeBars BEFORE enriched.compute", async () => {
+  it("calls writeBars BEFORE enriched.compute", async () => {
     const { stores, calls, spotWriteBars, enrichedCompute } = makeMockStores();
     const { server, tools } = makeServer();
     registerMarketImportTools(server as never, baseDir, stores);
@@ -161,7 +160,7 @@ describe("tools/market-imports — auto-enrich composition (W5 / D-27)", () => {
     expect(computeIdx).toBeGreaterThan(writeIdx);
   });
 
-  it("Test 2 — VIX ticker calls enriched.computeContext AFTER enriched.compute", async () => {
+  it("VIX ticker calls enriched.computeContext AFTER enriched.compute", async () => {
     const { stores, calls, enrichedComputeContext } = makeMockStores();
     const { server, tools } = makeServer();
     registerMarketImportTools(server as never, baseDir, stores);
@@ -183,7 +182,7 @@ describe("tools/market-imports — auto-enrich composition (W5 / D-27)", () => {
     expect(ctxIdx).toBeGreaterThan(computeIdx);
   });
 
-  it("Test 3 — non-VIX ticker does NOT call enriched.computeContext", async () => {
+  it("non-VIX ticker does NOT call enriched.computeContext", async () => {
     const { stores, enrichedCompute, enrichedComputeContext } = makeMockStores();
     const { server, tools } = makeServer();
     registerMarketImportTools(server as never, baseDir, stores);
@@ -201,7 +200,7 @@ describe("tools/market-imports — auto-enrich composition (W5 / D-27)", () => {
     expect(enrichedComputeContext).not.toHaveBeenCalled();
   });
 
-  it("Test 4 — skip_enrichment=true → writeBars only, no compute or computeContext", async () => {
+  it("skip_enrichment=true → writeBars only, no compute or computeContext", async () => {
     const { stores, spotWriteBars, enrichedCompute, enrichedComputeContext } = makeMockStores();
     const { server, tools } = makeServer();
     registerMarketImportTools(server as never, baseDir, stores);
@@ -220,7 +219,7 @@ describe("tools/market-imports — auto-enrich composition (W5 / D-27)", () => {
     expect(enrichedComputeContext).not.toHaveBeenCalled();
   });
 
-  it("Test 5 — dry_run=true → neither writeBars nor compute / computeContext", async () => {
+  it("dry_run=true → neither writeBars nor compute / computeContext", async () => {
     const { stores, spotWriteBars, enrichedCompute, enrichedComputeContext } = makeMockStores();
     const { server, tools } = makeServer();
     registerMarketImportTools(server as never, baseDir, stores);
@@ -239,7 +238,7 @@ describe("tools/market-imports — auto-enrich composition (W5 / D-27)", () => {
     expect(enrichedComputeContext).not.toHaveBeenCalled();
   });
 
-  it("Test 6 — writeBars throws → handler returns isError:true, compute NOT called", async () => {
+  it("writeBars throws → handler returns isError:true, compute NOT called", async () => {
     const { stores, enrichedCompute, enrichedComputeContext } = makeMockStores({
       writeBarsRejects: new Error("disk full"),
     });
@@ -262,7 +261,7 @@ describe("tools/market-imports — auto-enrich composition (W5 / D-27)", () => {
     expect(text?.text ?? "").toMatch(/disk full/i);
   });
 
-  it("Test 7 — compute throws AFTER writeBars succeeds → handler returns isError:true (loud failure per D-23)", async () => {
+  it("compute throws AFTER writeBars succeeds → handler returns isError:true (loud failure)", async () => {
     const { stores, spotWriteBars, enrichedCompute } = makeMockStores({
       computeRejects: new Error("enrichment math broke"),
     });
@@ -277,8 +276,8 @@ describe("tools/market-imports — auto-enrich composition (W5 / D-27)", () => {
       dry_run: false,
       skip_enrichment: false,
     });
-    // Spot data was written, but enrichment failed — handler must surface
-    // the failure (not silently swallow) per D-23 + Pattern 4 contract.
+    // Spot data was written, but enrichment failed — the handler must
+    // surface the failure (not silently swallow).
     expect(spotWriteBars).toHaveBeenCalled();
     expect(enrichedCompute).toHaveBeenCalled();
     expect(out.isError).toBe(true);
@@ -292,7 +291,7 @@ describe("tools/market-imports — auto-enrich composition (W5 / D-27)", () => {
   // groupByDate → writeBars wiring without touching enrichment.
   // ---------------------------------------------------------------------------
 
-  it("Test 8 — writeBars receives normalized ticker + ISO date + parsed bars", async () => {
+  it("writeBars receives normalized ticker + ISO date + parsed bars", async () => {
     const { stores, spotWriteBars } = makeMockStores();
     const { server, tools } = makeServer();
     registerMarketImportTools(server as never, baseDir, stores);

--- a/packages/mcp-server/tests/unit/market/stores/views.test.ts
+++ b/packages/mcp-server/tests/unit/market/stores/views.test.ts
@@ -1,20 +1,17 @@
 /**
- * Phase 2 Plan 02 — market-views.ts changes.
+ * Tests for market-views.ts Parquet-view registration.
  *
- * Covers the three new Parquet views registered alongside the existing 5:
+ * Covers the three primary Parquet views:
  *   - market.spot               (Hive: ticker=X/date=Y/data.parquet)
  *   - market.enriched           (per-ticker file: ticker=X/data.parquet)
  *   - market.enriched_context   (global single file: context/data.parquet)
  *
  * Ensures:
- *   - Empty market/ dir → all three land in tablesKept, not viewsCreated (Pitfall 2)
+ *   - Empty market/ dir → all three land in tablesKept, not viewsCreated
  *   - Populated dirs → view is registered and selectable
- *   - Existing views (intraday, daily, date_context, option_chain, option_quote_minutes)
- *     still resolve to tablesKept when their files are absent (D-22 preservation)
- *   - Idempotency: calling createMarketParquetViews twice does not error (Pitfall 9)
- *
- * Imports directly from src/db/market-views.ts + src/db/market-schemas.ts (source paths)
- * — Plan 01 owns all Wave 1 test-exports edits.
+ *   - Hive-partitioned views (option_chain, option_quote_minutes) still
+ *     resolve to tablesKept when their files are absent
+ *   - Idempotency: calling createMarketParquetViews twice does not error
  */
 import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import { DuckDBInstance, type DuckDBConnection } from "@duckdb/node-api";
@@ -128,9 +125,9 @@ async function writeLegacyOptionQuoteFixture(): Promise<void> {
 }
 
 /**
- * Phase 6 Plan 06-00 Task 1 — multi-bar fixture for RTH aggregation tests.
- * Writes N minute bars for a given (ticker, date) so the market.spot_daily
- * view's GROUP BY ticker+date + RTH window 09:30–16:00 can be exercised.
+ * Multi-bar fixture for RTH aggregation tests. Writes N minute bars for a
+ * given (ticker, date) so the market.spot_daily view's GROUP BY
+ * ticker+date + RTH window 09:30–16:00 can be exercised.
  */
 async function writeSpotMinuteBarsFixture(
   ticker: string,
@@ -167,8 +164,8 @@ async function writeSpotMinuteBarsFixture(
   `);
 }
 
-describe("Phase 2 market-views registration", () => {
-  it("empty market/ dir: spot/enriched/enriched_context land in tablesKept, not viewsCreated (Pitfall 2)", async () => {
+describe("market-views registration", () => {
+  it("empty market/ dir: spot/enriched/enriched_context land in tablesKept, not viewsCreated", async () => {
     const result = await createMarketParquetViews(conn, tmpDir);
     expect(result.viewsCreated).not.toContain("spot");
     expect(result.viewsCreated).not.toContain("enriched");
@@ -221,7 +218,7 @@ describe("Phase 2 market-views registration", () => {
     expect(read.getRows()).toEqual([[null, null, null, null, null, null, null]]);
   });
 
-  it("view-vs-table transparency: same SELECT works against view as against physical table (Pattern 2)", async () => {
+  it("view-vs-table transparency: same SELECT works against view as against physical table", async () => {
     await writeSpotPartitionFixture("SPX", "2025-01-06");
     await createMarketParquetViews(conn, tmpDir);
     const viaView = await conn.runAndReadAll(
@@ -230,7 +227,7 @@ describe("Phase 2 market-views registration", () => {
     expect(viaView.getRows().length).toBeGreaterThan(0);
   });
 
-  it("v3.0 views (option_chain, option_quote_minutes, spot, enriched, enriched_context) resolve in tablesKept on empty dir (D-22 post Phase 6 Wave D)", async () => {
+  it("canonical views (option_chain, option_quote_minutes, spot, enriched, enriched_context, spot_daily) resolve in tablesKept on empty dir", async () => {
     const result = await createMarketParquetViews(conn, tmpDir);
     expect(result.tablesKept).toContain("option_chain");
     expect(result.tablesKept).toContain("option_quote_minutes");
@@ -240,7 +237,7 @@ describe("Phase 2 market-views registration", () => {
     expect(result.tablesKept).toContain("spot_daily");
   });
 
-  it("second call is idempotent — re-registering views does not error (Pitfall 9)", async () => {
+  it("second call is idempotent — re-registering views does not error", async () => {
     await writeSpotPartitionFixture("SPX", "2025-01-06");
     await createMarketParquetViews(conn, tmpDir);
     await createMarketParquetViews(conn, tmpDir);
@@ -252,17 +249,17 @@ describe("Phase 2 market-views registration", () => {
 });
 
 // =============================================================================
-// Phase 6 Plan 06-00 Task 1 — market.spot_daily view
+// market.spot_daily view
 //
 // The view RTH-aggregates market.spot into ticker+date daily bars. Semantics
 // MUST match SpotStore.readDailyBars: first(open ORDER BY time), max(high),
 // min(low), last(close ORDER BY time), first(bid ORDER BY time),
 // last(ask ORDER BY time), RTH window 09:30–16:00 inclusive, GROUP BY
-// ticker+date. Registration is unconditional — a view over table-or-view works
-// whether market.spot resolves to a Parquet view or a fallback table (Pitfall 3).
+// ticker+date. Registration is unconditional — a view over table-or-view
+// works whether market.spot resolves to a Parquet view or a fallback table.
 // =============================================================================
 
-describe("Phase 6 market.spot_daily view", () => {
+describe("market.spot_daily view", () => {
   it("RTH aggregation correctness: open=first, close=last, high=max, low=min within 09:30–16:00", async () => {
     // 5 bars: 09:29 (pre-RTH, excluded), 09:30 (first RTH), 10:00,
     // 16:00 (last RTH), 16:30 (post-RTH, excluded).
@@ -298,7 +295,7 @@ describe("Phase 6 market.spot_daily view", () => {
     expect(Number(askVal)).toBe(626.0); // last RTH tick ask
   });
 
-  it("unconditional registration: view is registered even when market.spot is a fallback table (Pitfall 3)", async () => {
+  it("unconditional registration: view is registered even when market.spot is a fallback table", async () => {
     // Do NOT write any Parquet partitions — market.spot resolves to tablesKept.
     // Pre-create a physical fallback table so the view has something to bind to.
     await conn.run(`
@@ -338,9 +335,10 @@ describe("Phase 6 market.spot_daily view", () => {
   });
 
   it("DROP dance handles pre-existing table of same name — view replaces table without throwing", async () => {
-    // Pre-create a physical TABLE named market.spot_daily BEFORE createMarketParquetViews
-    // registers the view. The DROP VIEW IF EXISTS + DROP TABLE IF EXISTS pattern
-    // (Pattern 2 in market-views.ts) must tolerate the type mismatch gracefully.
+    // Pre-create a physical TABLE named market.spot_daily BEFORE
+    // createMarketParquetViews registers the view. The DROP VIEW IF EXISTS +
+    // DROP TABLE IF EXISTS dance in market-views.ts must tolerate the type
+    // mismatch gracefully.
     await conn.run(`
       CREATE TABLE market.spot_daily (
         ticker VARCHAR, date VARCHAR, open DOUBLE

--- a/packages/mcp-server/tests/unit/market/stores/watermark-adapter.test.ts
+++ b/packages/mcp-server/tests/unit/market/stores/watermark-adapter.test.ts
@@ -1,6 +1,5 @@
 /**
- * Unit tests for the enrichment-watermark JSON adapter
- * (Market Data 3.0 — Phase 2 Wave 1, Plan 02-01 Task 2).
+ * Unit tests for the enrichment-watermark JSON adapter.
  *
  * Exercises:
  *   - Missing file → empty structure (not an error)
@@ -8,8 +7,9 @@
  *   - Multi-ticker preservation on update
  *   - Passthrough preservation of unknown extension fields (forward compat)
  *   - Unknown ticker returns null
- *   - Malformed JSON → clear thrown error (D-21)
- *   - Zod schema edge cases: invalid ticker key / invalid date format / null date accepted
+ *   - Malformed JSON → clear thrown error
+ *   - Zod schema edge cases: invalid ticker key / invalid date format /
+ *     null date accepted
  */
 import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 import { mkdirSync, rmSync, writeFileSync } from "fs";
@@ -82,7 +82,7 @@ describe("enrichment watermarks adapter", () => {
     expect(await getEnrichedThrough("QQQ", dataDir)).toBeNull();
   });
 
-  it("malformed JSON throws clear error (D-21)", async () => {
+  it("malformed JSON throws clear error", async () => {
     mkdirSync(join(dataDir, "market-meta"), { recursive: true });
     writeFileSync(
       join(dataDir, "market-meta", "enrichment-watermarks.json"),

--- a/packages/mcp-server/tests/unit/market/tickers/resolver.test.ts
+++ b/packages/mcp-server/tests/unit/market/tickers/resolver.test.ts
@@ -6,18 +6,16 @@
  *   - extractRoot OCC tail-strip
  *   - extractRoot error on no leading alpha
  *   - rootToUnderlying across SPX family, QQQ family
- *   - Identity fallback for leveraged ETFs (D-05 correctness rule)
+ *   - Identity fallback for leveraged ETFs (leveraged ETFs must NOT fold
+ *     into the parent index)
  *   - Identity fallback for arbitrary unknown roots
- *
- * Tests will run once Plan 01-06 wires test-exports for the tickers module.
- * Until then `npm run build` must succeed and imports must compile cleanly.
  */
 import { describe, it, expect } from "@jest/globals";
 // Imported directly from source files rather than via test-exports.
 import { extractRoot, rootToUnderlying } from "../../../../src/market/tickers/resolver.js";
 import { TickerRegistry } from "../../../../src/market/tickers/registry.js";
 
-// A registry seeded with D-07 defaults (the one the production loader builds).
+// A registry seeded with the bundled defaults the production loader builds.
 const defaults = [
   { underlying: "SPX", roots: ["SPX", "SPXW", "SPXQ"] },
   { underlying: "QQQ", roots: ["QQQ", "QQQX"] },
@@ -79,7 +77,7 @@ describe("rootToUnderlying — QQQ family", () => {
   });
 });
 
-describe("rootToUnderlying — leveraged ETFs (identity fallback, per D-05)", () => {
+describe("rootToUnderlying — leveraged ETFs (identity fallback)", () => {
   const registry = new TickerRegistry(defaults);
   it("returns SPXL / SPXS / SPXU / SPXC as themselves — never folded into SPX", () => {
     expect(rootToUnderlying("SPXL", registry)).toBe("SPXL");

--- a/packages/mcp-server/tests/unit/migrate-option-data.test.ts
+++ b/packages/mcp-server/tests/unit/migrate-option-data.test.ts
@@ -1,15 +1,14 @@
 /**
- * Unit tests for migrate-option-data pure helpers (Phase 3 Wave 0).
+ * Unit tests for the migrate-option-data pure helpers.
  *
- * Covers (CONTEXT.md D-24):
+ * Covers:
  *   - groupTickersByUnderlying: SPX-family grouping, leveraged-ETF exclusion,
  *     unknown-root identity fallback, empty input, custom skipSet override.
- *   - buildOptionChainSelectQuery: EXCLUDE (underlying) per D-05, WHERE filter,
+ *   - buildOptionChainSelectQuery: EXCLUDE (underlying), WHERE filter,
  *     glob interpolation.
- *   - buildOptionQuoteSelectQuery: regexp_extract IN-list, no EXCLUDE (D-08),
+ *   - buildOptionQuoteSelectQuery: regexp_extract IN-list, no EXCLUDE
+ *     (quote-minute partitions don't carry an underlying column),
  *     empty-roots throw.
- *
- * Imports from the compiled test-exports.js (3 levels up — matches resolver.test.ts).
  */
 import { describe, it, expect } from "@jest/globals";
 import {
@@ -93,7 +92,7 @@ describe("groupTickersByUnderlying — edge cases", () => {
 });
 
 describe("buildOptionChainSelectQuery", () => {
-  it("includes EXCLUDE (underlying) per D-05", () => {
+  it("includes EXCLUDE (underlying) to avoid duplicating the partition column", () => {
     const sql = buildOptionChainSelectQuery("/tmp/dir/data*.parquet", "SPX");
     expect(sql).toContain("* EXCLUDE (underlying)");
   });
@@ -117,7 +116,7 @@ describe("buildOptionQuoteSelectQuery", () => {
     const sql = buildOptionQuoteSelectQuery("/tmp/dir/data*.parquet", ["SPX", "SPXW"]);
     expect(sql).toContain("IN ('SPX', 'SPXW')");
   });
-  it("does NOT include EXCLUDE (body has no underlying column per D-08)", () => {
+  it("does NOT include EXCLUDE (quote-minute body has no underlying column)", () => {
     const sql = buildOptionQuoteSelectQuery("/tmp/dir/data*.parquet", ["SPX"]);
     expect(sql).not.toContain("EXCLUDE");
   });

--- a/packages/mcp-server/tests/unit/tool-ticker-deps.test.ts
+++ b/packages/mcp-server/tests/unit/tool-ticker-deps.test.ts
@@ -1,13 +1,10 @@
 /**
- * Unit tests for the Tool Dependency Registry (RESOLVE-02 / Phase 4 Plan 04-00).
+ * Unit tests for the Tool Dependency Registry.
  *
- * Mirrors `tests/unit/data-pipeline.test.ts` structure per PATTERNS.md §Pattern
- * 8 (Contract-style unit test). Covers CONTEXT.md D-20 assertions plus two
- * additional edge cases (no targetTicker, registry shape).
- *
- * Project convention: import via `../../src/test-exports.js` (PATTERNS.md
- * §Pattern 6). Plan 04-00 Task 1 surfaces TOOL_TICKER_DEPS + unionTickerDeps
- * through test-exports.ts.
+ * Mirrors the contract-style unit test pattern used elsewhere in this tree.
+ * Covers the registry shape, unionTickerDeps composition, and a handful of
+ * edge cases (targetTicker substitution, deterministic sorting, unknown
+ * tool errors).
  */
 import { describe, it, expect } from '@jest/globals';
 import {
@@ -15,7 +12,7 @@ import {
   unionTickerDeps,
 } from '../../src/test-exports.js';
 
-describe('TOOL_TICKER_DEPS registry (D-18 shape)', () => {
+describe('TOOL_TICKER_DEPS registry shape', () => {
   it('declares backtester as [SPX, VIX, VIX9D]', () => {
     expect(TOOL_TICKER_DEPS.backtester).toEqual(['SPX', 'VIX', 'VIX9D']);
   });


### PR DESCRIPTION
Tier: 3 (public-repo, doc + test-name scrub)

## Summary

Final PR (4 of 4) for tradeblocks-org/enterprise#110. Comment + `describe`/`it`/`test` string rewrites across 19 test files + 1 fixture in `packages/mcp-server/tests/`. **Assertion bodies untouched. 1566/1566 tests pass.**

+323 / −368 lines. Zero behavior change. One file in scope (`wave-b-chain-consumer-contract.test.ts`) was already clean from #306/#307 — untouched here.

## Out of scope (preserved per #110)

- **Filenames** (`wave-a-*`, `wave-b-*`, `wave-c-*`, `phase-05-*`): renaming breaks git history and CI references. Separate initiative required.
- **`PHASE_5_SAMPLE_DATES`** (exported const in the fixture): identifier rename out of scope; only its docstring was scrubbed.

## What changed in wording

- **`describe` / `it` / `test` strings**: dropped Phase/Wave/Plan/D-NN labels while preserving assertion specificity. Examples:
  - `'Wave A spot-consumer contract: checkDataAvailability'` → `'spot-consumer contract: checkDataAvailability'`
  - `'Pitfall 4: mixed-underlying batch throws'` → `'mixed-underlying batch throws a clear error'`
  - `'Test 1.1 — ...'` → `'spot layout — spot/ticker=X/date=Y/data.parquet exists after writeBars'`
- **JSDoc + inline comments**: rewrote to convey test intent without internal-team vocab.
- **One block removed**: `wave-b-option-consumer-contract.test.ts` carried a JSDoc "Pre-migration external consumers" block listing migration-source file:line citations (e.g., `replay.ts:284,302`). Non-load-bearing planning residue — removed wholesale. The test's own `describe`/`it` names now carry the consumer list.

## On `tool-ticker-deps.ts` source-side

`packages/mcp-server/src/utils/tool-ticker-deps.ts` JSDoc still has `RESOLVE-02`, `Phase 4 CONTEXT D-21`, `Phase 4 Wave D` references **on this branch** because PR 3 (tradeblocks#313) — which scrubs that file — hasn't merged yet. Once both PR 3 and this PR land on `feat/tradeblocks-3.0`, the source + test sides are both clean.

## Verification

- Lint clean
- Typecheck: 3 pre-existing errors in `utils/exit-triggers.ts` on baseline — unrelated, untouched (real production bugs reading missing properties; tracked as a separate follow-up card)
- **`npm test`: 19 suites, 247 tests passing on the touched paths; full suite 120 suites / 1566 tests / all passing**
- Internal-vocab grep on the 19 touched files: clean (filenames excluded per scope)
- Public-boundary grep repo-wide: clean

## What I'm asking

Test-name rewrites are the load-bearing change here — they show up in CI logs and developer terminals. Skim 2-3 of the largest test files (`unit/market-enricher.test.ts`, `integration/trade-replay.test.ts`, `integration/wave-b-option-consumer-contract.test.ts`) and tell me if any rewrite muddies the assertion intent.

## Test plan

- [x] Lint clean
- [x] Typecheck clean of new errors
- [x] Full test suite passing (1566/1566)
- [x] Internal-vocab grep clean on touched files (filenames preserved per scope)
- [x] Public-boundary grep clean repo-wide
- [ ] Smith review

🤖 Generated with [Claude Code](https://claude.com/claude-code)