### PR TITLE
ci: add Tier 3 PR-open protocol gate (enterprise#220)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 # TradeBlocks Pull Request
 
+Tier:
+
+<!-- Tier is required for human-authored PRs. Use Tier: 3 for public-surface, CI/workflow, package contract, or release-path changes. Dependabot PRs are exempt from the no-tier failure path. -->
+
 ## 🧱 What's Changed
 
 <!-- Describe your changes here -->

--- a/.github/scripts/tier3_protocol_gate.py
+++ b/.github/scripts/tier3_protocol_gate.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Mechanical Tier 3 PR-open protocol gate.
+
+The semantic Worf review still happens in Picard's session. This script only
+checks the two machine-visible signals that make the Tier 3 protocol auditable:
+the `worf-cleared` label and the non-author Admiral review request.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+import re
+import sys
+from typing import Iterable
+
+
+LANE_TO_LOGIN = {
+    "romeo": "davidromeo",
+    "smith": "longpshorn",
+}
+LOGIN_TO_LANE = {login: lane for lane, login in LANE_TO_LOGIN.items()}
+WORF_CLEARED_LABEL = "worf-cleared"
+
+
+@dataclass(frozen=True)
+class GateResult:
+    ok: bool
+    message: str
+
+
+def _names(values: Iterable[object], key: str) -> list[str]:
+    names: list[str] = []
+    for value in values:
+        if isinstance(value, str):
+            names.append(value)
+        elif isinstance(value, dict) and isinstance(value.get(key), str):
+            names.append(value[key])
+    return names
+
+
+def _loads_json_list(raw: str | None) -> list[object]:
+    if not raw:
+        return []
+    parsed = json.loads(raw)
+    if not isinstance(parsed, list):
+        raise ValueError("expected a JSON list")
+    return parsed
+
+
+def author_lane(head_ref: str, author_login: str) -> str | None:
+    match = re.match(r"^(romeo|smith)/", head_ref)
+    if match:
+        return match.group(1)
+    return LOGIN_TO_LANE.get(author_login)
+
+
+def required_reviewer_for_lane(lane: str) -> str:
+    for candidate_lane, login in LANE_TO_LOGIN.items():
+        if candidate_lane != lane:
+            return login
+    raise ValueError(f"unknown lane: {lane}")
+
+
+def evaluate(
+    *,
+    tier: str,
+    head_ref: str,
+    author_login: str,
+    labels: Iterable[str],
+    requested_reviewers: Iterable[str],
+    pr_number: str = "<PR>",
+    required_label: str = WORF_CLEARED_LABEL,
+) -> GateResult:
+    tier = tier.strip()
+    if tier != "3":
+        return GateResult(True, f"PR is not Tier 3 (Tier: {tier or 'missing'}); tier3-protocol gate skipped.")
+
+    lane = author_lane(head_ref, author_login)
+    if lane is None:
+        return GateResult(
+            False,
+            "Unable to determine author lane from branch prefix or PR author. "
+            "Use a romeo/ or smith/ branch, or update the gate's login mapping.",
+        )
+
+    label_set = set(labels)
+    reviewer_set = set(requested_reviewers)
+    required_reviewer = required_reviewer_for_lane(lane)
+    errors: list[str] = []
+
+    if required_label not in label_set:
+        errors.append(
+            f"Missing `{required_label}` label. Dispatch Worf, address any HOLD findings, "
+            f"then apply the label with: gh pr edit {pr_number} --add-label {required_label}"
+        )
+
+    if required_reviewer not in reviewer_set:
+        errors.append(
+            f"Missing cross-Admiral review request for `{required_reviewer}`. "
+            f"PR body prose is not notification; request review with: "
+            f"gh pr edit {pr_number} --add-reviewer {required_reviewer}"
+        )
+
+    if errors:
+        return GateResult(False, "\n".join(errors))
+
+    return GateResult(
+        True,
+        f"Tier 3 protocol signals present: `{required_label}` label and `{required_reviewer}` review request.",
+    )
+
+
+def evaluate_from_env() -> GateResult:
+    labels = _names(_loads_json_list(os.environ.get("PR_LABELS_JSON")), "name")
+    reviewers = _names(_loads_json_list(os.environ.get("PR_REVIEWERS_JSON")), "login")
+    return evaluate(
+        tier=os.environ.get("PR_TIER", ""),
+        head_ref=os.environ.get("PR_HEAD_REF", ""),
+        author_login=os.environ.get("PR_AUTHOR_LOGIN", ""),
+        labels=labels,
+        requested_reviewers=reviewers,
+        pr_number=os.environ.get("PR_NUMBER", "<PR>"),
+        required_label=os.environ.get("WORF_CLEARED_LABEL", WORF_CLEARED_LABEL),
+    )
+
+
+def main() -> int:
+    try:
+        result = evaluate_from_env()
+    except Exception as exc:
+        print(f"::error::tier3-protocol gate crashed: {exc}", file=sys.stderr)
+        return 1
+
+    if result.ok:
+        print(result.message)
+        return 0
+
+    for line in result.message.splitlines():
+        print(f"::error::{line}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/worf-tier3-protocol.yml
+++ b/.github/workflows/worf-tier3-protocol.yml
@@ -1,0 +1,53 @@
+name: Worf Tier 3 protocol gate
+
+# Mechanical audit signal for public-repo Tier 3 PRs. This does not replace
+# subagent-Worf's semantic review; it checks that Picard recorded Worf clearance
+# and actually requested the non-author Admiral as reviewer.
+
+on:
+  pull_request:
+    types: [opened, synchronize, edited, reopened, labeled, unlabeled, review_requested, review_request_removed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  tier3-protocol:
+    name: Tier 3 PR-open protocol signals
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect declared tier
+        id: detect-tier
+        env:
+          PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -e
+          pr_body=$(printf '%s' "$PR_BODY" | tr -d '\r')
+          tier_line=$(printf '%s\n' "$pr_body" | grep -m 1 -E '^\*{0,2}Tier:[[:space:]]+[0-3]([[:space:]]|$|—|\*)' || true)
+          if [ -z "$tier_line" ]; then
+            if [ "$PR_AUTHOR_LOGIN" = "dependabot[bot]" ] || [ "$PR_AUTHOR_LOGIN" = "app/dependabot" ]; then
+              echo "No Tier line found on Dependabot PR; public-repo Tier 3 protocol gate skipped."
+              echo "tier=" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "::error::Public-repo PRs must declare a tier with a line starting 'Tier: N'. Dependabot PRs are the only no-tier short-circuit."
+            echo "tier=" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+          tier=$(printf '%s\n' "$tier_line" | sed -E 's/^\*{0,2}Tier:[[:space:]]+([0-3]).*/\1/')
+          echo "tier=$tier" >> "$GITHUB_OUTPUT"
+          echo "Tier detected: $tier"
+
+      - name: Check Worf clear label and cross-Admiral reviewer
+        env:
+          PR_TIER: ${{ steps.detect-tier.outputs.tier }}
+          PR_HEAD_REF: ${{ github.head_ref }}
+          PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+          PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels) }}
+          PR_REVIEWERS_JSON: ${{ toJson(github.event.pull_request.requested_reviewers) }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: python3 .github/scripts/tier3_protocol_gate.py

--- a/.github/workflows/worf-tier3-protocol.yml
+++ b/.github/workflows/worf-tier3-protocol.yml
@@ -10,9 +10,26 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 jobs:
+  worf-clear-staleness:
+    # On `synchronize` (new commits pushed), strip the `worf-cleared` label so
+    # Tier 3 PRs must re-Worf after a push. Mirrors `dismiss-stale-reviews` on
+    # the cross-Admiral side: pushed code invalidates the prior approval.
+    # No-op when the label isn't present.
+    name: Strip worf-cleared on push
+    if: ${{ github.event.action == 'synchronize' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove stale worf-cleared label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --remove-label worf-cleared 2>/dev/null || true
+
   tier3-protocol:
     name: Tier 3 PR-open protocol signals
     runs-on: ubuntu-latest


### PR DESCRIPTION
Tier: 3

Refs tradeblocks-org/enterprise#220.

## Summary

Adds the public-repo half of the Tier 3 PR-open protocol gate:

- New `.github/workflows/worf-tier3-protocol.yml` audit workflow.
- New `.github/scripts/tier3_protocol_gate.py`, matching the enterprise checker.
- Tier 3 PRs require the `worf-cleared` label and a requested review from the non-author Admiral.
- Non-Tier-3 PRs short-circuit.
- Dependabot PRs with no Tier line short-circuit; human-authored public PRs without a Tier line fail with remediation.
- `.github/pull_request_template.md` now includes a Tier placeholder so human-authored PRs have the expected field.

## Worf

Worf verdict: Tier 3 via public-repo cross-Admiral protocol. Worf confirmed the core checker enforces non-Tier-3 short-circuit, Worf label, cross-Admiral reviewer, and branch-prefix/author fallback mapping.

Worf notes addressed before PR open:

- Public-template rollout hazard addressed by adding a Tier placeholder.
- Untracked `__pycache__` artifacts removed before staging.
- Gate posture: audit/status signal, not a new branch-protection hard block in this PR.

## Verification

- Workflow YAML parse for `.github/workflows/worf-tier3-protocol.yml`.
- CLI smoke: Tier 3 with `worf-cleared` + `longpshorn` passes.
- Tier detection shell checks: `Tier: 3`, `**Tier: 3**`, Dependabot no-tier skip, human no-tier fail.
- `git diff --check`.
- Script parity check against the enterprise copy.

## Cross-repo pair

Sibling enterprise PR: enterprise PR opened from `romeo/220-tier3-protocol-gate`.

## Process

Tier 3 path: own-Admiral walkthrough first, then request Smith as cross-Admiral reviewer. This PR intentionally uses `Refs` rather than auto-closing enterprise#220; the issue closes only after both repo halves land.
