### PR TITLE
docs(db): scrub internal-ticket vocab from 6 db/ source files

### DIFF
--- a/packages/mcp-server/src/db/connection.ts
+++ b/packages/mcp-server/src/db/connection.ts
@@ -346,9 +346,9 @@ async function openReadWriteConnection(
   const dataDir = path.dirname(dbPath);
   const dataRoot = getDataRoot(dataDir);
 
-  // Parquet view overlay: create views over shared Parquet files.
-  // Replaces physical tables when Parquet files exist (D-00, D-09).
-  // The env var controls WRITE path; read path is always opportunistic (D-00c).
+  // Parquet view overlay: create views over shared Parquet files when present.
+  // The env var controls WRITE path; the read path is always opportunistic —
+  // views are registered whenever the Parquet files exist.
   // Runs BEFORE ensureMarketDataTables so stale views from a previous data path
   // are dropped first — otherwise CREATE TABLE IF NOT EXISTS is a no-op against
   // the existing view name, leaving a broken view referencing a missing file.
@@ -356,7 +356,7 @@ async function openReadWriteConnection(
 
   // Physical market data tables as fallback for datasets not covered by Parquet views.
   //
-  // IMPORTANT — lifecycle ordering (Phase 2 D-12, #market-data-3.0):
+  // IMPORTANT — lifecycle ordering:
   // Because createMarketParquetViews (above) runs FIRST, by the time we get here
   // a VIEW may already occupy any of the canonical names (e.g. market.option_quote_minutes
   // over legacy-layout Parquet files that lack the new `underlying` column). Any
@@ -364,10 +364,9 @@ async function openReadWriteConnection(
   // a physical table MUST filter information_schema.tables by
   // `table_type = 'BASE TABLE'` so it does not accidentally drop a legitimate VIEW.
   // VIEWs are owned by the Parquet-view layer, not by this schema layer.
-  // See market-schemas.ts §D-12 option_quote_minutes block for the canonical pattern.
   await ensureMarketDataTables(connection);
 
-  // One-time metadata migration: DuckDB -> JSON files (Phase 3)
+  // One-time metadata migration: DuckDB -> JSON files.
   // Runs only when TRADEBLOCKS_PARQUET=true and JSON files don't yet exist.
   // Must run AFTER all DuckDB tables are created (profiles, sync, market schemas).
   try {
@@ -694,8 +693,8 @@ export function getCurrentConnection(): DuckDBConnection {
   return connection;
 }
 
-// Phase 4 D-10: the legacy intraday write-target getter / module-state variable
-// + the connection.ext.ts override hook were DELETED. Every spot write now
+// Note: the legacy intraday write-target getter / module-state variable and
+// the connection.ext.ts override hook have been removed. Every spot write now
 // flows through SpotStore.writeBars (the canonical Hive-partitioned
 // `spot/ticker=X/date=Y/` layout); there is no longer a per-process override
-// of the write target. See PATTERNS.md §src/db/connection.ts for the rationale.
+// of the write target.

--- a/packages/mcp-server/src/db/json-migration.ts
+++ b/packages/mcp-server/src/db/json-migration.ts
@@ -7,9 +7,9 @@
  *
  * Idempotency: Each sub-migration checks if JSON files already exist for that store.
  * If yes, skips. If DuckDB table is empty, skips. Only migrates when DuckDB has data
- * and JSON doesn't. (D-01, D-01a)
+ * and JSON doesn't.
  *
- * DuckDB tables are left as-is after migration (D-01b).
+ * DuckDB tables are left as-is after migration.
  */
 
 import type { DuckDBConnection } from "@duckdb/node-api";
@@ -283,7 +283,7 @@ async function migrateFlatImportLog(conn: DuckDBConnection, dataDir: string): Pr
  *   - Skips if DuckDB tables are empty or don't exist
  *   - DuckDB tables are left as-is (not dropped or modified)
  *
- * Strategy definitions are migrated separately via json-migration.ext.ts (D-04).
+ * Strategy definitions are migrated separately via json-migration.ext.ts.
  *
  * @param conn - Active DuckDB connection (must be read-write)
  * @param dataDir - Root data directory (e.g., ~/tradeblocks-data)

--- a/packages/mcp-server/src/db/market-datasets.ts
+++ b/packages/mcp-server/src/db/market-datasets.ts
@@ -60,20 +60,18 @@ export function canonicalMarketTableName(dataset: CanonicalMarketDataset): strin
 }
 
 // ============================================================================
-// Market Data 3.0 — Declarative dataset registry (Phase 1)
+// Declarative dataset registry — canonical Parquet layout
 //
-// Describes the 3.0 target Parquet layout:
 //   spot:                 spot/ticker=X/date=Y/data.parquet
 //   enriched:             enriched/ticker=X/data.parquet
 //   enriched_context:     enriched/context/data.parquet
 //   option_chain:         option_chain/underlying=X/date=Y/data.parquet
 //   option_quote_minutes: option_quote_minutes/underlying=X/date=Y/data.parquet
+//
 // This registry is SEPARATE from the legacy CanonicalPartitionedDataset enum
-// and PARTITIONED_DATASETS map above. Both coexist per CONTEXT.md D-15:
-// legacy resolvers serve existing callers (date-only paths) until Phase 3/5
-// deletes them (option_chain/option_quote_minutes in Phase 3; intraday/
-// daily/date_context in Phase 5 after Phase 4 consumer migration);
-// the new DATASETS_V3 describes only the 3.0 target state.
+// and PARTITIONED_DATASETS map above. Both coexist while consumer migration
+// is ongoing: legacy resolvers serve existing callers (date-only paths) and
+// DATASETS_V3 describes the canonical target state.
 // ============================================================================
 
 export interface DatasetDef {
@@ -98,7 +96,8 @@ export const DATASETS_V3: Record<string, DatasetDef> = {
 //
 // Security note: writeParquetPartition applies a whitelist to every partition
 // key and value — /^[A-Za-z0-9._-]+$/ on values, /^[A-Za-z_][A-Za-z0-9_]*$/ on keys.
-// That is the deepest defense-in-depth layer (T-1-01). Helpers do not re-validate.
+// That is the deepest defense-in-depth layer against path traversal. Helpers
+// do not re-validate.
 
 export async function writeSpotPartition(
   conn: DuckDBConnection,
@@ -184,7 +183,6 @@ export async function writeEnrichedTickerFile(
  * SPECIAL CASE: partitionKeys=[] would cause writeParquetPartition's partition
  * loop to no-op and compose {baseDir}/data.parquet (one directory too shallow).
  * Bypass the generic writer and call writeParquetAtomic directly with the full target path.
- * Per RESEARCH.md Pattern 7 note (line 709).
  */
 export async function writeEnrichedContext(
   conn: DuckDBConnection,

--- a/packages/mcp-server/src/db/market-schemas.ts
+++ b/packages/mcp-server/src/db/market-schemas.ts
@@ -16,11 +16,11 @@
  * Table naming: market.spot resolves to catalog=market, schema=main, table=spot
  * after ATTACH '...' AS market. Do NOT create a schema within market.duckdb.
  *
- * Phase 6 Wave D (SQL-02 closure): the legacy fallback CREATE TABLE blocks
- * for daily / date_context / intraday / option_chain / option_quote_minutes
- * have been DELETED. option_chain + option_quote_minutes live only as Parquet
- * views (no physical fallback); spot / enriched / enriched_context are the
- * only physical fallback tables that remain.
+ * The legacy fallback CREATE TABLE blocks for daily / date_context / intraday /
+ * option_chain / option_quote_minutes have been removed. option_chain and
+ * option_quote_minutes live only as Parquet views (no physical fallback);
+ * spot / enriched / enriched_context are the only physical fallback tables
+ * that remain.
  */
 
 import type { DuckDBConnection } from "@duckdb/node-api";
@@ -40,7 +40,7 @@ import type { DuckDBConnection } from "@duckdb/node-api";
 export async function ensureMutableMarketTables(
   conn: DuckDBConnection,
 ): Promise<void> {
-  // D-11: legacy coverage-tracking table CREATE removed — grep-verified zero readers/writers today.
+  // Legacy coverage-tracking table CREATE removed — grep-verified zero readers/writers today.
   // Coverage is now derived from store.getCoverage() (Parquet: readdirSync; DuckDB: SELECT DISTINCT).
 
   // Sync state tracking for market data imports
@@ -72,26 +72,25 @@ export async function ensureMutableMarketTables(
  * (public repo, fresh clones without Parquet files).
  *
  * Must be called AFTER `ATTACH '...' AS market` in openReadWriteConnection.
- * Creates all columns upfront so later phases can write data without ALTER TABLE.
+ * Creates all columns upfront so writers do not need ALTER TABLE.
  *
- * Phase 6 Wave D retired the legacy fallback CREATE TABLE blocks for daily /
- * date_context / intraday / option_chain / option_quote_minutes; only the
- * three v3.0 canonical tables remain below.
+ * The legacy fallback CREATE TABLE blocks for daily / date_context / intraday /
+ * option_chain / option_quote_minutes have been retired; only the three
+ * canonical tables remain below.
  *
  * @param conn - Active DuckDB connection with market catalog attached
  */
 export async function ensureMarketDataTables(conn: DuckDBConnection): Promise<void> {
   // ============================================================================
-  // Phase 6 Wave D — one-time cleanup: drop legacy physical tables that
-  // persisted from pre-v3.0 runs. Idempotent (IF EXISTS). Mirrors Phase 2 D-12
-  // precheck pattern for option_quote_minutes.
+  // One-time cleanup: drop legacy physical tables that persist from pre-v3.0
+  // runs. Idempotent (IF EXISTS).
   //
-  // After the atomic hard-cut commit (Plan 06-04), the legacy CREATE TABLE
-  // blocks are gone — but existing market.duckdb files still contain these
-  // physical tables from earlier sessions. Drop them here so SELECTs against
-  // market.(daily|intraday|date_context) error cleanly per SQL-02 "no aliases".
-  // data_coverage is dropped as well per Phase 2 D-11 (coverage moved to
-  // store.getCoverage()).
+  // The legacy CREATE TABLE blocks have been removed, but existing
+  // market.duckdb files may still contain these physical tables from earlier
+  // sessions. Drop them here so SELECTs against
+  // market.(daily|intraday|date_context) error cleanly instead of returning
+  // stale data. data_coverage is dropped as well — coverage is now derived
+  // from store.getCoverage().
   // ============================================================================
   // NOTE: option_chain + option_quote_minutes are NOT in this list — those names
   // are still valid in v3.0 as Parquet-backed VIEWs (registered by
@@ -103,9 +102,9 @@ export async function ensureMarketDataTables(conn: DuckDBConnection): Promise<vo
   }
 
   // ============================================================================
-  // Market Data 3.0 — Phase 2 tables (D-24, D-25). Post Phase 6 Wave D, these
-  // are the ONLY physical fallback tables created for market data.
-  // Schemas match Parquet schemas exactly per spec §Schemas lines 338-427.
+  // Canonical physical fallback tables for market data — the only physical
+  // fallback tables created. Schemas match the corresponding Parquet schemas
+  // exactly.
   // ============================================================================
 
   // market.spot — raw minute bars, ticker-first.
@@ -125,7 +124,7 @@ export async function ensureMarketDataTables(conn: DuckDBConnection): Promise<vo
     )
   `);
 
-  // market.enriched — per-ticker computed fields, NO OHLCV (D-25).
+  // market.enriched — per-ticker computed fields, NO OHLCV.
   // PK: (ticker, date). OHLCV is joined at read time from market.spot.
   await conn.run(`
     CREATE TABLE IF NOT EXISTS market.enriched (
@@ -164,7 +163,6 @@ export async function ensureMarketDataTables(conn: DuckDBConnection): Promise<vo
   `);
 
   // market.enriched_context — cross-ticker derived context fields, one row per date.
-  // New canonical cross-ticker derived-context table (D-25).
   // PK: (date)
   await conn.run(`
     CREATE TABLE IF NOT EXISTS market.enriched_context (

--- a/packages/mcp-server/src/db/parquet-writer.ts
+++ b/packages/mcp-server/src/db/parquet-writer.ts
@@ -59,9 +59,9 @@ export interface WriteParquetAtomicOpts {
  * 4. COUNT(*) for rowCount
  * 5. DROP staging in finally block
  *
- * Threat mitigation (T-02-01): targetPath is always constructed by callers via
+ * Path-traversal mitigation: targetPath is always constructed by callers via
  * path.join(dataDir, 'market', ...) with no user-supplied path components.
- * Threat mitigation (T-02-02): Staging table names use Date.now() -- no user input.
+ * Identifier-injection mitigation: staging table names use Date.now() — no user input.
  *
  * @param conn - Active DuckDB connection
  * @param opts - Write options
@@ -139,7 +139,7 @@ export interface WriteParquetPartitionOpts {
 }
 
 /**
- * New generic multi-level Hive partition writer options (Market Data 3.0 Phase 1).
+ * Generic multi-level Hive partition writer options.
  *
  * Insertion order of `partitions` determines the Hive directory component order.
  * ES2015 guarantees string-keyed object insertion order is preserved by `Object.entries`.
@@ -164,10 +164,10 @@ export interface WriteParquetPartitionOptsV3 {
   filename?: string;
 }
 
-// Partition-value whitelist — defense-in-depth Layer 3 for T-1-01 (path traversal).
-// Allows uppercase/lowercase alnum, dot, underscore, hyphen. Rejects / \ .. null
-// whitespace and newlines. This is the deepest boundary (writer); Zod (Layer 1)
-// and the ticker registry (Layer 2) also validate upstream.
+// Partition-value whitelist — deepest defense-in-depth boundary against path
+// traversal. Allows uppercase/lowercase alnum, dot, underscore, hyphen.
+// Rejects / \ .. null whitespace and newlines. Zod schemas and the ticker
+// registry also validate upstream.
 const PARTITION_VALUE_RE = /^[A-Za-z0-9._-]+$/;
 // Partition-key whitelist — keys become `key=` prefix in directory names.
 // Must start with letter or underscore (no leading digit), then alnum/underscore.
@@ -177,28 +177,28 @@ const PARTITION_KEY_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
  * Write a single Hive partition to the correct directory layout.
  *
  * Two supported shapes (via TypeScript overloads):
- *   1. New generic (Market Data 3.0):
+ *   1. Generic multi-level:
  *        writeParquetPartition(conn, { baseDir, partitions: {ticker,date}, selectQuery })
  *        → baseDir/ticker=X/date=Y/data.parquet
- *   2. Legacy single-{date} shim (retained for 7 existing callers, deleted in Phase 4):
+ *   2. Legacy single-{date} shim (retained for existing callers):
  *        writeParquetPartition(conn, { baseDir, date, selectQuery })
- *        → baseDir/date=Y/data.parquet  (byte-identical to pre-3.0 behavior)
+ *        → baseDir/date=Y/data.parquet  (byte-identical to historical behavior)
  *
- * Overwrites existing partition file (idempotent per D-03).
+ * Overwrites existing partition file (idempotent — safe to re-run).
  *
- * Security (T-1-01): partition keys and values are validated against strict
- * whitelists BEFORE any filesystem operation. Unsafe input throws immediately.
+ * Security: partition keys and values are validated against strict whitelists
+ * BEFORE any filesystem operation. Unsafe input throws immediately.
  *
  * @param conn - Active DuckDB connection
  * @param opts - Partition write options (either shape)
  * @returns Object with rowCount of written rows
  */
-// Overload: new generic signature (Market Data 3.0)
+// Overload: generic multi-level signature
 export function writeParquetPartition(
   conn: DuckDBConnection,
   opts: WriteParquetPartitionOptsV3,
 ): Promise<{ rowCount: number }>;
-// Overload: legacy single-{date} signature (7 existing callers — Phase 3 deletes)
+// Overload: legacy single-{date} signature
 export function writeParquetPartition(
   conn: DuckDBConnection,
   opts: WriteParquetPartitionOpts,
@@ -208,8 +208,8 @@ export async function writeParquetPartition(
   conn: DuckDBConnection,
   opts: WriteParquetPartitionOpts | WriteParquetPartitionOptsV3,
 ): Promise<{ rowCount: number }> {
-  // Runtime dispatch — Pitfall 2: this boolean is load-bearing.
-  // The legacy shape has `date` but no `partitions`; the new shape has `partitions`.
+  // Runtime dispatch — this boolean is load-bearing.
+  // The legacy shape has `date` but no `partitions`; the generic shape has `partitions`.
   const isLegacy = "date" in opts && !("partitions" in opts);
   const partitions: Record<string, string> = isLegacy
     ? { date: (opts as WriteParquetPartitionOpts).date }
@@ -218,8 +218,8 @@ export async function writeParquetPartition(
     ? "data.parquet"
     : ((opts as WriteParquetPartitionOptsV3).filename ?? "data.parquet");
 
-  // T-1-01 mitigation: whitelist every partition key and value BEFORE composing
-  // any path. Reject unsafe input (path traversal, separators, whitespace, nulls).
+  // Path-traversal mitigation: whitelist every partition key and value BEFORE
+  // composing any path. Reject unsafe input (separators, whitespace, nulls).
   for (const [k, v] of Object.entries(partitions)) {
     if (!PARTITION_KEY_RE.test(k)) {
       throw new Error(

--- a/packages/mcp-server/src/db/schemas.ts
+++ b/packages/mcp-server/src/db/schemas.ts
@@ -118,18 +118,18 @@ export async function ensureTradeDataTable(conn: DuckDBConnection): Promise<void
   if (!(await hasColumn(conn, "trades", "trade_data", "ticker"))) {
     await conn.run(`ALTER TABLE trades.trade_data ADD COLUMN ticker VARCHAR`);
   }
-  // Migration: add source column for trade provenance tracking (Phase 76)
+  // Migration: add source column for trade provenance tracking.
   // 'csv' = imported from Option Omega CSV; other values may be populated by
   // optional private extensions when present.
   if (!(await hasColumn(conn, "trades", "trade_data", "source"))) {
     await conn.run(`ALTER TABLE trades.trade_data ADD COLUMN source VARCHAR DEFAULT 'csv'`);
     await conn.run(`UPDATE trades.trade_data SET source = 'csv' WHERE source IS NULL`);
   }
-  // Migration: add dte column for DTE-at-entry (Phase 80 gap closure)
+  // Migration: add dte column for DTE-at-entry.
   if (!(await hasColumn(conn, "trades", "trade_data", "dte"))) {
     await conn.run(`ALTER TABLE trades.trade_data ADD COLUMN dte INTEGER`);
   }
-  // Migration: add entry_greeks_json column for per-trade entry greeks (Phase 80 gap closure)
+  // Migration: add entry_greeks_json column for per-trade entry greeks.
   if (!(await hasColumn(conn, "trades", "trade_data", "entry_greeks_json"))) {
     await conn.run(`ALTER TABLE trades.trade_data ADD COLUMN entry_greeks_json JSON`);
   }


### PR DESCRIPTION
**Tier: 3**
**Worktree:** `tradeblocks-romeo-166-db-doc-scrub`
**Tracks:** tradeblocks-org/enterprise#166 (extends tradeblocks-org/enterprise#110)
**Precedent:** mirrors the doc-scrub shape from #306 / #307 / #311 / #312 / #313 / #314.

## Summary

26 comment-only edits across 6 `packages/mcp-server/src/db/` source files. The original #110 sweep inventory missed these files; this PR closes the gap. No identifier renames, no signature changes, no behavior delta.

| File | Edits | Highlights |
|---|---|---|
| `connection.ts` | 6 | Lifecycle-ordering comments + bottom tombstone comment cleaned of `Phase 4 D-10` / `PATTERNS.md` refs |
| `market-datasets.ts` | 3 | Registry banner reworded — dropped `Market Data 3.0 — Phase 1` / `CONTEXT.md D-15` / Phase 3/5 deletion roadmap |
| `market-schemas.ts` | 7 | Cleanup-banner rewrite (dropped `Phase 6 Wave D` / `SQL-02` / `Plan 06-04` / `Phase 2 D-11/D-12`) plus inline `D-NN` strips |
| `parquet-writer.ts` | 5 | T-NN-NN threat labels reworded to public-readable mitigation names; security rationale intact |
| `schemas.ts` | 3 | Three Migration: line `(Phase 76)` / `(Phase 80 ...)` parentheticals dropped |
| `json-migration.ts` | 2 | `(D-01, D-01a)` / `(D-01b)` / `(D-04)` parentheticals dropped from file JSDoc |

## What changed in wording

Threat-mitigation example from `parquet-writer.ts` (preserves the security explanation, replaces ticket IDs with named mitigations):

```diff
- * Threat mitigation (T-02-01): targetPath is always constructed by callers via
+ * Path-traversal mitigation: targetPath is always constructed by callers via
   path.join(dataDir, 'market', ...) with no user-supplied path components.
- * Threat mitigation (T-02-02): Staging table names use Date.now() -- no user input.
+ * Identifier-injection mitigation: staging table names use Date.now() — no user input.
```

Cleanup-banner example from `market-schemas.ts` (preserves the structural fact + idempotency note, drops the cross-plan refs):

```diff
- // Phase 6 Wave D — one-time cleanup: drop legacy physical tables that persisted
- // from pre-v3.0 runs. Idempotent (IF EXISTS). Mirrors Phase 2 D-12 precheck
- // pattern for option_quote_minutes.
+ // One-time cleanup: drop legacy physical tables that persist from pre-v3.0
+ // runs. Idempotent (IF EXISTS).
```

## Two leave-alone calls (considered and retained)

1. **`#14421` references in `connection.ts:10` and `:319`** — DuckDB upstream GitHub issue number. Legitimate public reference; navigating to the actual bug is useful for readers. Kept.
2. **"Option Omega" / "private extension" in `schemas.ts:122-123`** — both are canonical TradeBlocks vocabulary appearing across 14 sites on the public branch (e.g., `tools/guides.ts` has user-facing entries titled "Option Omega Backtest Overview"; "private extension" is the standard architectural concept used in `tickers/resolver.ts:8` and `utils/block-loader.ts:442`). Stripping here would create inconsistency. A broader "private vocab" sweep is a separate follow-up if desired.

## Verification

- Lint clean on all 6 files (`eslint`: 0 warnings, 0 errors)
- Typecheck on `packages/mcp-server` — delta 0 (3 pre-existing baseline errors at `utils/exit-triggers.ts:297/302/308` unchanged; those are fixed in companion PR tradeblocks#315)
- Full test suite: **120 suites / 1566 tests passing** (matches the floor cited in #314)
- Internal-vocab grep on the 6 touched files: zero matches
- Public-boundary grep (`backtester|holodeck|OO-replication|admiral`): zero matches

## CI heads-up

Repo CI is currently configured `pull_request: branches: [master]` only, so this PR (targeting `feat/tradeblocks-3.0`) shows no CI checks beyond the dependabot skip. tradeblocks#310 widens the trigger.

## What I'm asking

Skim 2-3 of the largest rewrites — `market-schemas.ts` cleanup banner, `parquet-writer.ts` threat-label section, `connection.ts` bottom tombstone — and tell me if any rewrite muddies the original technical meaning.

Closes tradeblocks-org/enterprise#166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)