### PR TITLE
fix(mcp-server): exit-triggers typecheck — declare requiredHits + allLegsSync

### DIFF
--- a/packages/mcp-server/src/utils/exit-triggers.ts
+++ b/packages/mcp-server/src/utils/exit-triggers.ts
@@ -59,6 +59,8 @@ export interface ExitTriggerConfig {
   spreadWidth?: number;                          // Width of spread in dollars
   contracts?: number;                            // Number of contracts
   multiplier?: number;                           // Default 100
+  // profitTarget confirmation: N synchronized-quote bars at-or-above threshold required before firing (default 2)
+  requiredHits?: number;
   // Internal: set by handler when unit='percent' to compute dollar threshold
   entryCost?: number;                            // D-11: cost/credit of entry (negative = credit received)
   entrySLRatio?: number;                         // Runtime-hydrated opening short/long ratio for slRatioMove
@@ -294,7 +296,7 @@ export function evaluateTrigger(
       case 'profitTarget': {
         // unit='percent' requires entryCost; if missing, cannot compute — no fire
         if (trigger.unit === 'percent' && trigger.entryCost == null) break;
-        const requiredHits = (trigger.requiredHits as number | undefined) ?? 2;
+        const requiredHits = trigger.requiredHits ?? 2;
         const dollarThresholdPT = trigger.unit === 'percent'
           ? threshold * Math.abs(trigger.entryCost!)
           : threshold;

--- a/packages/mcp-server/src/utils/trade-replay.ts
+++ b/packages/mcp-server/src/utils/trade-replay.ts
@@ -45,6 +45,12 @@ export interface PnlPoint {
   netVega?: number | null;
   // IVP from canonical market datasets (typically VIX ticker rows in market.enriched)
   ivp?: number | null;
+  // True when all legs have synchronized quotes at this minute; false when one or more
+  // legs lack a fresh quote. Triggers like profitTarget gate hit-counting on this so
+  // unsynchronized bars don't count toward confirmation and don't reset the counter.
+  // When undefined (no producer populates the field) consumers treat the bar as synchronized.
+  // TODO: populated by a future quote-sync detector — currently forward-compat only.
+  allLegsSync?: boolean;
 }
 
 /** Configuration for greeks computation in P&L path. */


### PR DESCRIPTION
**Tier: 3**
**Worktree:** `tradeblocks-romeo-165-exit-triggers-typecheck`
**Tracks:** tradeblocks-org/enterprise#165

## Summary

Resolves three pre-existing typecheck errors in `packages/mcp-server/src/utils/exit-triggers.ts` (lines 297/302/308 on the `feat/tradeblocks-3.0` baseline) by declaring two missing optional fields on the corresponding exported interfaces:

- `ExitTriggerConfig.requiredHits?: number` — N synchronized-quote bars at-or-above threshold required before a `profitTarget` fires (default 2 preserved at the call site).
- `PnlPoint.allLegsSync?: boolean` — formalizes the asymmetric `!== false` reads that already gate hit-counting (unsynchronized bars don't count toward confirmation and don't reset the counter). No producer populates the field today — forward-compat only — and the `undefined → synchronized` convention preserves current behavior.

## Root cause

The reads of `requiredHits` and `allLegsSync` were introduced together with the Market Data 3.0 work in `b1c82f0` (2026-04-20) but the interface declarations were never paired with them. A `(trigger.requiredHits as number | undefined) ?? 2` cast at `:297` was the only thing keeping the file compiling; runtime evaluation of the unread fields silently returned `undefined`.

## Surface impact

Both additions are optional fields on already-exported types — backwards-compatible widening. Internal modules only (neither file appears in the `tradeblocks-mcp` `exports` map), but the types ship in the published source tree, so per the Tier 3 review protocol this PR carries an Admiral sign-off requirement.

## Test plan

- [x] Typecheck: 0 errors in `packages/mcp-server` (was 3).
- [x] `exit-triggers.test.ts` — 75/75 pass (test at lines 60-68 anchors the default-2 hit-confirmation semantics via `result.index === 4`).
- [x] Related suites (`batch-exit-analysis.test.ts` + `profile-schema-v2.test.ts`) — 22/22 pass.
- [x] ESLint clean on both touched files.
- [x] Grep across `packages/mcp-server` + `packages/lib` for other reads of these fields — only the three flagged lines.

Closes tradeblocks-org/enterprise#165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)