### PR TITLE
feat(mcp-server): 6 market-ingestor + thetadata hardening fixes

### DIFF
--- a/packages/mcp-server/src/market/ingestor/market-ingestor.ts
+++ b/packages/mcp-server/src/market/ingestor/market-ingestor.ts
@@ -1103,13 +1103,18 @@ export class MarketIngestor {
     const errors: string[] = [];
 
     // Step 1 — spot ingest per ticker (asOf = from = to).
+    // Always request minute-resolution bars: downstream option-quote enrichment
+    // needs the per-minute underlying price to compute greeks and to align
+    // quote rows. A daily bar (single row at implicit 09:30) leaves every
+    // minute after 09:30 without an underlying-price lookup and trips the
+    // coverage_gap guard for the whole partition.
     const spotResults: IngestResult[] = [];
     for (const ticker of opts.spotTickers) {
       const rawResult = await this.ingestBars({
         tickers: [ticker],
         from: opts.asOf,
         to: opts.asOf,
-        timespan: "1d",
+        timespan: "1m",
         provider: opts.provider,
       });
       const result = await this.applyCoverageFallback("spot", ticker, opts.asOf, rawResult);

--- a/packages/mcp-server/src/market/ingestor/market-ingestor.ts
+++ b/packages/mcp-server/src/market/ingestor/market-ingestor.ts
@@ -51,6 +51,25 @@ export interface MarketIngestorDeps {
 // spot outage (which sends the ratio to ~1.0) is caught immediately.
 const COVERAGE_GAP_THRESHOLD = 0.5;
 
+// Sibling of COVERAGE_GAP_THRESHOLD, distinct failure mode. Fires when
+// underlying-price lookup SUCCEEDED but `computeQuoteGreeks` returned null for
+// the majority of the rows that actually attempted the math (zero/negative
+// option price, corrupt expiration → negative DTE, malformed strike grid).
+// Without this guard those rows would mis-attribute as `coverage_gap` because
+// they all flowed into `unresolvedRows`; coverage_gap's denominator
+// (`missingUnderlyingRows + computedRows`) excludes math failures, so a
+// math-only failure mode never tripped coverage_gap by itself, but a single
+// missing-underlying row in the same partition would — labeling the trip
+// "coverage gap" even though the bulk of the leak was BS-math corruption.
+// Both guards can fire on the same partition when both subsets exceed their
+// thresholds independently; see types.ts on the no-dedupe convention.
+//
+// Set to 0.5 for symmetry with COVERAGE_GAP_THRESHOLD. Tunable from telemetry
+// independently — the two failure modes have different operational meanings
+// (spot/chain coverage vs. quote/chain corruption) and may want different
+// trip points later.
+const COMPUTE_FAILURE_THRESHOLD = 0.5;
+
 function coverageGapEntry(
   stats: QuoteGreeksStats,
   batch: { underlying: string; date: string; ticker?: string; rows: number },
@@ -68,6 +87,29 @@ function coverageGapEntry(
     ...(batch.ticker ? { ticker: batch.ticker } : {}),
     rows: batch.rows,
     reason: "coverage_gap",
+    error: message,
+    resolveRatio: ratio,
+  };
+}
+
+function computeFailureEntry(
+  stats: QuoteGreeksStats,
+  batch: { underlying: string; date: string; ticker?: string; rows: number },
+): IngestSkippedBatch | null {
+  const attemptedRows = stats.mathFailedRows + stats.computedRows;
+  if (attemptedRows <= 0) return null;
+  const ratio = stats.mathFailedRows / attemptedRows;
+  if (ratio <= COMPUTE_FAILURE_THRESHOLD) return null;
+  const message =
+    `compute failure: ${stats.mathFailedRows}/${attemptedRows} rows failed ` +
+    `black-scholes math after underlying-price lookup succeeded ` +
+    `(ratio=${ratio.toFixed(2)}, threshold=${COMPUTE_FAILURE_THRESHOLD.toFixed(2)})`;
+  return {
+    underlying: batch.underlying,
+    date: batch.date,
+    ...(batch.ticker ? { ticker: batch.ticker } : {}),
+    rows: batch.rows,
+    reason: "compute_failure",
     error: message,
     resolveRatio: ratio,
   };
@@ -372,6 +414,7 @@ export class MarketIngestor {
           computedRows: 0,
           missingContractRows: 0,
           missingUnderlyingRows: 0,
+          mathFailedRows: 0,
           unresolvedRows: 0,
         },
       };
@@ -704,7 +747,7 @@ export class MarketIngestor {
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         // Warn is still emitted for live tail-following — the load-bearing
-        // signal is `result.skipped[]` / `status: "partial"` (issue #121).
+        // signal is `result.skipped[]` / `status: "partial"`.
         console.warn(
           "[drainBulkQuotes] enrichQuoteRows failed; skipping batch",
           {
@@ -728,6 +771,11 @@ export class MarketIngestor {
         date,
         rows: rows.length,
       });
+      const computeFailure = computeFailureEntry(enriched.stats, {
+        underlying: resolvedUnderlying,
+        date,
+        rows: rows.length,
+      });
       if (gap) {
         console.warn("[drainBulkQuotes] coverage gap; skipping batch", {
           underlying: resolvedUnderlying,
@@ -736,8 +784,17 @@ export class MarketIngestor {
           resolveRatio: gap.resolveRatio,
         });
         skipped.push(gap);
-        continue;
       }
+      if (computeFailure) {
+        console.warn("[drainBulkQuotes] compute failure; skipping batch", {
+          underlying: resolvedUnderlying,
+          date,
+          rows: rows.length,
+          resolveRatio: computeFailure.resolveRatio,
+        });
+        skipped.push(computeFailure);
+      }
+      if (gap || computeFailure) continue;
       await this.deps.stores.quote.writeQuotes(resolvedUnderlying, date, enriched.rows);
       totalRows += rows.length;
     }
@@ -794,7 +851,7 @@ export class MarketIngestor {
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         // Warn is still emitted for live tail-following — the load-bearing
-        // signal is `result.skipped[]` / `status: "partial"` (issue #121).
+        // signal is `result.skipped[]` / `status: "partial"`.
         console.warn(
           "[writeQuotesForTicker] enrichQuoteRows failed; skipping batch",
           {
@@ -821,6 +878,12 @@ export class MarketIngestor {
         ticker,
         rows: rows.length,
       });
+      const computeFailure = computeFailureEntry(enriched.stats, {
+        underlying,
+        date,
+        ticker,
+        rows: rows.length,
+      });
       if (gap) {
         console.warn("[writeQuotesForTicker] coverage gap; skipping batch", {
           underlying,
@@ -830,8 +893,18 @@ export class MarketIngestor {
           resolveRatio: gap.resolveRatio,
         });
         skipped.push(gap);
-        continue;
       }
+      if (computeFailure) {
+        console.warn("[writeQuotesForTicker] compute failure; skipping batch", {
+          underlying,
+          date,
+          ticker,
+          rows: rows.length,
+          resolveRatio: computeFailure.resolveRatio,
+        });
+        skipped.push(computeFailure);
+      }
+      if (gap || computeFailure) continue;
       await this.deps.stores.quote.writeQuotes(underlying, date, enriched.rows);
       rowsWritten += rows.length;
       if (!minDate || date < minDate) minDate = date;

--- a/packages/mcp-server/src/market/ingestor/market-ingestor.ts
+++ b/packages/mcp-server/src/market/ingestor/market-ingestor.ts
@@ -13,6 +13,8 @@ import type {
   ComputeVixContextOptions,
   RefreshOptions,
   IngestResult,
+  IngestSkippedBatch,
+  IngestStatus,
   RefreshResult,
   BulkProgressReporter,
 } from "./types.js";
@@ -318,8 +320,8 @@ export class MarketIngestor {
     if (rows.length === 0) return rows;
 
     const [contracts, underlyingBars] = await Promise.all([
-      this.deps.stores.chain.readChain(underlying, date).catch(() => []),
-      this.deps.stores.spot.readBars(underlying, date, date).catch(() => []),
+      this.deps.stores.chain.readChain(underlying, date),
+      this.deps.stores.spot.readBars(underlying, date, date),
     ]);
 
     const contractByTicker = new Map(
@@ -396,7 +398,7 @@ export class MarketIngestor {
   /**
    * Per-ticker path: one provider call per OCC ticker over the full [from, to]
    * range. Works on any provider that implements `fetchQuotes`. Used by
-   * backtesters that already know the exact contracts they care about.
+   * callers that already know the exact contracts they care about.
    */
   private async ingestQuotesByTicker(
     provider: MarketDataProvider,
@@ -415,6 +417,7 @@ export class MarketIngestor {
     let totalRows = 0;
     let minDate: string | undefined;
     let maxDate: string | undefined;
+    const skipped: IngestSkippedBatch[] = [];
 
     for (const ticker of tickers) {
       let quotes: Awaited<ReturnType<NonNullable<MarketDataProvider["fetchQuotes"]>>>;
@@ -433,12 +436,14 @@ export class MarketIngestor {
       totalRows += written.rowsWritten;
       if (written.minDate && (!minDate || written.minDate < minDate)) minDate = written.minDate;
       if (written.maxDate && (!maxDate || written.maxDate > maxDate)) maxDate = written.maxDate;
+      if (written.skipped.length > 0) skipped.push(...written.skipped);
     }
 
     return {
-      status: "ok",
+      status: skipped.length > 0 ? "partial" : "ok",
       rowsWritten: totalRows,
       dateRange: minDate ? { from: minDate, to: maxDate! } : undefined,
+      ...(skipped.length > 0 ? { skipped } : {}),
     };
   }
 
@@ -468,36 +473,39 @@ export class MarketIngestor {
     let totalRows = 0;
     let minDate: string | undefined;
     let maxDate: string | undefined;
+    const skipped: IngestSkippedBatch[] = [];
 
     for (const underlying of underlyings) {
       const upperUnderlying = underlying.toUpperCase();
       for (const date of dates) {
-        const written = await this.drainBulkQuotes(
+        const drain = await this.drainBulkQuotes(
           provider,
           upperUnderlying,
           date,
           onProgress,
         );
-        if (written > 0) {
-          totalRows += written;
+        if (drain.rowsWritten > 0) {
+          totalRows += drain.rowsWritten;
           if (!minDate || date < minDate) minDate = date;
           if (!maxDate || date > maxDate) maxDate = date;
         }
+        if (drain.skipped.length > 0) skipped.push(...drain.skipped);
         // Always emit a date-flushed event — even on 0 rows — so callers see
         // predictable progress even for empty dates (holidays, missing data).
         await this.safeEmit(onProgress, {
           kind: "date-flushed",
           underlying: upperUnderlying,
           date,
-          rowsWritten: written,
+          rowsWritten: drain.rowsWritten,
         });
       }
     }
 
     return {
-      status: "ok",
+      status: skipped.length > 0 ? "partial" : "ok",
       rowsWritten: totalRows,
       dateRange: minDate ? { from: minDate, to: maxDate! } : undefined,
+      ...(skipped.length > 0 ? { skipped } : {}),
     };
   }
 
@@ -531,7 +539,7 @@ export class MarketIngestor {
     upperUnderlying: string,
     date: string,
     onProgress?: BulkProgressReporter,
-  ): Promise<number> {
+  ): Promise<{ rowsWritten: number; skipped: IngestSkippedBatch[] }> {
     // Tickers → resolved underlying mapping is cached per call; the typical
     // case is all contracts mapping to the same underlying (e.g. SPX + SPXW
     // → "SPX"), so the per-underlying bucket is almost always a single key.
@@ -624,25 +632,49 @@ export class MarketIngestor {
     }
 
     let totalRows = 0;
+    const skipped: IngestSkippedBatch[] = [];
     for (const [resolvedUnderlying, rows] of bucket) {
       if (rows.length === 0) continue;
-      const enriched = await this.enrichQuoteRows(
-        resolvedUnderlying,
-        date,
-        rows,
-        this.quoteGreeksSourceForProvider(provider),
-      );
+      let enriched: QuoteRow[];
+      try {
+        enriched = await this.enrichQuoteRows(
+          resolvedUnderlying,
+          date,
+          rows,
+          this.quoteGreeksSourceForProvider(provider),
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        // Warn is still emitted for live tail-following — the load-bearing
+        // signal is `result.skipped[]` / `status: "partial"` (issue #121).
+        console.warn(
+          "[drainBulkQuotes] enrichQuoteRows failed; skipping batch",
+          {
+            underlying: resolvedUnderlying,
+            date,
+            rows: rows.length,
+            error: message,
+          },
+        );
+        skipped.push({
+          underlying: resolvedUnderlying,
+          date,
+          rows: rows.length,
+          error: message,
+        });
+        continue;
+      }
       await this.deps.stores.quote.writeQuotes(resolvedUnderlying, date, enriched);
       totalRows += rows.length;
     }
-    return totalRows;
+    return { rowsWritten: totalRows, skipped };
   }
 
   private async writeQuotesForTicker(
     provider: MarketDataProvider,
     ticker: string,
     quotes: Map<string, MinuteQuote>,
-  ): Promise<{ rowsWritten: number; minDate?: string; maxDate?: string }> {
+  ): Promise<{ rowsWritten: number; minDate?: string; maxDate?: string; skipped: IngestSkippedBatch[] }> {
     const root = extractRoot(ticker);
     const underlying = this.deps.stores.quote.tickers.resolve(root);
 
@@ -675,19 +707,45 @@ export class MarketIngestor {
     let rowsWritten = 0;
     let minDate: string | undefined;
     let maxDate: string | undefined;
+    const skipped: IngestSkippedBatch[] = [];
     for (const [date, rows] of byDate) {
-      const enriched = await this.enrichQuoteRows(
-        underlying,
-        date,
-        rows,
-        this.quoteGreeksSourceForProvider(provider),
-      );
+      let enriched: QuoteRow[];
+      try {
+        enriched = await this.enrichQuoteRows(
+          underlying,
+          date,
+          rows,
+          this.quoteGreeksSourceForProvider(provider),
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        // Warn is still emitted for live tail-following — the load-bearing
+        // signal is `result.skipped[]` / `status: "partial"` (issue #121).
+        console.warn(
+          "[writeQuotesForTicker] enrichQuoteRows failed; skipping batch",
+          {
+            underlying,
+            date,
+            ticker,
+            rows: rows.length,
+            error: message,
+          },
+        );
+        skipped.push({
+          underlying,
+          date,
+          ticker,
+          rows: rows.length,
+          error: message,
+        });
+        continue;
+      }
       await this.deps.stores.quote.writeQuotes(underlying, date, enriched);
       rowsWritten += rows.length;
       if (!minDate || date < minDate) minDate = date;
       if (!maxDate || date > maxDate) maxDate = date;
     }
-    return { rowsWritten, minDate, maxDate };
+    return { rowsWritten, minDate, maxDate, skipped };
   }
 
   async ingestChain(opts: IngestChainOptions): Promise<IngestResult> {
@@ -954,11 +1012,29 @@ export class MarketIngestor {
       }
     }
 
+    // Aggregate per-operation `skipped` entries so callers don't have to
+    // traverse perOperation themselves. A "partial" status is contagious:
+    // any operation returning partial flips refresh to partial too.
+    const aggregateSkipped: IngestSkippedBatch[] = [];
+    const collect = (r: IngestResult | null): void => {
+      if (r?.skipped && r.skipped.length > 0) aggregateSkipped.push(...r.skipped);
+    };
+    for (const r of spotResults) collect(r);
+    for (const r of chainResults) collect(r);
+    for (const r of quoteResults) collect(r);
+    collect(vixContext);
+
+    let status: IngestStatus;
+    if (errors.length > 0) status = "error";
+    else if (aggregateSkipped.length > 0) status = "partial";
+    else status = "ok";
+
     return {
-      status: errors.length > 0 ? "error" : "ok",
+      status,
       perOperation: { spot: spotResults, chain: chainResults, quotes: quoteResults, vixContext },
       coverage,
       errors,
+      ...(aggregateSkipped.length > 0 ? { skipped: aggregateSkipped } : {}),
     };
   }
 }

--- a/packages/mcp-server/src/market/ingestor/market-ingestor.ts
+++ b/packages/mcp-server/src/market/ingestor/market-ingestor.ts
@@ -28,27 +28,39 @@ export interface MarketIngestorDeps {
 }
 
 // When `applyQuoteGreeks` fails to resolve the underlying price for more than
-// this fraction of rows visited, the batch is suspected of a coverage gap
-// (partial-day spot bars, missing chain partition, schema-filter mismatch).
-// Such batches are dropped — they'd otherwise persist with intact bid/ask but
-// null greeks, which silently corrupts the option_quotes store.
+// this fraction of the rows that actually attempted underlying-price lookup,
+// the batch is suspected of a coverage gap (partial-day spot bars, missing
+// chain partition, schema-filter mismatch). Such batches are dropped — they'd
+// otherwise persist with intact bid/ask but null greeks, which silently
+// corrupts the option_quotes store.
+//
+// Denominator is `missingUnderlyingRows + computedRows` — i.e. only rows that
+// reached the underlying-lookup branch in compute mode. Rows skipped earlier
+// (provider greeks already present, missing contract meta, provider-only mode)
+// don't dilute the signal. This catches a real production leak: a mixed-source
+// partition where one provider supplies inline greeks for 60% of rows and the
+// remaining 40% all fail underlying lookup on a partial-day spot outage — a
+// `missing/visited` ratio of 0.4 wouldn't trip the 0.5 threshold, but
+// `missing/attempted` is 1.0 and does.
+//
 // Tunable from telemetry: lower → more conservative (false-positives on
 // genuinely-sparse chain reads); higher → more leakage of null-greeks rows.
-// 0.5 is the initial pick: aggressive enough to catch a partial-day spot
-// outage that leaves the underlying-price map nearly empty (the canonical
-// failure mode this guard targets), conservative enough that a single
-// sparsely-quoted expiration with a few unresolved rows doesn't trip it.
+// 0.5 means "half of the rows that needed compute failed to resolve the
+// underlying price" — conservative enough that a few unresolved rows in a
+// large compute batch don't trip it, aggressive enough that a partial-day
+// spot outage (which sends the ratio to ~1.0) is caught immediately.
 const COVERAGE_GAP_THRESHOLD = 0.5;
 
 function coverageGapEntry(
   stats: QuoteGreeksStats,
   batch: { underlying: string; date: string; ticker?: string; rows: number },
 ): IngestSkippedBatch | null {
-  if (stats.rowsVisited <= 0) return null;
-  const ratio = stats.missingUnderlyingRows / stats.rowsVisited;
+  const attemptedRows = stats.missingUnderlyingRows + stats.computedRows;
+  if (attemptedRows <= 0) return null;
+  const ratio = stats.missingUnderlyingRows / attemptedRows;
   if (ratio <= COVERAGE_GAP_THRESHOLD) return null;
   const message =
-    `underlying-price coverage gap: ${stats.missingUnderlyingRows}/${stats.rowsVisited} rows ` +
+    `underlying-price coverage gap: ${stats.missingUnderlyingRows}/${attemptedRows} rows ` +
     `missing underlying price (ratio=${ratio.toFixed(2)}, threshold=${COVERAGE_GAP_THRESHOLD.toFixed(2)})`;
   return {
     underlying: batch.underlying,

--- a/packages/mcp-server/src/market/ingestor/market-ingestor.ts
+++ b/packages/mcp-server/src/market/ingestor/market-ingestor.ts
@@ -19,12 +19,46 @@ import type {
   BulkProgressReporter,
 } from "./types.js";
 import type { QuoteRow } from "../stores/types.js";
-import { applyQuoteGreeks } from "../../utils/option-quote-greeks.js";
+import { applyQuoteGreeks, type QuoteGreeksStats } from "../../utils/option-quote-greeks.js";
 
 export interface MarketIngestorDeps {
   stores: MarketStores;
   dataRoot: string;
   providerFactory?: () => MarketDataProvider;
+}
+
+// When `applyQuoteGreeks` fails to resolve the underlying price for more than
+// this fraction of rows visited, the batch is suspected of a coverage gap
+// (partial-day spot bars, missing chain partition, schema-filter mismatch).
+// Such batches are dropped — they'd otherwise persist with intact bid/ask but
+// null greeks, which silently corrupts the option_quotes store.
+// Tunable from telemetry: lower → more conservative (false-positives on
+// genuinely-sparse chain reads); higher → more leakage of null-greeks rows.
+// 0.5 is the initial pick: aggressive enough to catch a partial-day spot
+// outage that leaves the underlying-price map nearly empty (the canonical
+// failure mode this guard targets), conservative enough that a single
+// sparsely-quoted expiration with a few unresolved rows doesn't trip it.
+const COVERAGE_GAP_THRESHOLD = 0.5;
+
+function coverageGapEntry(
+  stats: QuoteGreeksStats,
+  batch: { underlying: string; date: string; ticker?: string; rows: number },
+): IngestSkippedBatch | null {
+  if (stats.rowsVisited <= 0) return null;
+  const ratio = stats.missingUnderlyingRows / stats.rowsVisited;
+  if (ratio <= COVERAGE_GAP_THRESHOLD) return null;
+  const message =
+    `underlying-price coverage gap: ${stats.missingUnderlyingRows}/${stats.rowsVisited} rows ` +
+    `missing underlying price (ratio=${ratio.toFixed(2)}, threshold=${COVERAGE_GAP_THRESHOLD.toFixed(2)})`;
+  return {
+    underlying: batch.underlying,
+    date: batch.date,
+    ...(batch.ticker ? { ticker: batch.ticker } : {}),
+    rows: batch.rows,
+    reason: "coverage_gap",
+    error: message,
+    resolveRatio: ratio,
+  };
 }
 
 function providerErrorMessage(error: unknown): string {
@@ -316,8 +350,20 @@ export class MarketIngestor {
     date: string,
     rows: QuoteRow[],
     defaultProviderSource?: "massive" | "thetadata",
-  ): Promise<QuoteRow[]> {
-    if (rows.length === 0) return rows;
+  ): Promise<{ rows: QuoteRow[]; stats: QuoteGreeksStats }> {
+    if (rows.length === 0) {
+      return {
+        rows,
+        stats: {
+          rowsVisited: 0,
+          existingGreeksRows: 0,
+          computedRows: 0,
+          missingContractRows: 0,
+          missingUnderlyingRows: 0,
+          unresolvedRows: 0,
+        },
+      };
+    }
 
     const [contracts, underlyingBars] = await Promise.all([
       this.deps.stores.chain.readChain(underlying, date),
@@ -336,7 +382,7 @@ export class MarketIngestor {
       }
     }
 
-    applyQuoteGreeks({
+    const stats = applyQuoteGreeks({
       rows,
       getDate: (row) => row.timestamp.slice(0, 10),
       getTime: (row) => row.timestamp.slice(11, 16),
@@ -355,7 +401,7 @@ export class MarketIngestor {
       defaultProviderSource,
     });
 
-    return rows;
+    return { rows, stats };
   }
 
   async ingestQuotes(opts: IngestQuotesOptions): Promise<IngestResult> {
@@ -635,7 +681,7 @@ export class MarketIngestor {
     const skipped: IngestSkippedBatch[] = [];
     for (const [resolvedUnderlying, rows] of bucket) {
       if (rows.length === 0) continue;
-      let enriched: QuoteRow[];
+      let enriched: { rows: QuoteRow[]; stats: QuoteGreeksStats };
       try {
         enriched = await this.enrichQuoteRows(
           resolvedUnderlying,
@@ -660,11 +706,27 @@ export class MarketIngestor {
           underlying: resolvedUnderlying,
           date,
           rows: rows.length,
+          reason: "read_failed",
           error: message,
         });
         continue;
       }
-      await this.deps.stores.quote.writeQuotes(resolvedUnderlying, date, enriched);
+      const gap = coverageGapEntry(enriched.stats, {
+        underlying: resolvedUnderlying,
+        date,
+        rows: rows.length,
+      });
+      if (gap) {
+        console.warn("[drainBulkQuotes] coverage gap; skipping batch", {
+          underlying: resolvedUnderlying,
+          date,
+          rows: rows.length,
+          resolveRatio: gap.resolveRatio,
+        });
+        skipped.push(gap);
+        continue;
+      }
+      await this.deps.stores.quote.writeQuotes(resolvedUnderlying, date, enriched.rows);
       totalRows += rows.length;
     }
     return { rowsWritten: totalRows, skipped };
@@ -709,7 +771,7 @@ export class MarketIngestor {
     let maxDate: string | undefined;
     const skipped: IngestSkippedBatch[] = [];
     for (const [date, rows] of byDate) {
-      let enriched: QuoteRow[];
+      let enriched: { rows: QuoteRow[]; stats: QuoteGreeksStats };
       try {
         enriched = await this.enrichQuoteRows(
           underlying,
@@ -736,11 +798,29 @@ export class MarketIngestor {
           date,
           ticker,
           rows: rows.length,
+          reason: "read_failed",
           error: message,
         });
         continue;
       }
-      await this.deps.stores.quote.writeQuotes(underlying, date, enriched);
+      const gap = coverageGapEntry(enriched.stats, {
+        underlying,
+        date,
+        ticker,
+        rows: rows.length,
+      });
+      if (gap) {
+        console.warn("[writeQuotesForTicker] coverage gap; skipping batch", {
+          underlying,
+          date,
+          ticker,
+          rows: rows.length,
+          resolveRatio: gap.resolveRatio,
+        });
+        skipped.push(gap);
+        continue;
+      }
+      await this.deps.stores.quote.writeQuotes(underlying, date, enriched.rows);
       rowsWritten += rows.length;
       if (!minDate || date < minDate) minDate = date;
       if (!maxDate || date > maxDate) maxDate = date;

--- a/packages/mcp-server/src/market/ingestor/types.ts
+++ b/packages/mcp-server/src/market/ingestor/types.ts
@@ -1,4 +1,26 @@
-export type IngestStatus = "ok" | "skipped" | "unsupported" | "error";
+export type IngestStatus = "ok" | "partial" | "skipped" | "unsupported" | "error";
+
+/**
+ * Per-batch failure entry attached to a result when the ingest completed some
+ * batches but logged-and-skipped others. The current producer is
+ * `MarketIngestor.enrichQuoteRows` failures inside the quote-ingest paths:
+ * a transient DuckDB flake or schema mismatch on the enrichment read causes
+ * the affected (underlying, date[, ticker]) batch to be skipped instead of
+ * abandoning the whole ingest (so a long bulk refresh isn't killed by one
+ * bad partition), and the entry surfaces in the result so orchestrators can
+ * distinguish "complete" from "complete with N batches dropped".
+ *
+ * Orchestrated callers MUST treat `status: "partial"` as a non-success
+ * signal — `rowsWritten` undercounts when batches are skipped.
+ */
+export interface IngestSkippedBatch {
+  underlying: string;
+  date: string;
+  /** Set on the per-ticker quote path; absent on the bulk-by-underlying path. */
+  ticker?: string;
+  rows: number;
+  error: string;
+}
 
 export interface IngestResult {
   status: IngestStatus;
@@ -6,6 +28,12 @@ export interface IngestResult {
   dateRange?: { from: string; to: string };
   enrichment?: { from: string; to: string } | null;
   error?: string;
+  /**
+   * Batches that the ingest logged-and-skipped instead of aborting on. Present
+   * only when `status === "partial"`. Empty/undefined for clean runs.
+   * See `IngestSkippedBatch` for the producer surface.
+   */
+  skipped?: IngestSkippedBatch[];
   details?: Record<string, unknown>;
 }
 
@@ -23,7 +51,7 @@ export interface IngestQuotesOptions {
   /**
    * Specific OCC tickers to fetch. Per-ticker provider calls (Massive, or
    * ThetaData single-contract quote). Use when you know the exact contracts
-   * you need (e.g. a backtester trade list).
+   * you need (e.g. a downstream trade list).
    *
    * Mutually exclusive with `underlyings`. Exactly one of the two must be
    * non-empty.
@@ -162,4 +190,11 @@ export interface RefreshResult {
   };
   coverage: Record<string, { totalDates: number; dateRange?: { from: string; to: string } }>;
   errors: string[];
+  /**
+   * Aggregated `skipped` entries pulled up from every `perOperation.*` IngestResult.
+   * Present (possibly empty) on every non-skipped refresh so orchestrators can
+   * inspect partial-batch failures without traversing `perOperation`. When
+   * `status === "partial"`, this array has at least one entry.
+   */
+  skipped?: IngestSkippedBatch[];
 }

--- a/packages/mcp-server/src/market/ingestor/types.ts
+++ b/packages/mcp-server/src/market/ingestor/types.ts
@@ -2,30 +2,47 @@ export type IngestStatus = "ok" | "partial" | "skipped" | "unsupported" | "error
 
 /**
  * Per-batch failure entry attached to a result when the ingest completed some
- * batches but logged-and-skipped others. Two producers, distinguished by
+ * batches but logged-and-skipped others. Three producers, distinguished by
  * `reason`:
  *
- *   - `"read_failed"`  — `enrichQuoteRows` threw (e.g. transient DuckDB flake,
- *                        schema mismatch). The affected
- *                        (underlying, date[, ticker]) batch is dropped
- *                        instead of abandoning the whole ingest.
- *   - `"coverage_gap"` — the enrichment read succeeded but returned too few
- *                        underlying-price/chain rows to resolve greeks for
- *                        most of the batch (e.g. partial-day spot bars,
- *                        missing chain partition). Without this guard the
- *                        batch would persist with intact bid/ask but null
- *                        greeks. The `resolveRatio` field carries the
- *                        observed missingUnderlyingRows / attemptedRows
- *                        fraction (where attemptedRows = missingUnderlyingRows
- *                        + computedRows — only rows that reached the
- *                        underlying-lookup branch) that tripped
- *                        COVERAGE_GAP_THRESHOLD.
+ *   - `"read_failed"`     — `enrichQuoteRows` threw (e.g. transient DuckDB
+ *                           flake, schema mismatch). The affected
+ *                           (underlying, date[, ticker]) batch is dropped
+ *                           instead of abandoning the whole ingest.
+ *   - `"coverage_gap"`    — the enrichment read succeeded but returned too few
+ *                           underlying-price/chain rows to resolve greeks for
+ *                           most of the batch (e.g. partial-day spot bars,
+ *                           missing chain partition). Without this guard the
+ *                           batch would persist with intact bid/ask but null
+ *                           greeks. The `resolveRatio` field carries the
+ *                           observed missingUnderlyingRows / attemptedRows
+ *                           fraction (where attemptedRows =
+ *                           missingUnderlyingRows + computedRows — only rows
+ *                           that reached the underlying-lookup branch) that
+ *                           tripped COVERAGE_GAP_THRESHOLD.
+ *   - `"compute_failure"` — the underlying-price lookup succeeded but
+ *                           black-scholes math failed for most of the
+ *                           compute-mode rows (zero/negative option price,
+ *                           corrupt expiration → negative DTE, malformed
+ *                           strike grid). Sibling to coverage_gap on a
+ *                           distinct failure mode: spot is healthy but the
+ *                           chain/quote data is corrupt. Without this guard
+ *                           those rows mis-attribute as coverage_gap in the
+ *                           operator log. The `resolveRatio` field carries
+ *                           mathFailedRows / (mathFailedRows + computedRows)
+ *                           — the fraction of attempted math that failed —
+ *                           that tripped COMPUTE_FAILURE_THRESHOLD.
  *
- * Both reasons escalate the enclosing IngestResult to `status: "partial"`.
+ * All reasons escalate the enclosing IngestResult to `status: "partial"`.
  * Orchestrated callers MUST treat `partial` as a non-success signal —
  * `rowsWritten` undercounts when batches are skipped.
+ *
+ * Both guards can fire on the same partition (lookup-failure subset AND
+ * math-failure subset both above their respective thresholds). The skipped[]
+ * array carries one entry per tripped guard — operators benefit from seeing
+ * both signals; no dedupe.
  */
-export type IngestSkippedReason = "read_failed" | "coverage_gap";
+export type IngestSkippedReason = "read_failed" | "coverage_gap" | "compute_failure";
 
 export interface IngestSkippedBatch {
   underlying: string;
@@ -35,7 +52,7 @@ export interface IngestSkippedBatch {
   rows: number;
   reason: IngestSkippedReason;
   error: string;
-  /** Present only when `reason === "coverage_gap"`. */
+  /** Present on `"coverage_gap"` and `"compute_failure"`. */
   resolveRatio?: number;
 }
 

--- a/packages/mcp-server/src/market/ingestor/types.ts
+++ b/packages/mcp-server/src/market/ingestor/types.ts
@@ -15,8 +15,11 @@ export type IngestStatus = "ok" | "partial" | "skipped" | "unsupported" | "error
  *                        missing chain partition). Without this guard the
  *                        batch would persist with intact bid/ask but null
  *                        greeks. The `resolveRatio` field carries the
- *                        observed missingUnderlyingRows/rowsVisited fraction
- *                        that tripped COVERAGE_GAP_THRESHOLD.
+ *                        observed missingUnderlyingRows / attemptedRows
+ *                        fraction (where attemptedRows = missingUnderlyingRows
+ *                        + computedRows — only rows that reached the
+ *                        underlying-lookup branch) that tripped
+ *                        COVERAGE_GAP_THRESHOLD.
  *
  * Both reasons escalate the enclosing IngestResult to `status: "partial"`.
  * Orchestrated callers MUST treat `partial` as a non-success signal —

--- a/packages/mcp-server/src/market/ingestor/types.ts
+++ b/packages/mcp-server/src/market/ingestor/types.ts
@@ -2,24 +2,38 @@ export type IngestStatus = "ok" | "partial" | "skipped" | "unsupported" | "error
 
 /**
  * Per-batch failure entry attached to a result when the ingest completed some
- * batches but logged-and-skipped others. The current producer is
- * `MarketIngestor.enrichQuoteRows` failures inside the quote-ingest paths:
- * a transient DuckDB flake or schema mismatch on the enrichment read causes
- * the affected (underlying, date[, ticker]) batch to be skipped instead of
- * abandoning the whole ingest (so a long bulk refresh isn't killed by one
- * bad partition), and the entry surfaces in the result so orchestrators can
- * distinguish "complete" from "complete with N batches dropped".
+ * batches but logged-and-skipped others. Two producers, distinguished by
+ * `reason`:
  *
- * Orchestrated callers MUST treat `status: "partial"` as a non-success
- * signal — `rowsWritten` undercounts when batches are skipped.
+ *   - `"read_failed"`  — `enrichQuoteRows` threw (e.g. transient DuckDB flake,
+ *                        schema mismatch). The affected
+ *                        (underlying, date[, ticker]) batch is dropped
+ *                        instead of abandoning the whole ingest.
+ *   - `"coverage_gap"` — the enrichment read succeeded but returned too few
+ *                        underlying-price/chain rows to resolve greeks for
+ *                        most of the batch (e.g. partial-day spot bars,
+ *                        missing chain partition). Without this guard the
+ *                        batch would persist with intact bid/ask but null
+ *                        greeks. The `resolveRatio` field carries the
+ *                        observed missingUnderlyingRows/rowsVisited fraction
+ *                        that tripped COVERAGE_GAP_THRESHOLD.
+ *
+ * Both reasons escalate the enclosing IngestResult to `status: "partial"`.
+ * Orchestrated callers MUST treat `partial` as a non-success signal —
+ * `rowsWritten` undercounts when batches are skipped.
  */
+export type IngestSkippedReason = "read_failed" | "coverage_gap";
+
 export interface IngestSkippedBatch {
   underlying: string;
   date: string;
   /** Set on the per-ticker quote path; absent on the bulk-by-underlying path. */
   ticker?: string;
   rows: number;
+  reason: IngestSkippedReason;
   error: string;
+  /** Present only when `reason === "coverage_gap"`. */
+  resolveRatio?: number;
 }
 
 export interface IngestResult {

--- a/packages/mcp-server/src/market/stores/chain-sql.ts
+++ b/packages/mcp-server/src/market/stores/chain-sql.ts
@@ -2,13 +2,20 @@
  * Pure SQL builder for ChainStore reads (Market Data 3.0 — Phase 2 Wave 1).
  *
  * Option chains are partitioned by (underlying, date). A single `readChain`
- * call targets exactly one partition, so the builder binds two positional
- * parameters: $1=underlying, $2=date.
+ * call targets exactly one partition. Values are inlined as SQL literals
+ * because `runAndReadAll(sql, params)` leaks C++ handles via DuckDB's
+ * `extract_statements` path (see `spot-sql.ts` header for the full writeup
+ * and `feedback_duckdb_extract_statements_leak.md`).
  *
  * Purity contract (CONTEXT.md D-05): no `this`, no `ctx`, no DuckDB value-level
  * imports. Tests in `tests/unit/market/stores/chain-sql.test.ts`.
  */
+import { escapeSqlLiteral } from "../../utils/quote-parquet-projection.js";
 import type { BuiltSQL } from "./spot-sql.js";
+
+function lit(value: string): string {
+  return `'${escapeSqlLiteral(value)}'`;
+}
 
 /**
  * Build the `SELECT ... FROM market.option_chain` SQL for a single underlying +
@@ -18,13 +25,12 @@ import type { BuiltSQL } from "./spot-sql.js";
 export function buildReadChainSQL(
   underlying: string,
   date: string,
-): BuiltSQL<[string, string]> {
+): BuiltSQL {
   return {
     sql: `SELECT underlying, date, ticker, contract_type, strike, expiration, dte, exercise_style
           FROM market.option_chain
-          WHERE underlying = $1 AND date = $2
+          WHERE underlying = ${lit(underlying)} AND date = ${lit(date)}
           ORDER BY ticker`,
-    params: [underlying, date],
   };
 }
 
@@ -41,16 +47,15 @@ export function buildReadChainSQL(
 export function buildReadChainDatesSQL(
   underlying: string,
   dates: string[],
-): BuiltSQL<string[]> {
+): BuiltSQL {
   if (dates.length === 0) {
     throw new Error("buildReadChainDatesSQL: dates must not be empty");
   }
-  const placeholders = dates.map((_, i) => `$${i + 2}`).join(", ");
+  const dateList = dates.map(lit).join(", ");
   return {
     sql: `SELECT underlying, date, ticker, contract_type, strike, expiration, dte, exercise_style
           FROM market.option_chain
-          WHERE underlying = $1 AND date IN (${placeholders})
+          WHERE underlying = ${lit(underlying)} AND date IN (${dateList})
           ORDER BY date, ticker`,
-    params: [underlying, ...dates],
   };
 }

--- a/packages/mcp-server/src/market/stores/chain-sql.ts
+++ b/packages/mcp-server/src/market/stores/chain-sql.ts
@@ -4,8 +4,7 @@
  * Option chains are partitioned by (underlying, date). A single `readChain`
  * call targets exactly one partition. Values are inlined as SQL literals
  * because `runAndReadAll(sql, params)` leaks C++ handles via DuckDB's
- * `extract_statements` path (see `spot-sql.ts` header for the full writeup
- * and `feedback_duckdb_extract_statements_leak.md`).
+ * `extract_statements` path (see `spot-sql.ts` header for the full writeup).
  *
  * Purity contract (CONTEXT.md D-05): no `this`, no `ctx`, no DuckDB value-level
  * imports. Tests in `tests/unit/market/stores/chain-sql.test.ts`.

--- a/packages/mcp-server/src/market/stores/chain-store.ts
+++ b/packages/mcp-server/src/market/stores/chain-store.ts
@@ -36,11 +36,14 @@ export abstract class ChainStore {
    * check matters.
    */
   async hasChain(underlying: string, date: string): Promise<boolean> {
+    // Inline literals — bound-param path leaks extract_statements handles
+    // (see chain-sql.ts / spot-sql.ts headers).
+    const underlyingLit = underlying.replace(/'/g, "''");
+    const dateLit = date.replace(/'/g, "''");
     const reader = await this.ctx.conn.runAndReadAll(
       `SELECT 1 FROM market.option_chain
-        WHERE underlying = $1 AND date = $2
+        WHERE underlying = '${underlyingLit}' AND date = '${dateLit}'
         LIMIT 1`,
-      [underlying, date] as (string | number | boolean | null | bigint)[],
     );
     return reader.getRows().length > 0;
   }
@@ -57,11 +60,9 @@ export abstract class ChainStore {
     dates: string[],
   ): Promise<ContractRow[]> {
     if (dates.length === 0) return [];
-    const built = buildReadChainDatesSQL(underlying, dates);
-    const reader = await this.ctx.conn.runAndReadAll(
-      built.sql,
-      built.params as (string | number | boolean | null | bigint)[],
-    );
+    // Builder inlines values; unbound runAndReadAll(sql) bypasses extract_statements.
+    const { sql } = buildReadChainDatesSQL(underlying, dates);
+    const reader = await this.ctx.conn.runAndReadAll(sql);
     return reader.getRows().map((r) => ({
       underlying: String(r[0]),
       date: String(r[1]),

--- a/packages/mcp-server/src/market/stores/duckdb-chain-store.ts
+++ b/packages/mcp-server/src/market/stores/duckdb-chain-store.ts
@@ -60,11 +60,10 @@ export class DuckdbChainStore extends ChainStore {
     underlying: string,
     date: string,
   ): Promise<ContractRow[]> {
-    const { sql, params } = buildReadChainSQL(underlying, date);
-    const reader = await this.ctx.conn.runAndReadAll(
-      sql,
-      params as (string | number | boolean | null | bigint)[],
-    );
+    // Builder inlines values; unbound runAndReadAll(sql) bypasses
+    // extract_statements (chain-sql.ts header).
+    const { sql } = buildReadChainSQL(underlying, date);
+    const reader = await this.ctx.conn.runAndReadAll(sql);
     return reader.getRows().map((r) => ({
       underlying: String(r[0]),
       date: String(r[1]),
@@ -82,11 +81,14 @@ export class DuckdbChainStore extends ChainStore {
     from: string,
     to: string,
   ): Promise<CoverageReport> {
+    // Inline literals — same leak rationale as readChain.
+    const underlyingLit = underlying.replace(/'/g, "''");
+    const fromLit = from.replace(/'/g, "''");
+    const toLit = to.replace(/'/g, "''");
     const reader = await this.ctx.conn.runAndReadAll(
       `SELECT DISTINCT date FROM market.option_chain
-         WHERE underlying = $1 AND date >= $2 AND date <= $3
+         WHERE underlying = '${underlyingLit}' AND date >= '${fromLit}' AND date <= '${toLit}'
          ORDER BY date`,
-      [underlying, from, to],
     );
     const dates = reader.getRows().map((r) => String(r[0]));
     return {

--- a/packages/mcp-server/src/market/stores/duckdb-enriched-store.ts
+++ b/packages/mcp-server/src/market/stores/duckdb-enriched-store.ts
@@ -61,17 +61,16 @@ export class DuckdbEnrichedStore extends EnrichedStore {
   }
 
   async read(opts: EnrichedReadOpts): Promise<Record<string, unknown>[]> {
-    const { sql, params } = buildReadEnrichedSQL({
+    // Builder inlines values; unbound runAndReadAll(sql) bypasses extract_statements
+    // (see enriched-sql.ts / spot-sql.ts headers).
+    const { sql } = buildReadEnrichedSQL({
       ticker: opts.ticker,
       from: opts.from,
       to: opts.to,
       includeContext: !!opts.includeContext,
       includeOhlcv: !!opts.includeOhlcv,
     });
-    const reader = await this.ctx.conn.runAndReadAll(
-      sql,
-      params as (string | number | boolean | null | bigint)[],
-    );
+    const reader = await this.ctx.conn.runAndReadAll(sql);
     const names = reader.columnNames();
     return reader
       .getRows()
@@ -82,10 +81,10 @@ export class DuckdbEnrichedStore extends EnrichedStore {
 
   async getCoverage(ticker: string): Promise<CoverageReport> {
     // D-27: coverage answers "what rows exist" directly from the enriched
-    // table — not from the watermark JSON.
+    // table — not from the watermark JSON. Inline literal — same leak rationale.
+    const tickerLit = ticker.replace(/'/g, "''");
     const reader = await this.ctx.conn.runAndReadAll(
-      `SELECT DISTINCT date FROM market.enriched WHERE ticker = $1 ORDER BY date`,
-      [ticker],
+      `SELECT DISTINCT date FROM market.enriched WHERE ticker = '${tickerLit}' ORDER BY date`,
     );
     const dates = reader.getRows().map((r) => String(r[0]));
     return {

--- a/packages/mcp-server/src/market/stores/duckdb-quote-store.ts
+++ b/packages/mcp-server/src/market/stores/duckdb-quote-store.ts
@@ -363,11 +363,14 @@ export class DuckdbQuoteStore extends QuoteStore {
     from: string,
     to: string,
   ): Promise<CoverageReport> {
+    // Inline literal path — same leak rationale (see spot-sql.ts header).
+    const underlyingLit = underlying.replace(/'/g, "''");
+    const fromLit = from.replace(/'/g, "''");
+    const toLit = to.replace(/'/g, "''");
     const reader = await this.ctx.conn.runAndReadAll(
       `SELECT DISTINCT date FROM market.option_quote_minutes
-         WHERE underlying = $1 AND date >= $2 AND date <= $3
+         WHERE underlying = '${underlyingLit}' AND date >= '${fromLit}' AND date <= '${toLit}'
          ORDER BY date`,
-      [underlying, from, to],
     );
     const dates = reader.getRows().map((r) => String(r[0]));
     return {

--- a/packages/mcp-server/src/market/stores/duckdb-spot-store.ts
+++ b/packages/mcp-server/src/market/stores/duckdb-spot-store.ts
@@ -65,11 +65,10 @@ export class DuckdbSpotStore extends SpotStore {
     from: string,
     to: string,
   ): Promise<BarRow[]> {
-    const { sql, params } = buildReadBarsSQL(ticker, from, to);
-    const reader = await this.ctx.conn.runAndReadAll(
-      sql,
-      params as (string | number | boolean | null | bigint)[],
-    );
+    // Builders inline values as SQL literals; the unbound runAndReadAll(sql)
+    // path bypasses extract_statements (see spot-sql.ts header).
+    const { sql } = buildReadBarsSQL(ticker, from, to);
+    const reader = await this.ctx.conn.runAndReadAll(sql);
     return reader.getRows().map((r) => ({
       ticker: String(r[0]),
       date: String(r[1]),
@@ -89,11 +88,8 @@ export class DuckdbSpotStore extends SpotStore {
     from: string,
     to: string,
   ): Promise<BarRow[]> {
-    const { sql, params } = buildReadDailyBarsSQL(ticker, from, to);
-    const reader = await this.ctx.conn.runAndReadAll(
-      sql,
-      params as (string | number | boolean | null | bigint)[],
-    );
+    const { sql } = buildReadDailyBarsSQL(ticker, from, to);
+    const reader = await this.ctx.conn.runAndReadAll(sql);
     return reader.getRows().map((r) => ({
       ticker: String(r[0]),
       date: String(r[1]),
@@ -113,11 +109,14 @@ export class DuckdbSpotStore extends SpotStore {
     from: string,
     to: string,
   ): Promise<CoverageReport> {
+    // Inline literals — same leak rationale as readBars (spot-sql.ts header).
+    const tickerLit = ticker.replace(/'/g, "''");
+    const fromLit = from.replace(/'/g, "''");
+    const toLit = to.replace(/'/g, "''");
     const reader = await this.ctx.conn.runAndReadAll(
       `SELECT DISTINCT date FROM market.spot
-         WHERE ticker = $1 AND date >= $2 AND date <= $3
+         WHERE ticker = '${tickerLit}' AND date >= '${fromLit}' AND date <= '${toLit}'
          ORDER BY date`,
-      [ticker, from, to],
     );
     const dates = reader.getRows().map((r) => String(r[0]));
     return {

--- a/packages/mcp-server/src/market/stores/enriched-sql.ts
+++ b/packages/mcp-server/src/market/stores/enriched-sql.ts
@@ -7,14 +7,14 @@
  *                        VIX-family fields (Vol_Regime, Term_Structure_State,
  *                        Trend_Direction, VIX_Spike_Pct, VIX_Gap_Pct)
  *
- * Both subqueries/joins share the outer query's positional parameters
- * (`$1=ticker`, `$2=from`, `$3=to`) — the builder never duplicates params
- * just because a flag is flipped.
+ * Values are inlined as SQL literals — see `spot-sql.ts` header for the
+ * extract_statements GC leak that ruled out positional parameters.
  *
  * Purity contract (PATTERNS.md "Pure SQL builders"; CONTEXT.md D-05): no `this`,
  * no `ctx`, no DB-connection value-level imports. Tests live in
  * `tests/unit/market/stores/enriched-sql.test.ts`.
  */
+import { escapeSqlLiteral } from "../../utils/quote-parquet-projection.js";
 import { rthDailyAggregateSubquery } from "./rth-aggregation.js";
 import type { BuiltSQL } from "./spot-sql.js";
 
@@ -26,6 +26,10 @@ export interface BuildReadEnrichedArgs {
   includeOhlcv: boolean;
 }
 
+function lit(value: string): string {
+  return `'${escapeSqlLiteral(value)}'`;
+}
+
 /**
  * Build the `SELECT ... FROM market.enriched ...` SQL, optionally joined with
  * the RTH daily aggregate from `market.spot` and the `market.enriched_context`
@@ -33,17 +37,18 @@ export interface BuildReadEnrichedArgs {
  */
 export function buildReadEnrichedSQL(
   args: BuildReadEnrichedArgs,
-): BuiltSQL<[string, string, string]> {
+): BuiltSQL {
   const { ticker, from, to, includeContext, includeOhlcv } = args;
 
-  // The subquery reuses the OUTER $1/$2/$3 placeholders — do not duplicate
-  // params. If consumers later need different date ranges for the inner and
-  // outer queries, revisit; for the current call-site map they always match.
+  const tickerLit = lit(ticker);
+  const fromLit = lit(from);
+  const toLit = lit(to);
+
   const ohlcvJoin = includeOhlcv
     ? `LEFT JOIN ${rthDailyAggregateSubquery({
-        tickerParamIdx: 1,
-        fromParamIdx: 2,
-        toParamIdx: 3,
+        tickerLit,
+        fromLit,
+        toLit,
       })} s_daily
          ON s_daily.ticker = e.ticker AND s_daily.date = e.date`
     : "";
@@ -65,9 +70,9 @@ export function buildReadEnrichedSQL(
     FROM market.enriched e
     ${ohlcvJoin}
     ${ctxJoin}
-    WHERE e.ticker = $1 AND e.date >= $2 AND e.date <= $3
+    WHERE e.ticker = ${tickerLit} AND e.date >= ${fromLit} AND e.date <= ${toLit}
     ORDER BY e.date
   `;
 
-  return { sql, params: [ticker, from, to] };
+  return { sql };
 }

--- a/packages/mcp-server/src/market/stores/parquet-chain-store.ts
+++ b/packages/mcp-server/src/market/stores/parquet-chain-store.ts
@@ -138,11 +138,9 @@ export class ParquetChainStore extends ChainStore {
         exercise_style: String(r[7]),
       }));
     }
-    const { sql, params } = buildReadChainSQL(underlying, date);
-    const reader = await this.ctx.conn.runAndReadAll(
-      sql,
-      params as (string | number | boolean | null | bigint)[],
-    );
+    // Builder inlines values; unbound runAndReadAll(sql) bypasses extract_statements.
+    const { sql } = buildReadChainSQL(underlying, date);
+    const reader = await this.ctx.conn.runAndReadAll(sql);
     return reader.getRows().map((r) => ({
       underlying: String(r[0]),
       date: String(r[1]),

--- a/packages/mcp-server/src/market/stores/parquet-enriched-store.ts
+++ b/packages/mcp-server/src/market/stores/parquet-enriched-store.ts
@@ -75,9 +75,8 @@ export class ParquetEnrichedStore extends EnrichedStore {
     // Fast path: when the caller doesn't need cross-ticker context or RTH
     // OHLCV joins, read directly from the ticker's parquet file. Avoids
     // the `market.enriched` view glob (~430ms) AND the extract_statements
-    // GC handle leak (see feedback_duckdb_extract_statements_leak memory
-    // and parquet-quote-store.ts:327). Hit on every entry-pipeline date
-    // when an RSI / vol-regime filter is configured.
+    // GC handle leak (see parquet-quote-store.ts:327). Hit on every
+    // entry-pipeline date when an RSI / vol-regime filter is configured.
     const wantsJoins = !!opts.includeContext || !!opts.includeOhlcv;
     if (!wantsJoins) {
       const filePath = path.join(

--- a/packages/mcp-server/src/market/stores/parquet-enriched-store.ts
+++ b/packages/mcp-server/src/market/stores/parquet-enriched-store.ts
@@ -100,17 +100,15 @@ export class ParquetEnrichedStore extends EnrichedStore {
           .map((row) => Object.fromEntries(names.map((n, i) => [n, row[i]])));
       }
     }
-    const { sql, params } = buildReadEnrichedSQL({
+    // Builder inlines values; unbound runAndReadAll(sql) bypasses extract_statements.
+    const { sql } = buildReadEnrichedSQL({
       ticker: opts.ticker,
       from: opts.from,
       to: opts.to,
       includeContext: !!opts.includeContext,
       includeOhlcv: !!opts.includeOhlcv,
     });
-    const reader = await this.ctx.conn.runAndReadAll(
-      sql,
-      params as (string | number | boolean | null | bigint)[],
-    );
+    const reader = await this.ctx.conn.runAndReadAll(sql);
     const names = reader.columnNames();
     return reader
       .getRows()
@@ -134,9 +132,9 @@ export class ParquetEnrichedStore extends EnrichedStore {
       // is a union), so we return empty early to match Parquet reality.
       return { earliest: null, latest: null, missingDates: [], totalDates: 0 };
     }
+    const tickerLit = ticker.replace(/'/g, "''");
     const reader = await this.ctx.conn.runAndReadAll(
-      `SELECT DISTINCT date FROM market.enriched WHERE ticker = $1 ORDER BY date`,
-      [ticker],
+      `SELECT DISTINCT date FROM market.enriched WHERE ticker = '${tickerLit}' ORDER BY date`,
     );
     const dates = reader.getRows().map((r) => String(r[0]));
     return {

--- a/packages/mcp-server/src/market/stores/parquet-spot-store.ts
+++ b/packages/mcp-server/src/market/stores/parquet-spot-store.ts
@@ -138,19 +138,10 @@ export class ParquetSpotStore extends SpotStore {
     to: string,
   ): Promise<BarRow[]> {
     const direct = this.buildDirectParquetReadBarsSQL(ticker, from, to);
-    // Direct path: no params, call runAndReadAll(sql) without 2nd arg to bypass
-    // extract_statements (which leaks C++ handles per call — see
-    // parquet-quote-store.ts:327 for the full root-cause writeup).
-    let reader;
-    if (direct) {
-      reader = await this.ctx.conn.runAndReadAll(direct.sql);
-    } else {
-      const fallback = buildReadBarsSQL(ticker, from, to);
-      reader = await this.ctx.conn.runAndReadAll(
-        fallback.sql,
-        fallback.params as (string | number | boolean | null | bigint)[],
-      );
-    }
+    // Both paths inline values — bound-param runAndReadAll(sql, values) leaks
+    // extract_statements handles (parquet-quote-store.ts:327, spot-sql.ts).
+    const { sql } = direct ?? buildReadBarsSQL(ticker, from, to);
+    const reader = await this.ctx.conn.runAndReadAll(sql);
     return reader.getRows().map((r) => ({
       ticker: String(r[0]),
       date: String(r[1]),
@@ -171,16 +162,9 @@ export class ParquetSpotStore extends SpotStore {
     to: string,
   ): Promise<BarRow[]> {
     const direct = this.buildDirectParquetReadBarsSQL(ticker, from, to, { dailyAgg: true });
-    let reader;
-    if (direct) {
-      reader = await this.ctx.conn.runAndReadAll(direct.sql);
-    } else {
-      const fallback = buildReadDailyBarsSQL(ticker, from, to);
-      reader = await this.ctx.conn.runAndReadAll(
-        fallback.sql,
-        fallback.params as (string | number | boolean | null | bigint)[],
-      );
-    }
+    // Same leak rationale as readBars — both paths run via unbound query().
+    const { sql } = direct ?? buildReadDailyBarsSQL(ticker, from, to);
+    const reader = await this.ctx.conn.runAndReadAll(sql);
     return reader.getRows().map((r) => ({
       ticker: String(r[0]),
       date: String(r[1]),

--- a/packages/mcp-server/src/market/stores/quote-sql.ts
+++ b/packages/mcp-server/src/market/stores/quote-sql.ts
@@ -7,16 +7,18 @@
  * OCC ticker resolves to the same underlying (D-07); this builder trusts its
  * caller on that front.
  *
- * Param layout:
- *   $1        → underlying
- *   $2        → from (date)
- *   $3        → to   (date)
- *   $4..$N    → occTickers (variable-length IN list)
+ * Values are inlined as SQL literals — see `spot-sql.ts` header for the
+ * extract_statements GC leak that ruled out positional parameters.
  *
  * Purity contract (CONTEXT.md D-05): pure function, no DuckDB value-level
  * imports. Tests in `tests/unit/market/stores/quote-sql.test.ts`.
  */
+import { escapeSqlLiteral } from "../../utils/quote-parquet-projection.js";
 import type { BuiltSQL } from "./spot-sql.js";
+
+function lit(value: string): string {
+  return `'${escapeSqlLiteral(value)}'`;
+}
 
 /**
  * Build the bulk quote read. Throws if `occTickers` is empty (prevents emitting
@@ -33,35 +35,27 @@ export function buildReadQuotesSQL(
   from: string,
   to: string,
   opts?: { timeStart?: string; timeEnd?: string },
-): BuiltSQL<string[]> {
+): BuiltSQL {
   if (occTickers.length === 0) {
     throw new Error("buildReadQuotesSQL: occTickers must not be empty");
   }
   const timeStart = opts?.timeStart;
   const timeEnd = opts?.timeEnd;
   const hasTimeFilter = timeStart != null && timeEnd != null;
-  // $1..$3: underlying + date range. Optional time filter consumes $4/$5
-  // when present. OCC ticker IN-list placeholders follow.
-  const timeOffset = hasTimeFilter ? 2 : 0;
-  const tickerPlaceholders = occTickers
-    .map((_, i) => `$${i + 4 + timeOffset}`)
-    .join(", ");
-  const params: string[] = [underlying, from, to];
-  if (hasTimeFilter) params.push(timeStart!, timeEnd!);
-  params.push(...occTickers);
+
+  const tickerList = occTickers.map(lit).join(", ");
   const timeClause = hasTimeFilter
-    ? `AND time >= $4 AND time <= $5\n           `
+    ? `AND time >= ${lit(timeStart!)} AND time <= ${lit(timeEnd!)}\n           `
     : "";
   return {
     sql: `SELECT ticker, date, time, bid, ask, mid, last_updated_ns,
                  delta, gamma, theta, vega, iv, greeks_source, greeks_revision,
                  rate_type, rate_value, gamma_source
           FROM market.option_quote_minutes
-          WHERE underlying = $1
-            AND date >= $2
-            AND date <= $3
-            ${timeClause}AND ticker IN (${tickerPlaceholders})
+          WHERE underlying = ${lit(underlying)}
+            AND date >= ${lit(from)}
+            AND date <= ${lit(to)}
+            ${timeClause}AND ticker IN (${tickerList})
           ORDER BY ticker, date, time`,
-    params,
   };
 }

--- a/packages/mcp-server/src/market/stores/rth-aggregation.ts
+++ b/packages/mcp-server/src/market/stores/rth-aggregation.ts
@@ -9,29 +9,31 @@
  * aggregate — NEVER the window-function equivalents (which cannot be combined
  * with `GROUP BY`).
  *
+ * Values arrive pre-quoted from the caller so the subquery composes cleanly
+ * with the surrounding inline-literal SQL (see `spot-sql.ts` header for why
+ * positional params are off-limits — the extract_statements GC leak).
+ *
  * Used by:
  *   - `enriched-sql.ts::buildReadEnrichedSQL` when `includeOhlcv=true`
  */
 
 export interface RthWindowOpts {
-  /** Index of the positional placeholder bound to the ticker (e.g. 1 → $1). */
-  tickerParamIdx: number;
-  /** Index of the placeholder bound to the `from` date. */
-  fromParamIdx: number;
-  /** Index of the placeholder bound to the `to` date. */
-  toParamIdx: number;
+  /** SQL-literal expression for the ticker (e.g. `'SPX'`). */
+  tickerLit: string;
+  /** SQL-literal expression for the `from` date (e.g. `'2025-01-01'`). */
+  fromLit: string;
+  /** SQL-literal expression for the `to` date (e.g. `'2025-01-31'`). */
+  toLit: string;
 }
 
 /**
  * Emit a derived-table expression that produces daily OHLCV rows by aggregating
- * minute bars in `market.spot` within the RTH window.
- *
- * The caller supplies the positional `$N` indices so the subquery can share the
- * same parameters as the surrounding query (avoiding duplicate bindings when
- * embedded in, e.g., `buildReadEnrichedSQL`).
+ * minute bars in `market.spot` within the RTH window. Inputs are pre-escaped
+ * SQL literals so the subquery embeds directly inside a larger inline-literal
+ * SQL statement (no positional params anywhere in the pipeline).
  */
 export function rthDailyAggregateSubquery(opts: RthWindowOpts): string {
-  const { tickerParamIdx, fromParamIdx, toParamIdx } = opts;
+  const { tickerLit, fromLit, toLit } = opts;
   return `(
     SELECT ticker, date,
            first(open  ORDER BY time) AS open,
@@ -39,8 +41,8 @@ export function rthDailyAggregateSubquery(opts: RthWindowOpts): string {
            min(low)                   AS low,
            last(close  ORDER BY time) AS close
     FROM market.spot
-    WHERE ticker = $${tickerParamIdx}
-      AND date >= $${fromParamIdx} AND date <= $${toParamIdx}
+    WHERE ticker = ${tickerLit}
+      AND date >= ${fromLit} AND date <= ${toLit}
       AND time >= '09:30' AND time <= '16:00'
       -- Defense-in-depth: drop minute bars with zero/null OHLC before
       -- aggregating. Mirrors the same guard on market.spot_daily and the

--- a/packages/mcp-server/src/market/stores/spot-sql.ts
+++ b/packages/mcp-server/src/market/stores/spot-sql.ts
@@ -2,27 +2,44 @@
  * Pure SQL builders for SpotStore reads (Market Data 3.0 — Phase 2 Wave 1).
  *
  * Every export is a pure function: given primitive inputs, it returns
- * `{ sql, params }` where `params` are positional bindings for DuckDB's
- * `$1`/`$2`/`$3` placeholders.
+ * `{ sql }` where the SQL string already has every partition-selector value
+ * inlined as a SQL literal. Callers MUST invoke `runAndReadAll(sql)` with no
+ * second argument.
+ *
+ * Why no positional parameters: the DuckDB Node-API binding routes
+ * `runAndReadAll(sql, values)` through `node_bindings.extract_statements`,
+ * which allocates a C++ handle with no JS-side destroy method (the wrapper
+ * `DuckDBExtractedStatements` only has a constructor — see
+ * `node_modules/@duckdb/node-api/lib/DuckDBExtractedStatements.js`). Handles
+ * release only on JS GC, so under sustained read load the driver eventually
+ * throws `Failed to execute prepared statement`. Inlining values into the SQL
+ * string sends the call through `node_bindings.query()` instead, which is
+ * leak-free. See `parquet-quote-store.ts:340` for the full root-cause writeup
+ * and the project memory entry `feedback_duckdb_extract_statements_leak.md`.
  *
  * Purity contract (CONTEXT.md D-05, PATTERNS.md "Pure SQL builders"):
  *   - No `this` / no `ctx` / no DB-connection value-level import
  *   - No side effects; no IO
  *   - Composable — concrete stores in Waves 2-3 feed the result to `conn.run()`
  *
- * Security note (T-2-02): user-controlled values (ticker, from, to) are bound
- * positionally. The SQL strings never interpolate untrusted text. Partition-
- * value whitelisting + positional binding together mitigate SQL injection.
+ * Security note (T-2-02): user-controlled values (ticker, from, to) are
+ * single-quote-escaped via `escapeSqlLiteral` before interpolation. Inputs
+ * arrive from typed config / partition-resolved registries (no untrusted
+ * free-text), and the escape closes the residual injection vector.
  */
 
+import { escapeSqlLiteral } from "../../utils/quote-parquet-projection.js";
+
 /**
- * Shape returned by every SQL builder: the SQL text plus the positional params
- * in $1/$2/$... order. Generic `P` lets tests assert exact tuple types when
- * useful.
+ * Shape returned by every SQL builder. Just the SQL text — values are inlined
+ * as SQL literals (see file header for the why).
  */
-export interface BuiltSQL<P extends unknown[] = unknown[]> {
+export interface BuiltSQL {
   sql: string;
-  params: P;
+}
+
+function lit(value: string): string {
+  return `'${escapeSqlLiteral(value)}'`;
 }
 
 /**
@@ -33,13 +50,12 @@ export function buildReadBarsSQL(
   ticker: string,
   from: string,
   to: string,
-): BuiltSQL<[string, string, string]> {
+): BuiltSQL {
   return {
     sql: `SELECT ticker, date, time, open, high, low, close, bid, ask
           FROM market.spot
-          WHERE ticker = $1 AND date >= $2 AND date <= $3
+          WHERE ticker = ${lit(ticker)} AND date >= ${lit(from)} AND date <= ${lit(to)}
           ORDER BY date, time`,
-    params: [ticker, from, to],
   };
 }
 
@@ -55,7 +71,7 @@ export function buildReadDailyBarsSQL(
   ticker: string,
   from: string,
   to: string,
-): BuiltSQL<[string, string, string]> {
+): BuiltSQL {
   return {
     sql: `SELECT
             ticker,
@@ -67,8 +83,8 @@ export function buildReadDailyBarsSQL(
             first(bid   ORDER BY time) AS bid,
             last(ask    ORDER BY time) AS ask
           FROM market.spot
-          WHERE ticker = $1
-            AND date >= $2 AND date <= $3
+          WHERE ticker = ${lit(ticker)}
+            AND date >= ${lit(from)} AND date <= ${lit(to)}
             AND time >= '09:30' AND time <= '16:00'
             -- Defense-in-depth: drop minute bars with zero/null OHLC
             -- before aggregating. Mirrors market.spot_daily and the direct-
@@ -80,7 +96,6 @@ export function buildReadDailyBarsSQL(
             AND close IS NOT NULL AND close > 0
           GROUP BY ticker, date
           ORDER BY date`,
-    params: [ticker, from, to],
   };
 }
 
@@ -95,12 +110,12 @@ export function buildReadRthOpensSQL(
   ticker: string,
   from: string,
   to: string,
-): BuiltSQL<[string, string, string]> {
+): BuiltSQL {
   return {
     sql: `SELECT date, first(open ORDER BY time) AS open
           FROM market.spot
-          WHERE ticker = $1
-            AND date >= $2 AND date <= $3
+          WHERE ticker = ${lit(ticker)}
+            AND date >= ${lit(from)} AND date <= ${lit(to)}
             AND time >= '09:30' AND time <= '16:00'
             -- Defense-in-depth: drop bars with zero/null open before
             -- aggregating; first(open) could otherwise return 0 if a bad
@@ -108,6 +123,5 @@ export function buildReadRthOpensSQL(
             AND open IS NOT NULL AND open > 0
           GROUP BY date
           ORDER BY date`,
-    params: [ticker, from, to],
   };
 }

--- a/packages/mcp-server/src/market/stores/spot-sql.ts
+++ b/packages/mcp-server/src/market/stores/spot-sql.ts
@@ -14,8 +14,7 @@
  * release only on JS GC, so under sustained read load the driver eventually
  * throws `Failed to execute prepared statement`. Inlining values into the SQL
  * string sends the call through `node_bindings.query()` instead, which is
- * leak-free. See `parquet-quote-store.ts:340` for the full root-cause writeup
- * and the project memory entry `feedback_duckdb_extract_statements_leak.md`.
+ * leak-free. See `parquet-quote-store.ts:340` for the full root-cause writeup.
  *
  * Purity contract (CONTEXT.md D-05, PATTERNS.md "Pure SQL builders"):
  *   - No `this` / no `ctx` / no DB-connection value-level import

--- a/packages/mcp-server/src/market/stores/spot-store.ts
+++ b/packages/mcp-server/src/market/stores/spot-store.ts
@@ -29,7 +29,7 @@ export abstract class SpotStore {
     from: string,
     to: string,
     opts?: { rthOnly?: boolean; dailyAgg?: boolean },
-  ): { sql: string; params: [] } | null {
+  ): { sql: string } | null {
     const tickerDir = path.join(resolveMarketDir(this.ctx.dataDir), "spot", `ticker=${ticker}`);
     if (!existsSync(tickerDir)) return null;
     const allDates = listPartitionValues(tickerDir, "date");
@@ -66,7 +66,6 @@ export abstract class SpotStore {
                 AND close IS NOT NULL AND close > 0
               GROUP BY date
               ORDER BY date`,
-        params: [],
       };
     }
     const rthClause = opts?.rthOnly ? "AND time >= '09:30' AND time <= '16:00'" : "";
@@ -75,7 +74,6 @@ export abstract class SpotStore {
             FROM read_parquet([${fileList}], hive_partitioning=true)
             WHERE 1=1 ${rthClause}
             ORDER BY date, time`,
-      params: [],
     };
   }
 

--- a/packages/mcp-server/src/tools/market-fetch.ts
+++ b/packages/mcp-server/src/tools/market-fetch.ts
@@ -119,11 +119,18 @@ export function registerMarketFetchTools(
           tickers, underlyings, from, to, provider, dryRun: dry_run, onProgress,
         });
         const mode = underlyings ? `bulk (${underlyings.join(",")})` : `per-ticker (${tickers?.length ?? 0})`;
+        // `partial` means some batches were logged-and-skipped. The structured
+        // `skipped[]` array on the result body carries the details; we surface
+        // the count in the summary so console callers see it.
+        const partialSuffix =
+          result.status === "partial" && result.skipped
+            ? ` — ${result.skipped.length} batch(es) skipped (see result.skipped[])`
+            : "";
         const summary =
           result.status === "unsupported" ? `Unsupported: ${result.error}` :
           result.status === "error" ? `Error: ${result.error}` :
           dry_run ? `[DRY RUN] Would fetch quotes: ${mode}` :
-          `${result.status}: wrote ${result.rowsWritten} quote rows (${mode})`;
+          `${result.status}: wrote ${result.rowsWritten} quote rows (${mode})${partialSuffix}`;
         return createToolOutput(summary, result);
       } finally {
         await downgradeToReadOnly(baseDir);
@@ -328,13 +335,21 @@ export function registerMarketFetchTools(
           ...(result.perOperation.vixContext ? [result.perOperation.vixContext] : []),
         ];
         const unsupportedCount = operationResults.filter((item) => item.status === "unsupported").length;
-        const skippedCount = operationResults.filter((item) => item.status === "skipped").length;
+        const skippedOpCount = operationResults.filter((item) => item.status === "skipped").length;
+        // `partial` surfaces enrichQuoteRows batch-skip details. The structured
+        // skipped[] array lives on the refresh result body; we surface the count
+        // here so console operators don't miss it in CI logs.
+        const partialBatchCount = result.skipped?.length ?? 0;
+        const partialSuffix =
+          result.status === "partial" && partialBatchCount > 0
+            ? ` — ${partialBatchCount} batch(es) skipped on enrichment (see result.skipped[])`
+            : "";
         const summary =
           result.status === "error"
             ? `Refresh completed with ${result.errors.length} error(s): ${result.errors.join("; ")}`
-            : unsupportedCount > 0 || skippedCount > 0
-              ? `Refresh completed for ${asOf} with ${unsupportedCount} unsupported and ${skippedCount} skipped operation(s): ${result.perOperation.spot.length} spot, ${result.perOperation.chain.length} chain, ${result.perOperation.quotes.length} quote operation(s)`
-              : `Refresh complete for ${asOf}: ${result.perOperation.spot.length} spot, ${result.perOperation.chain.length} chain, ${result.perOperation.quotes.length} quote operation(s)`;
+            : unsupportedCount > 0 || skippedOpCount > 0
+              ? `Refresh completed for ${asOf} with ${unsupportedCount} unsupported and ${skippedOpCount} skipped operation(s): ${result.perOperation.spot.length} spot, ${result.perOperation.chain.length} chain, ${result.perOperation.quotes.length} quote operation(s)${partialSuffix}`
+              : `Refresh complete for ${asOf}: ${result.perOperation.spot.length} spot, ${result.perOperation.chain.length} chain, ${result.perOperation.quotes.length} quote operation(s)${partialSuffix}`;
         return createToolOutput(summary, result);
       } finally {
         await downgradeToReadOnly(baseDir);

--- a/packages/mcp-server/src/utils/option-quote-greeks.ts
+++ b/packages/mcp-server/src/utils/option-quote-greeks.ts
@@ -31,6 +31,12 @@ export interface QuoteGreeksStats {
   computedRows: number;
   missingContractRows: number;
   missingUnderlyingRows: number;
+  // Underlying-price lookup succeeded but `computeQuoteGreeks` returned null
+  // (zero/negative option price, corrupt expiration → negative DTE, malformed
+  // strike). Drives the `compute_failure` ingest-skipped reason —
+  // distinguishes BS-math failure from spot/chain coverage gaps so operators
+  // chase the right root cause.
+  mathFailedRows: number;
   unresolvedRows: number;
 }
 
@@ -173,6 +179,7 @@ export function applyQuoteGreeks<T extends QuoteGreekFields>(params: {
     computedRows: 0,
     missingContractRows: 0,
     missingUnderlyingRows: 0,
+    mathFailedRows: 0,
     unresolvedRows: 0,
   };
 
@@ -215,6 +222,7 @@ export function applyQuoteGreeks<T extends QuoteGreekFields>(params: {
       contractType: meta.contract_type,
     });
     if (!greeks) {
+      stats.mathFailedRows++;
       stats.unresolvedRows++;
       continue;
     }

--- a/packages/mcp-server/src/utils/providers/thetadata.ts
+++ b/packages/mcp-server/src/utils/providers/thetadata.ts
@@ -371,14 +371,15 @@ export class ThetaDataProvider implements MarketDataProvider {
             } catch (error) {
               // ThetaData returns NOT_FOUND for (root, expiration, right)
               // combos that have no quotes on this date (e.g., zero-volume
-              // expirations near the current month boundary). Skip the
-              // expiration instead of aborting the whole bulk fetch.
+              // expirations near the current month boundary). Treat as an
+              // empty result and fall through to the per-iteration notify
+              // so the final expiration in a group still emits a
+              // phase="complete" event when it NOT_FOUNDs.
               const msg = error instanceof Error ? error.message : String(error);
-              if (/NOT_FOUND|No data found/i.test(msg)) {
-                completedExpirations += 1;
-                continue;
+              if (!/NOT_FOUND|No data found/i.test(msg)) {
+                throw error;
               }
-              throw error;
+              quotes = [];
             }
             for (const q of quotes) {
               // Drop rows missing bid or ask; the parquet schema is DOUBLE

--- a/packages/mcp-server/tests/unit/market-ingestor-progress.test.ts
+++ b/packages/mcp-server/tests/unit/market-ingestor-progress.test.ts
@@ -45,6 +45,23 @@ describe("MarketIngestor bulk progress reporter", () => {
     conn = await instance.connect();
     await conn.run(`ATTACH ':memory:' AS market`);
     await ensureMarketDataTables(conn);
+    // option_chain is required because enrichQuoteRows reads it for every
+    // (underlying, date) batch — issue #121 removed the .catch(() => [])
+    // swallow that previously hid the missing-table error here. Without
+    // this fixture the per-ticker quote ingest returns "partial".
+    await conn.run(`
+      CREATE TABLE IF NOT EXISTS market.option_chain (
+        underlying      VARCHAR NOT NULL,
+        date            VARCHAR NOT NULL,
+        ticker          VARCHAR NOT NULL,
+        contract_type   VARCHAR NOT NULL,
+        strike          DOUBLE NOT NULL,
+        expiration      VARCHAR NOT NULL,
+        dte             INTEGER NOT NULL,
+        exercise_style  VARCHAR,
+        PRIMARY KEY (underlying, date, ticker)
+      )
+    `);
     await conn.run(`
       CREATE TABLE IF NOT EXISTS market.option_quote_minutes (
         underlying      VARCHAR NOT NULL,

--- a/packages/mcp-server/tests/unit/market-ingestor-progress.test.ts
+++ b/packages/mcp-server/tests/unit/market-ingestor-progress.test.ts
@@ -46,9 +46,9 @@ describe("MarketIngestor bulk progress reporter", () => {
     await conn.run(`ATTACH ':memory:' AS market`);
     await ensureMarketDataTables(conn);
     // option_chain is required because enrichQuoteRows reads it for every
-    // (underlying, date) batch — issue #121 removed the .catch(() => [])
-    // swallow that previously hid the missing-table error here. Without
-    // this fixture the per-ticker quote ingest returns "partial".
+    // (underlying, date) batch — the .catch(() => []) swallow that previously
+    // hid the missing-table error here has been removed. Without this
+    // fixture the per-ticker quote ingest returns "partial".
     await conn.run(`
       CREATE TABLE IF NOT EXISTS market.option_chain (
         underlying      VARCHAR NOT NULL,

--- a/packages/mcp-server/tests/unit/market/ingestor/ingest-quotes.test.ts
+++ b/packages/mcp-server/tests/unit/market/ingestor/ingest-quotes.test.ts
@@ -23,8 +23,24 @@ describe("MarketIngestor.ingestQuotes", () => {
     conn = await instance.connect();
     await conn.run(`ATTACH ':memory:' AS market`);
     await ensureMarketDataTables(conn);
-    // option_quote_minutes is not created by ensureMarketDataTables (it's a Parquet
-    // view in production; tests must create the physical fallback table directly).
+    // option_chain + option_quote_minutes are not created by ensureMarketDataTables
+    // (they're Parquet views in production; tests must create the physical fallback
+    // tables directly). option_chain is required because enrichQuoteRows reads it
+    // for every (underlying, date) batch — issue #121 removed the .catch(() => [])
+    // swallow that previously hid the missing-table error here.
+    await conn.run(`
+      CREATE TABLE IF NOT EXISTS market.option_chain (
+        underlying      VARCHAR NOT NULL,
+        date            VARCHAR NOT NULL,
+        ticker          VARCHAR NOT NULL,
+        contract_type   VARCHAR NOT NULL,
+        strike          DOUBLE NOT NULL,
+        expiration      VARCHAR NOT NULL,
+        dte             INTEGER NOT NULL,
+        exercise_style  VARCHAR,
+        PRIMARY KEY (underlying, date, ticker)
+      )
+    `);
     await conn.run(`
       CREATE TABLE IF NOT EXISTS market.option_quote_minutes (
         underlying      VARCHAR NOT NULL,

--- a/packages/mcp-server/tests/unit/market/ingestor/ingest-quotes.test.ts
+++ b/packages/mcp-server/tests/unit/market/ingestor/ingest-quotes.test.ts
@@ -26,8 +26,8 @@ describe("MarketIngestor.ingestQuotes", () => {
     // option_chain + option_quote_minutes are not created by ensureMarketDataTables
     // (they're Parquet views in production; tests must create the physical fallback
     // tables directly). option_chain is required because enrichQuoteRows reads it
-    // for every (underlying, date) batch — issue #121 removed the .catch(() => [])
-    // swallow that previously hid the missing-table error here.
+    // for every (underlying, date) batch — the .catch(() => []) swallow that
+    // previously hid the missing-table error here has been removed.
     await conn.run(`
       CREATE TABLE IF NOT EXISTS market.option_chain (
         underlying      VARCHAR NOT NULL,

--- a/packages/mcp-server/tests/unit/market/ingestor/refresh.test.ts
+++ b/packages/mcp-server/tests/unit/market/ingestor/refresh.test.ts
@@ -249,6 +249,45 @@ describe("MarketIngestor.refresh", () => {
     rmSync(dataDir, { recursive: true, force: true });
   });
 
+  it("requests minute-resolution spot bars", async () => {
+    // Regression guard: refresh() used to hardcode timespan: "1d" for the
+    // spot ingest, which wrote one daily bar per ticker per date. Every
+    // minute after 09:30 was then left without an underlying-price lookup,
+    // tripping coverage_gap on every option-quote partition. Spot ingest
+    // must always request minute resolution.
+    const calls: Array<{ timespan?: string; multiplier?: number; ticker: string }> = [];
+    const provider: MarketDataProvider = {
+      name: "spy",
+      capabilities: () => ({
+        tradeBars: true, quotes: true, greeks: false,
+        flatFiles: false, bulkByRoot: false, perTicker: true,
+        minuteBars: true, dailyBars: true,
+      }),
+      fetchBars: async (opts) => {
+        calls.push({ timespan: opts.timespan, multiplier: opts.multiplier, ticker: opts.ticker });
+        return [];
+      },
+      fetchOptionSnapshot: async () => emptySnapshot(),
+    };
+    const stores = createMarketStores({ conn, dataDir, parquetMode: false, tickers });
+    const ingestor = new MarketIngestor({
+      stores,
+      dataRoot: dataDir,
+      providerFactory: () => provider,
+    });
+
+    await ingestor.refresh({
+      asOf: "2026-01-05",
+      spotTickers: ["SPX", "QQQ"],
+      computeVixContext: false,
+    });
+
+    expect(calls).toEqual([
+      expect.objectContaining({ ticker: "SPX", timespan: "minute", multiplier: 1 }),
+      expect.objectContaining({ ticker: "QQQ", timespan: "minute", multiplier: 1 }),
+    ]);
+  });
+
   it("runs ingestBars per spot ticker and reports per-operation results", async () => {
     const bars: BarRow[] = [
       { ticker: "SPX", date: "2026-01-05", open: 4800, high: 4820, low: 4790, close: 4810, volume: 0 },

--- a/packages/mcp-server/tests/unit/market/ingestor/refresh.test.ts
+++ b/packages/mcp-server/tests/unit/market/ingestor/refresh.test.ts
@@ -506,7 +506,7 @@ describe("MarketIngestor.refresh", () => {
     warnSpy.mockRestore();
   });
 
-  it("skips the batch with reason=coverage_gap when enrichment reads return empty (issue #167)", async () => {
+  it("skips the batch with reason=coverage_gap when enrichment reads return empty", async () => {
     // Companion to the throw-path test above: enrichQuoteRows succeeds but
     // stores.spot.readBars returns [] (e.g. partial-day spot coverage,
     // missing chain partition). Without the coverage-gap guard, applyQuoteGreeks
@@ -739,7 +739,7 @@ describe("MarketIngestor.refresh", () => {
     writeQuotesSpy.mockRestore();
   });
 
-  it("trips coverage_gap on the per-ticker path when enrichment reads return empty (issue #183)", async () => {
+  it("trips coverage_gap on the per-ticker path when enrichment reads return empty", async () => {
     // Mirror of the bulk-path coverage_gap test on the per-ticker
     // writeQuotesForTicker branch. The per-ticker code path emits its own
     // coverageGapEntry call site; without this test, regressions there would
@@ -828,6 +828,440 @@ describe("MarketIngestor.refresh", () => {
 
     const warnCall = warnSpy.mock.calls.find((call) =>
       typeof call[0] === "string" && call[0].includes("coverage gap"),
+    );
+    expect(warnCall).toBeDefined();
+    warnSpy.mockRestore();
+    writeQuotesSpy.mockRestore();
+  });
+
+  it("trips coverage_gap on the per-ticker path when only the compute-mode subset fails (mixed-source partition)", async () => {
+    // Mirror of the bulk-path mixed-source coverage_gap test on the
+    // per-ticker writeQuotesForTicker branch. The canonical per-ticker
+    // test above covers the every-row-fails shape (1/1 = 1.0 under both
+    // numerators); this case proves the sharpened denominator —
+    // `missingUnderlyingRows / (missingUnderlyingRows + computedRows)` —
+    // also routes through the per-ticker call site. One timestamp carries
+    // full provider greeks (skipped early by applyQuoteGreeks, increments
+    // existingGreeksRows); the other has none (enters compute, hits the
+    // empty underlying-price map, increments missingUnderlyingRows). Old
+    // denominator: 1/2 = 0.5 → does NOT trip. New denominator: 1/1 = 1.0
+    // → DOES trip.
+    const provider: MarketDataProvider = {
+      name: "perticker",
+      capabilities: () => ({
+        tradeBars: true,
+        quotes: true,
+        greeks: false,
+        flatFiles: false,
+        bulkByRoot: false,
+        perTicker: true,
+        minuteBars: true,
+        dailyBars: true,
+      }),
+      fetchBars: async (options) => options.timespan === "minute"
+        ? [
+            { ticker: "SPX", date: "2026-01-05", time: "09:30", open: 4800, high: 4802, low: 4799, close: 4801, volume: 0 },
+          ]
+        : [
+            { ticker: "SPX", date: "2026-01-05", open: 4800, high: 4820, low: 4790, close: 4810, volume: 0 },
+          ],
+      fetchOptionSnapshot: async () => emptySnapshot(),
+      fetchContractList: async () => ({
+        underlying: "SPX",
+        contracts: [
+          {
+            ticker: "SPXW260107C04800000",
+            contract_type: "call",
+            strike: 4800,
+            expiration: "2026-01-07",
+            exercise_style: "european",
+          },
+        ],
+      }),
+      fetchQuotes: async () => new Map([
+        ["2026-01-05 09:30", {
+          bid: 10.0,
+          ask: 10.5,
+          delta: 0.22,
+          gamma: 0.05,
+          theta: -0.12,
+          vega: 0.31,
+          iv: 0.19,
+          greeks_source: "thetadata",
+        }],
+        ["2026-01-05 09:31", { bid: 10.1, ask: 10.6 }],
+      ]),
+    };
+    const stores = createMarketStores({ conn, dataDir, parquetMode: false, tickers });
+    const readBarsSpy = jest.spyOn(stores.spot, "readBars").mockResolvedValue([]);
+    const writeQuotesSpy = jest.spyOn(stores.quote, "writeQuotes");
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const ingestor = new MarketIngestor({
+      stores,
+      dataRoot: dataDir,
+      providerFactory: () => provider,
+    });
+
+    const result = await ingestor.refresh({
+      asOf: "2026-01-05",
+      spotTickers: ["SPX"],
+      chainUnderlyings: ["SPX"],
+      quoteTickers: ["SPXW260107C04800000"],
+      computeVixContext: false,
+    });
+
+    expect(result.status).toBe("partial");
+    expect(result.skipped).toBeDefined();
+    expect(result.skipped).toHaveLength(1);
+    const entry = result.skipped![0];
+    expect(entry).toEqual(expect.objectContaining({
+      underlying: "SPX",
+      date: "2026-01-05",
+      ticker: "SPXW260107C04800000",
+      rows: 2,
+      reason: "coverage_gap",
+    }));
+    // New denominator: 1 compute-mode failure / 1 attempted lookup = 1.0.
+    // Under the old denominator (1/2 = 0.5) this would not have tripped at all.
+    expect(entry.resolveRatio).toBe(1);
+    expect(entry.error).toMatch(/1\/1 rows missing/);
+
+    const quotePartitionWrites = writeQuotesSpy.mock.calls.filter(
+      (call) => call[0] === "SPX" && call[1] === "2026-01-05",
+    );
+    expect(quotePartitionWrites).toHaveLength(0);
+
+    readBarsSpy.mockRestore();
+    const quotes = await stores.quote.readQuotes(["SPXW260107C04800000"], "2026-01-05", "2026-01-05");
+    const row = quotes.get("SPXW260107C04800000")?.[0];
+    expect(row).toBeUndefined();
+
+    const warnCall = warnSpy.mock.calls.find((call) =>
+      typeof call[0] === "string" && call[0].includes("coverage gap"),
+    );
+    expect(warnCall).toBeDefined();
+    warnSpy.mockRestore();
+    writeQuotesSpy.mockRestore();
+  });
+
+  it("trips compute_failure on the bulk path when black-scholes fails after lookup succeeds", async () => {
+    // Coverage gap catches the case where the underlying-price lookup itself
+    // fails. compute_failure closes the sibling failure mode: spot is healthy
+    // and the underlying-price lookup succeeds, but the option data is corrupt
+    // (zero option price, negative DTE, malformed strike) and
+    // `computeQuoteGreeks` returns null for the majority of rows. Without this
+    // guard those rows incremented only `unresolvedRows`, so a single
+    // missing-spot row in the same partition would mis-attribute the entire
+    // failure as `coverage_gap` in the operator log. This test forces the
+    // math-only failure path: spot is pre-seeded, the chain is valid, but
+    // bid=ask=0 drives `optionPrice <= 0` in `computeQuoteGreeks` → null
+    // greeks → the new `mathFailedRows` counter increments and
+    // `computeFailureEntry` trips on
+    // `mathFailedRows / (mathFailedRows + computedRows) = 1/1 = 1.0`.
+    const provider: MarketDataProvider = {
+      name: "bulk",
+      capabilities: () => ({
+        tradeBars: true,
+        quotes: true,
+        greeks: false,
+        flatFiles: false,
+        bulkByRoot: true,
+        perTicker: false,
+        minuteBars: true,
+        dailyBars: true,
+      }),
+      fetchBars: async (options) => options.timespan === "minute"
+        ? [
+            { ticker: "SPX", date: "2026-01-05", time: "09:30", open: 4800, high: 4802, low: 4799, close: 4801, volume: 0 },
+          ]
+        : [
+            { ticker: "SPX", date: "2026-01-05", open: 4800, high: 4820, low: 4790, close: 4810, volume: 0 },
+          ],
+      fetchOptionSnapshot: async () => emptySnapshot(),
+      fetchContractList: async () => ({
+        underlying: "SPX",
+        contracts: [
+          {
+            ticker: "SPXW260107C04800000",
+            contract_type: "call",
+            strike: 4800,
+            expiration: "2026-01-07",
+            exercise_style: "european",
+          },
+        ],
+      }),
+      fetchBulkQuotes: async function* () {
+        // bid=ask=0 → mid=0 → optionPrice<=0 guard in computeQuoteGreeks
+        // returns null. Underlying lookup succeeds (spot pre-seeded at 09:30).
+        yield [
+          { ticker: "SPXW260107C04800000", timestamp: "2026-01-05 09:30", bid: 0, ask: 0 },
+        ];
+      },
+    };
+    const stores = createMarketStores({ conn, dataDir, parquetMode: false, tickers });
+    await stores.spot.writeBars("SPX", "2026-01-05", [
+      { ticker: "SPX", date: "2026-01-05", time: "09:30", open: 4800, high: 4802, low: 4799, close: 4801, volume: 0 },
+    ]);
+    const writeQuotesSpy = jest.spyOn(stores.quote, "writeQuotes");
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const ingestor = new MarketIngestor({
+      stores,
+      dataRoot: dataDir,
+      providerFactory: () => provider,
+    });
+
+    const result = await ingestor.refresh({
+      asOf: "2026-01-05",
+      spotTickers: ["SPX"],
+      chainUnderlyings: ["SPX"],
+      quoteUnderlyings: ["SPX"],
+      computeVixContext: false,
+    });
+
+    expect(result.status).toBe("partial");
+    expect(result.skipped).toBeDefined();
+    expect(result.skipped).toHaveLength(1);
+    const entry = result.skipped![0];
+    expect(entry).toEqual(expect.objectContaining({
+      underlying: "SPX",
+      date: "2026-01-05",
+      rows: 1,
+      reason: "compute_failure",
+    }));
+    expect(entry.resolveRatio).toBe(1);
+    expect(entry.error).toMatch(/compute failure.*black-scholes/);
+    expect(entry.error).toMatch(/1\/1 rows failed/);
+
+    const quotePartitionWrites = writeQuotesSpy.mock.calls.filter(
+      (call) => call[0] === "SPX" && call[1] === "2026-01-05",
+    );
+    expect(quotePartitionWrites).toHaveLength(0);
+
+    const quotes = await stores.quote.readQuotes(["SPXW260107C04800000"], "2026-01-05", "2026-01-05");
+    expect(quotes.get("SPXW260107C04800000")?.[0]).toBeUndefined();
+
+    const warnCall = warnSpy.mock.calls.find((call) =>
+      typeof call[0] === "string" && call[0].includes("compute failure"),
+    );
+    expect(warnCall).toBeDefined();
+    warnSpy.mockRestore();
+    writeQuotesSpy.mockRestore();
+  });
+
+  it("emits both coverage_gap and compute_failure when both failure modes hit the same partition", async () => {
+    // Load-bearing test for the no-dedupe convention (see types.ts on
+    // IngestSkippedReason). When a partition exhibits BOTH failure modes
+    // — some rows fail underlying-price lookup AND some rows clear lookup
+    // but fail black-scholes math — both guards must fire and both entries
+    // must land in skipped[]. Combining them into a single entry would
+    // obscure the second signal from operators chasing root cause; picking
+    // one would mislabel the trip in the operator log. Two rows: one at
+    // 09:30 with bid=ask=0 (spot present, BS math fails — mathFailedRows)
+    // and one at 09:31 (no spot pre-seeded for that minute, underlying
+    // lookup fails — missingUnderlyingRows). Each subset's ratio is 1/1=1.0.
+    const provider: MarketDataProvider = {
+      name: "bulk",
+      capabilities: () => ({
+        tradeBars: true,
+        quotes: true,
+        greeks: false,
+        flatFiles: false,
+        bulkByRoot: true,
+        perTicker: false,
+        minuteBars: true,
+        dailyBars: true,
+      }),
+      fetchBars: async (options) => options.timespan === "minute"
+        ? [
+            { ticker: "SPX", date: "2026-01-05", time: "09:30", open: 4800, high: 4802, low: 4799, close: 4801, volume: 0 },
+          ]
+        : [
+            { ticker: "SPX", date: "2026-01-05", open: 4800, high: 4820, low: 4790, close: 4810, volume: 0 },
+          ],
+      fetchOptionSnapshot: async () => emptySnapshot(),
+      fetchContractList: async () => ({
+        underlying: "SPX",
+        contracts: [
+          {
+            ticker: "SPXW260107C04800000",
+            contract_type: "call",
+            strike: 4800,
+            expiration: "2026-01-07",
+            exercise_style: "european",
+          },
+          {
+            ticker: "SPXW260107C04810000",
+            contract_type: "call",
+            strike: 4810,
+            expiration: "2026-01-07",
+            exercise_style: "european",
+          },
+        ],
+      }),
+      fetchBulkQuotes: async function* () {
+        yield [
+          // BS-math failure: spot pre-seeded at 09:30, but mid=0.
+          { ticker: "SPXW260107C04800000", timestamp: "2026-01-05 09:30", bid: 0, ask: 0 },
+          // Coverage gap: valid mid, but no spot bar at 09:31.
+          { ticker: "SPXW260107C04810000", timestamp: "2026-01-05 09:31", bid: 5.0, ask: 5.5 },
+        ];
+      },
+    };
+    const stores = createMarketStores({ conn, dataDir, parquetMode: false, tickers });
+    // Pre-seed ONLY the 09:30 minute. The 09:31 row's lookup will miss.
+    await stores.spot.writeBars("SPX", "2026-01-05", [
+      { ticker: "SPX", date: "2026-01-05", time: "09:30", open: 4800, high: 4802, low: 4799, close: 4801, volume: 0 },
+    ]);
+    const writeQuotesSpy = jest.spyOn(stores.quote, "writeQuotes");
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const ingestor = new MarketIngestor({
+      stores,
+      dataRoot: dataDir,
+      providerFactory: () => provider,
+    });
+
+    const result = await ingestor.refresh({
+      asOf: "2026-01-05",
+      spotTickers: ["SPX"],
+      chainUnderlyings: ["SPX"],
+      quoteUnderlyings: ["SPX"],
+      computeVixContext: false,
+    });
+
+    expect(result.status).toBe("partial");
+    expect(result.skipped).toBeDefined();
+    expect(result.skipped).toHaveLength(2);
+    const reasons = (result.skipped ?? []).map((s) => s.reason).sort();
+    expect(reasons).toEqual(["compute_failure", "coverage_gap"]);
+
+    const gap = result.skipped!.find((s) => s.reason === "coverage_gap")!;
+    expect(gap).toEqual(expect.objectContaining({
+      underlying: "SPX",
+      date: "2026-01-05",
+      rows: 2,
+    }));
+    expect(gap.resolveRatio).toBe(1);
+    expect(gap.error).toMatch(/coverage gap/);
+
+    const compute = result.skipped!.find((s) => s.reason === "compute_failure")!;
+    expect(compute).toEqual(expect.objectContaining({
+      underlying: "SPX",
+      date: "2026-01-05",
+      rows: 2,
+    }));
+    expect(compute.resolveRatio).toBe(1);
+    expect(compute.error).toMatch(/compute failure.*black-scholes/);
+
+    // Neither guard tripping → write skipped. Both tripping → still skipped.
+    const quotePartitionWrites = writeQuotesSpy.mock.calls.filter(
+      (call) => call[0] === "SPX" && call[1] === "2026-01-05",
+    );
+    expect(quotePartitionWrites).toHaveLength(0);
+
+    const quotes = await stores.quote.readQuotes(
+      ["SPXW260107C04800000", "SPXW260107C04810000"],
+      "2026-01-05",
+      "2026-01-05",
+    );
+    expect(quotes.get("SPXW260107C04800000")?.[0]).toBeUndefined();
+    expect(quotes.get("SPXW260107C04810000")?.[0]).toBeUndefined();
+
+    warnSpy.mockRestore();
+    writeQuotesSpy.mockRestore();
+  });
+
+  it("trips compute_failure on the per-ticker path when black-scholes fails after lookup succeeds", async () => {
+    // Per-ticker mirror of the bulk-path compute_failure test. The
+    // writeQuotesForTicker call site emits its own computeFailureEntry call;
+    // without this test, regressions on that branch would slip past the
+    // bulk-only assertion. Mirrors the structure of the per-ticker
+    // coverage_gap mirrors — same shape, distinct reason channel.
+    const provider: MarketDataProvider = {
+      name: "perticker",
+      capabilities: () => ({
+        tradeBars: true,
+        quotes: true,
+        greeks: false,
+        flatFiles: false,
+        bulkByRoot: false,
+        perTicker: true,
+        minuteBars: true,
+        dailyBars: true,
+      }),
+      fetchBars: async (options) => options.timespan === "minute"
+        ? [
+            { ticker: "SPX", date: "2026-01-05", time: "09:30", open: 4800, high: 4802, low: 4799, close: 4801, volume: 0 },
+          ]
+        : [
+            { ticker: "SPX", date: "2026-01-05", open: 4800, high: 4820, low: 4790, close: 4810, volume: 0 },
+          ],
+      fetchOptionSnapshot: async () => emptySnapshot(),
+      fetchContractList: async () => ({
+        underlying: "SPX",
+        contracts: [
+          {
+            ticker: "SPXW260107C04800000",
+            contract_type: "call",
+            strike: 4800,
+            expiration: "2026-01-07",
+            exercise_style: "european",
+          },
+        ],
+      }),
+      fetchQuotes: async () => new Map([
+        // bid=ask=0 → mid=0 → BS math returns null. Spot is pre-seeded.
+        ["2026-01-05 09:30", { bid: 0, ask: 0 }],
+      ]),
+    };
+    const stores = createMarketStores({ conn, dataDir, parquetMode: false, tickers });
+    await stores.spot.writeBars("SPX", "2026-01-05", [
+      { ticker: "SPX", date: "2026-01-05", time: "09:30", open: 4800, high: 4802, low: 4799, close: 4801, volume: 0 },
+    ]);
+    const writeQuotesSpy = jest.spyOn(stores.quote, "writeQuotes");
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const ingestor = new MarketIngestor({
+      stores,
+      dataRoot: dataDir,
+      providerFactory: () => provider,
+    });
+
+    const result = await ingestor.refresh({
+      asOf: "2026-01-05",
+      spotTickers: ["SPX"],
+      chainUnderlyings: ["SPX"],
+      quoteTickers: ["SPXW260107C04800000"],
+      computeVixContext: false,
+    });
+
+    expect(result.status).toBe("partial");
+    expect(result.skipped).toBeDefined();
+    expect(result.skipped).toHaveLength(1);
+    const entry = result.skipped![0];
+    expect(entry).toEqual(expect.objectContaining({
+      underlying: "SPX",
+      date: "2026-01-05",
+      ticker: "SPXW260107C04800000",
+      rows: 1,
+      reason: "compute_failure",
+    }));
+    expect(entry.resolveRatio).toBe(1);
+    expect(entry.error).toMatch(/compute failure.*black-scholes/);
+    expect(entry.error).toMatch(/1\/1 rows failed/);
+
+    const quotePartitionWrites = writeQuotesSpy.mock.calls.filter(
+      (call) => call[0] === "SPX" && call[1] === "2026-01-05",
+    );
+    expect(quotePartitionWrites).toHaveLength(0);
+
+    const quotes = await stores.quote.readQuotes(["SPXW260107C04800000"], "2026-01-05", "2026-01-05");
+    expect(quotes.get("SPXW260107C04800000")?.[0]).toBeUndefined();
+
+    const warnCall = warnSpy.mock.calls.find((call) =>
+      typeof call[0] === "string" && call[0].includes("compute failure"),
     );
     expect(warnCall).toBeDefined();
     warnSpy.mockRestore();

--- a/packages/mcp-server/tests/unit/market/ingestor/refresh.test.ts
+++ b/packages/mcp-server/tests/unit/market/ingestor/refresh.test.ts
@@ -395,14 +395,115 @@ describe("MarketIngestor.refresh", () => {
     const quotes = await stores.quote.readQuotes(["SPXW260107C04800000"], "2026-01-05", "2026-01-05");
     const row = quotes.get("SPXW260107C04800000")?.[0];
     expect(row).toEqual(expect.objectContaining({
+      bid: 10,
+      ask: 10.5,
+      timestamp: "2026-01-05 09:30",
       greeks_source: "computed",
       greeks_revision: 3,
+      rate_type: "sofr",
+      rate_value: expect.any(Number),
+      gamma_source: "computed_sofr_q0",
     }));
+    expect(row?.rate_value).toBeGreaterThan(0);
+    expect(row?.rate_value).toBeLessThan(0.1);
     expect(row?.delta).not.toBeNull();
     expect(row?.gamma).not.toBeNull();
     expect(row?.theta).not.toBeNull();
     expect(row?.vega).not.toBeNull();
     expect(row?.iv).not.toBeNull();
+  });
+
+  it("logs and skips the batch when enrichQuoteRows reads fail (no silent null-greeks persist)", async () => {
+    const provider: MarketDataProvider = {
+      name: "bulk",
+      capabilities: () => ({
+        tradeBars: true,
+        quotes: true,
+        greeks: false,
+        flatFiles: false,
+        bulkByRoot: true,
+        perTicker: false,
+        minuteBars: true,
+        dailyBars: true,
+      }),
+      fetchBars: async (options) => options.timespan === "minute"
+        ? [
+            { ticker: "SPX", date: "2026-01-05", time: "09:30", open: 4800, high: 4802, low: 4799, close: 4801, volume: 0 },
+          ]
+        : [
+            { ticker: "SPX", date: "2026-01-05", open: 4800, high: 4820, low: 4790, close: 4810, volume: 0 },
+          ],
+      fetchOptionSnapshot: async () => emptySnapshot(),
+      fetchContractList: async () => ({
+        underlying: "SPX",
+        contracts: [
+          {
+            ticker: "SPXW260107C04800000",
+            contract_type: "call",
+            strike: 4800,
+            expiration: "2026-01-07",
+            exercise_style: "european",
+          },
+        ],
+      }),
+      fetchBulkQuotes: async function* () {
+        yield [
+          { ticker: "SPXW260107C04800000", timestamp: "2026-01-05 09:30", bid: 10.0, ask: 10.5 },
+        ];
+      },
+    };
+    const stores = createMarketStores({ conn, dataDir, parquetMode: false, tickers });
+    // Force the enrichment read to fail. Previously this would be swallowed
+    // by .catch(() => []) in enrichQuoteRows and a row with intact bid/ask
+    // but null greeks would silently persist. The fix surfaces the error:
+    // the batch logs a structured warning and is skipped (no row persisted).
+    const readChainSpy = jest.spyOn(stores.chain, "readChain").mockImplementation(async () => {
+      throw new Error("simulated transient DuckDB flake");
+    });
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const ingestor = new MarketIngestor({
+      stores,
+      dataRoot: dataDir,
+      providerFactory: () => provider,
+    });
+
+    const result = await ingestor.refresh({
+      asOf: "2026-01-05",
+      spotTickers: ["SPX"],
+      chainUnderlyings: ["SPX"],
+      quoteUnderlyings: ["SPX"],
+      computeVixContext: false,
+    });
+
+    // Partial-status is the load-bearing signal; warn is supplementary.
+    expect(result.status).toBe("partial");
+    expect(result.skipped).toBeDefined();
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped![0]).toEqual(expect.objectContaining({
+      underlying: "SPX",
+      date: "2026-01-05",
+      rows: 1,
+      error: "simulated transient DuckDB flake",
+    }));
+    // Restore the real chain reader so the post-condition read isn't itself broken.
+    readChainSpy.mockRestore();
+    const quotes = await stores.quote.readQuotes(["SPXW260107C04800000"], "2026-01-05", "2026-01-05");
+    const row = quotes.get("SPXW260107C04800000")?.[0];
+    // The batch must be skipped — no row with null greeks persisted.
+    expect(row).toBeUndefined();
+    // The structured warn is still emitted for live tail-following.
+    const warnCall = warnSpy.mock.calls.find((call) =>
+      typeof call[0] === "string" && call[0].includes("enrichQuoteRows failed"),
+    );
+    expect(warnCall).toBeDefined();
+    const ctx = warnCall![1] as Record<string, unknown>;
+    expect(ctx).toEqual(expect.objectContaining({
+      underlying: "SPX",
+      date: "2026-01-05",
+      error: "simulated transient DuckDB flake",
+    }));
+    warnSpy.mockRestore();
   });
 
   it("persists provider minute greeks inline when bulk quotes already carry them", async () => {

--- a/packages/mcp-server/tests/unit/market/ingestor/refresh.test.ts
+++ b/packages/mcp-server/tests/unit/market/ingestor/refresh.test.ts
@@ -506,6 +506,110 @@ describe("MarketIngestor.refresh", () => {
     warnSpy.mockRestore();
   });
 
+  it("skips the batch with reason=coverage_gap when enrichment reads return empty (issue #167)", async () => {
+    // Companion to the throw-path test above: enrichQuoteRows succeeds but
+    // stores.spot.readBars returns [] (e.g. partial-day spot coverage,
+    // missing chain partition). Without the coverage-gap guard, applyQuoteGreeks
+    // would resolve no underlying prices, every row would increment
+    // missingUnderlyingRows, and the batch would silently persist with
+    // intact bid/ask but null greeks. The fix surfaces this as a distinct
+    // reason="coverage_gap" skipped[] entry and refuses to write.
+    const provider: MarketDataProvider = {
+      name: "bulk",
+      capabilities: () => ({
+        tradeBars: true,
+        quotes: true,
+        greeks: false,
+        flatFiles: false,
+        bulkByRoot: true,
+        perTicker: false,
+        minuteBars: true,
+        dailyBars: true,
+      }),
+      fetchBars: async (options) => options.timespan === "minute"
+        ? [
+            { ticker: "SPX", date: "2026-01-05", time: "09:30", open: 4800, high: 4802, low: 4799, close: 4801, volume: 0 },
+          ]
+        : [
+            { ticker: "SPX", date: "2026-01-05", open: 4800, high: 4820, low: 4790, close: 4810, volume: 0 },
+          ],
+      fetchOptionSnapshot: async () => emptySnapshot(),
+      fetchContractList: async () => ({
+        underlying: "SPX",
+        contracts: [
+          {
+            ticker: "SPXW260107C04800000",
+            contract_type: "call",
+            strike: 4800,
+            expiration: "2026-01-07",
+            exercise_style: "european",
+          },
+        ],
+      }),
+      fetchBulkQuotes: async function* () {
+        yield [
+          { ticker: "SPXW260107C04800000", timestamp: "2026-01-05 09:30", bid: 10.0, ask: 10.5 },
+        ];
+      },
+    };
+    const stores = createMarketStores({ conn, dataDir, parquetMode: false, tickers });
+    // Force the spot read to return empty rows for the enrichment lookup.
+    // The provider still writes daily/minute spot bars upstream of this point
+    // (refresh.spot ingest), but the in-memory readBars used by enrichQuoteRows
+    // is intercepted to simulate the coverage-gap scenario.
+    const readBarsSpy = jest.spyOn(stores.spot, "readBars").mockResolvedValue([]);
+    const writeQuotesSpy = jest.spyOn(stores.quote, "writeQuotes");
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const ingestor = new MarketIngestor({
+      stores,
+      dataRoot: dataDir,
+      providerFactory: () => provider,
+    });
+
+    const result = await ingestor.refresh({
+      asOf: "2026-01-05",
+      spotTickers: ["SPX"],
+      chainUnderlyings: ["SPX"],
+      quoteUnderlyings: ["SPX"],
+      computeVixContext: false,
+    });
+
+    expect(result.status).toBe("partial");
+    expect(result.skipped).toBeDefined();
+    expect(result.skipped).toHaveLength(1);
+    const entry = result.skipped![0];
+    expect(entry).toEqual(expect.objectContaining({
+      underlying: "SPX",
+      date: "2026-01-05",
+      rows: 1,
+      reason: "coverage_gap",
+    }));
+    expect(typeof entry.resolveRatio).toBe("number");
+    expect(entry.resolveRatio).toBeGreaterThan(0.5);
+    expect(entry.resolveRatio).toBeLessThanOrEqual(1);
+    expect(entry.error).toMatch(/coverage gap/);
+
+    // writeQuotes must NOT have been called for the affected partition —
+    // that's the whole point: we refuse to persist null-greeks rows.
+    const quotePartitionWrites = writeQuotesSpy.mock.calls.filter(
+      (call) => call[0] === "SPX" && call[1] === "2026-01-05",
+    );
+    expect(quotePartitionWrites).toHaveLength(0);
+
+    readBarsSpy.mockRestore();
+    const quotes = await stores.quote.readQuotes(["SPXW260107C04800000"], "2026-01-05", "2026-01-05");
+    const row = quotes.get("SPXW260107C04800000")?.[0];
+    expect(row).toBeUndefined();
+
+    const warnCall = warnSpy.mock.calls.find((call) =>
+      typeof call[0] === "string" && call[0].includes("coverage gap"),
+    );
+    expect(warnCall).toBeDefined();
+    warnSpy.mockRestore();
+    writeQuotesSpy.mockRestore();
+  });
+
   it("persists provider minute greeks inline when bulk quotes already carry them", async () => {
     const provider: MarketDataProvider = {
       name: "thetadata",

--- a/packages/mcp-server/tests/unit/market/ingestor/refresh.test.ts
+++ b/packages/mcp-server/tests/unit/market/ingestor/refresh.test.ts
@@ -610,6 +610,230 @@ describe("MarketIngestor.refresh", () => {
     writeQuotesSpy.mockRestore();
   });
 
+  it("trips coverage_gap on the bulk path when only the compute-mode subset fails (mixed-source partition)", async () => {
+    // The empty-read case where every row needs compute and every row fails
+    // is one mode; this test covers the proportional leak: when a partition
+    // has rows with provider-supplied greeks (skipped by applyQuoteGreeks
+    // early) AND compute-mode rows that all fail underlying lookup, the old
+    // `missingUnderlyingRows / rowsVisited` denominator diluted the failure
+    // ratio below the 0.5 trip line. With the corrected
+    // `missingUnderlyingRows / (missingUnderlyingRows + computedRows)`
+    // denominator, the ratio reflects "of rows that tried to compute, what
+    // fraction failed" — here 1/1 = 1.0, well above the 0.5 threshold.
+    const provider: MarketDataProvider = {
+      name: "bulk",
+      capabilities: () => ({
+        tradeBars: true,
+        quotes: true,
+        greeks: false,
+        flatFiles: false,
+        bulkByRoot: true,
+        perTicker: false,
+        minuteBars: true,
+        dailyBars: true,
+      }),
+      fetchBars: async (options) => options.timespan === "minute"
+        ? [
+            { ticker: "SPX", date: "2026-01-05", time: "09:30", open: 4800, high: 4802, low: 4799, close: 4801, volume: 0 },
+          ]
+        : [
+            { ticker: "SPX", date: "2026-01-05", open: 4800, high: 4820, low: 4790, close: 4810, volume: 0 },
+          ],
+      fetchOptionSnapshot: async () => emptySnapshot(),
+      fetchContractList: async () => ({
+        underlying: "SPX",
+        contracts: [
+          {
+            ticker: "SPXW260107C04800000",
+            contract_type: "call",
+            strike: 4800,
+            expiration: "2026-01-07",
+            exercise_style: "european",
+          },
+          {
+            ticker: "SPXW260107C04810000",
+            contract_type: "call",
+            strike: 4810,
+            expiration: "2026-01-07",
+            exercise_style: "european",
+          },
+        ],
+      }),
+      fetchBulkQuotes: async function* () {
+        // One row carries full provider greeks (skipped by applyQuoteGreeks early,
+        // increments existingGreeksRows). The other row has none (enters the
+        // compute branch, hits the empty underlying-price map, increments
+        // missingUnderlyingRows). Old denominator: 1/2 = 0.5 → does NOT trip.
+        // New denominator: 1/1 = 1.0 → DOES trip.
+        yield [
+          {
+            ticker: "SPXW260107C04800000",
+            timestamp: "2026-01-05 09:30",
+            bid: 10.0,
+            ask: 10.5,
+            delta: 0.22,
+            gamma: 0.05,
+            theta: -0.12,
+            vega: 0.31,
+            iv: 0.19,
+            greeks_source: "thetadata",
+          },
+          {
+            ticker: "SPXW260107C04810000",
+            timestamp: "2026-01-05 09:30",
+            bid: 5.0,
+            ask: 5.5,
+          },
+        ];
+      },
+    };
+    const stores = createMarketStores({ conn, dataDir, parquetMode: false, tickers });
+    const readBarsSpy = jest.spyOn(stores.spot, "readBars").mockResolvedValue([]);
+    const writeQuotesSpy = jest.spyOn(stores.quote, "writeQuotes");
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const ingestor = new MarketIngestor({
+      stores,
+      dataRoot: dataDir,
+      providerFactory: () => provider,
+    });
+
+    const result = await ingestor.refresh({
+      asOf: "2026-01-05",
+      spotTickers: ["SPX"],
+      chainUnderlyings: ["SPX"],
+      quoteUnderlyings: ["SPX"],
+      computeVixContext: false,
+    });
+
+    expect(result.status).toBe("partial");
+    expect(result.skipped).toBeDefined();
+    expect(result.skipped).toHaveLength(1);
+    const entry = result.skipped![0];
+    expect(entry).toEqual(expect.objectContaining({
+      underlying: "SPX",
+      date: "2026-01-05",
+      rows: 2,
+      reason: "coverage_gap",
+    }));
+    // New denominator: 1 compute-mode failure / 1 attempted lookup = 1.0.
+    // Under the old denominator (1/2 = 0.5) this would not have tripped at all.
+    expect(entry.resolveRatio).toBe(1);
+    expect(entry.error).toMatch(/1\/1 rows missing/);
+
+    const quotePartitionWrites = writeQuotesSpy.mock.calls.filter(
+      (call) => call[0] === "SPX" && call[1] === "2026-01-05",
+    );
+    expect(quotePartitionWrites).toHaveLength(0);
+
+    readBarsSpy.mockRestore();
+    const quotes = await stores.quote.readQuotes(
+      ["SPXW260107C04800000", "SPXW260107C04810000"],
+      "2026-01-05",
+      "2026-01-05",
+    );
+    expect(quotes.get("SPXW260107C04800000")?.[0]).toBeUndefined();
+    expect(quotes.get("SPXW260107C04810000")?.[0]).toBeUndefined();
+
+    warnSpy.mockRestore();
+    writeQuotesSpy.mockRestore();
+  });
+
+  it("trips coverage_gap on the per-ticker path when enrichment reads return empty (issue #183)", async () => {
+    // Mirror of the bulk-path coverage_gap test on the per-ticker
+    // writeQuotesForTicker branch. The per-ticker code path emits its own
+    // coverageGapEntry call site; without this test, regressions there would
+    // slip through the bulk-only assertions. Uses fetchQuotes (per-ticker)
+    // rather than fetchBulkQuotes, routed via quoteTickers on refresh.
+    const provider: MarketDataProvider = {
+      name: "perticker",
+      capabilities: () => ({
+        tradeBars: true,
+        quotes: true,
+        greeks: false,
+        flatFiles: false,
+        bulkByRoot: false,
+        perTicker: true,
+        minuteBars: true,
+        dailyBars: true,
+      }),
+      fetchBars: async (options) => options.timespan === "minute"
+        ? [
+            { ticker: "SPX", date: "2026-01-05", time: "09:30", open: 4800, high: 4802, low: 4799, close: 4801, volume: 0 },
+          ]
+        : [
+            { ticker: "SPX", date: "2026-01-05", open: 4800, high: 4820, low: 4790, close: 4810, volume: 0 },
+          ],
+      fetchOptionSnapshot: async () => emptySnapshot(),
+      fetchContractList: async () => ({
+        underlying: "SPX",
+        contracts: [
+          {
+            ticker: "SPXW260107C04800000",
+            contract_type: "call",
+            strike: 4800,
+            expiration: "2026-01-07",
+            exercise_style: "european",
+          },
+        ],
+      }),
+      fetchQuotes: async () => new Map([
+        ["2026-01-05 09:30", { bid: 10.0, ask: 10.5 }],
+      ]),
+    };
+    const stores = createMarketStores({ conn, dataDir, parquetMode: false, tickers });
+    const readBarsSpy = jest.spyOn(stores.spot, "readBars").mockResolvedValue([]);
+    const writeQuotesSpy = jest.spyOn(stores.quote, "writeQuotes");
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    const ingestor = new MarketIngestor({
+      stores,
+      dataRoot: dataDir,
+      providerFactory: () => provider,
+    });
+
+    const result = await ingestor.refresh({
+      asOf: "2026-01-05",
+      spotTickers: ["SPX"],
+      chainUnderlyings: ["SPX"],
+      quoteTickers: ["SPXW260107C04800000"],
+      computeVixContext: false,
+    });
+
+    expect(result.status).toBe("partial");
+    expect(result.skipped).toBeDefined();
+    expect(result.skipped).toHaveLength(1);
+    const entry = result.skipped![0];
+    expect(entry).toEqual(expect.objectContaining({
+      underlying: "SPX",
+      date: "2026-01-05",
+      ticker: "SPXW260107C04800000",
+      rows: 1,
+      reason: "coverage_gap",
+    }));
+    expect(typeof entry.resolveRatio).toBe("number");
+    expect(entry.resolveRatio).toBeGreaterThan(0.5);
+    expect(entry.resolveRatio).toBeLessThanOrEqual(1);
+    expect(entry.error).toMatch(/coverage gap/);
+
+    const quotePartitionWrites = writeQuotesSpy.mock.calls.filter(
+      (call) => call[0] === "SPX" && call[1] === "2026-01-05",
+    );
+    expect(quotePartitionWrites).toHaveLength(0);
+
+    readBarsSpy.mockRestore();
+    const quotes = await stores.quote.readQuotes(["SPXW260107C04800000"], "2026-01-05", "2026-01-05");
+    const row = quotes.get("SPXW260107C04800000")?.[0];
+    expect(row).toBeUndefined();
+
+    const warnCall = warnSpy.mock.calls.find((call) =>
+      typeof call[0] === "string" && call[0].includes("coverage gap"),
+    );
+    expect(warnCall).toBeDefined();
+    warnSpy.mockRestore();
+    writeQuotesSpy.mockRestore();
+  });
+
   it("persists provider minute greeks inline when bulk quotes already carry them", async () => {
     const provider: MarketDataProvider = {
       name: "thetadata",

--- a/packages/mcp-server/tests/unit/market/stores/chain-sql.test.ts
+++ b/packages/mcp-server/tests/unit/market/stores/chain-sql.test.ts
@@ -3,7 +3,7 @@
  *
  * The chain builder targets a single underlying + date partition. Values are
  * inlined as SQL literals to bypass the DuckDB `extract_statements` GC leak
- * (see `spot-sql.ts` header / `feedback_duckdb_extract_statements_leak.md`).
+ * (see `spot-sql.ts` header).
  */
 import { describe, it, expect } from "@jest/globals";
 import { buildReadChainSQL } from "../../../../src/test-exports.js";

--- a/packages/mcp-server/tests/unit/market/stores/chain-sql.test.ts
+++ b/packages/mcp-server/tests/unit/market/stores/chain-sql.test.ts
@@ -1,19 +1,24 @@
 /**
  * Unit tests for chain SQL builder (Phase 2 Wave 1 — Plan 02-01).
  *
- * The chain builder is a single underlying + single date read (one partition
- * per call). Verifies positional parameter binding and column projection.
+ * The chain builder targets a single underlying + date partition. Values are
+ * inlined as SQL literals to bypass the DuckDB `extract_statements` GC leak
+ * (see `spot-sql.ts` header / `feedback_duckdb_extract_statements_leak.md`).
  */
 import { describe, it, expect } from "@jest/globals";
 import { buildReadChainSQL } from "../../../../src/test-exports.js";
 
 describe("buildReadChainSQL", () => {
-  it("queries market.option_chain with positional underlying/date params", () => {
-    const { sql, params } = buildReadChainSQL("SPX", "2025-01-06");
+  it("queries market.option_chain with inlined underlying/date literals", () => {
+    const { sql } = buildReadChainSQL("SPX", "2025-01-06");
     expect(sql).toContain("FROM market.option_chain");
-    expect(sql).toContain("WHERE underlying = $1");
-    expect(sql).toContain("AND date = $2");
-    expect(params).toEqual(["SPX", "2025-01-06"]);
+    expect(sql).toContain("underlying = 'SPX'");
+    expect(sql).toContain("AND date = '2025-01-06'");
+  });
+
+  it("emits no positional placeholders (leak-free runAndReadAll path)", () => {
+    const { sql } = buildReadChainSQL("SPX", "2025-01-06");
+    expect(sql).not.toMatch(/\$\d/);
   });
 
   it("projects the contract columns the ContractRow shape expects", () => {
@@ -38,8 +43,14 @@ describe("buildReadChainSQL", () => {
   });
 
   it("handles non-SPX underlyings without SPX-specific hardcoding", () => {
-    const { sql, params } = buildReadChainSQL("QQQ", "2025-06-20");
+    const { sql } = buildReadChainSQL("QQQ", "2025-06-20");
     expect(sql).toContain("FROM market.option_chain");
-    expect(params).toEqual(["QQQ", "2025-06-20"]);
+    expect(sql).toContain("underlying = 'QQQ'");
+    expect(sql).toContain("AND date = '2025-06-20'");
+  });
+
+  it("escapes embedded single quotes in inputs", () => {
+    const { sql } = buildReadChainSQL("Q'Q", "2025-01-06");
+    expect(sql).toContain("underlying = 'Q''Q'");
   });
 });

--- a/packages/mcp-server/tests/unit/market/stores/enriched-sql.test.ts
+++ b/packages/mcp-server/tests/unit/market/stores/enriched-sql.test.ts
@@ -2,7 +2,9 @@
  * Unit tests for enriched SQL builder (Phase 2 Wave 1 — Plan 02-01).
  *
  * Confirms the four include-flag combinations emit the correct set of
- * JOINs + columns without ever changing the positional parameters.
+ * JOINs + columns. Values are inlined as SQL literals (no positional
+ * placeholders) — see `spot-sql.ts` header for the extract_statements
+ * GC leak rationale.
  */
 import { describe, it, expect } from "@jest/globals";
 import { buildReadEnrichedSQL } from "../../../../src/test-exports.js";
@@ -10,16 +12,16 @@ import { buildReadEnrichedSQL } from "../../../../src/test-exports.js";
 describe("buildReadEnrichedSQL", () => {
   const base = { ticker: "SPX", from: "2025-01-01", to: "2025-01-06" } as const;
 
-  it("queries market.enriched aliased as `e` and orders by date", () => {
+  it("queries market.enriched aliased as `e` with inlined literals and orders by date", () => {
     const { sql } = buildReadEnrichedSQL({ ...base, includeOhlcv: false, includeContext: false });
     expect(sql).toContain("FROM market.enriched e");
-    expect(sql).toContain("WHERE e.ticker = $1");
-    expect(sql).toContain("e.date >= $2");
-    expect(sql).toContain("e.date <= $3");
+    expect(sql).toContain("e.ticker = 'SPX'");
+    expect(sql).toContain("e.date >= '2025-01-01'");
+    expect(sql).toContain("e.date <= '2025-01-06'");
     expect(sql).toContain("ORDER BY e.date");
   });
 
-  it("always binds exactly [ticker, from, to] regardless of include flags", () => {
+  it("inlines [ticker, from, to] in every include-flag variant", () => {
     const variants = [
       { includeOhlcv: false, includeContext: false },
       { includeOhlcv: true, includeContext: false },
@@ -28,8 +30,11 @@ describe("buildReadEnrichedSQL", () => {
     ] as const;
 
     for (const v of variants) {
-      const { params } = buildReadEnrichedSQL({ ...base, ...v });
-      expect(params).toEqual(["SPX", "2025-01-01", "2025-01-06"]);
+      const { sql } = buildReadEnrichedSQL({ ...base, ...v });
+      expect(sql).toContain("'SPX'");
+      expect(sql).toContain("'2025-01-01'");
+      expect(sql).toContain("'2025-01-06'");
+      expect(sql).not.toMatch(/\$\d/);
     }
   });
 
@@ -79,17 +84,16 @@ describe("buildReadEnrichedSQL", () => {
     expect(sql).toContain("c.Vol_Regime");
   });
 
-  it("reuses $1/$2/$3 inside the OHLCV subquery (does not duplicate params)", () => {
-    const { sql, params } = buildReadEnrichedSQL({
+  it("inlines the same ticker/date literals inside the OHLCV subquery", () => {
+    const { sql } = buildReadEnrichedSQL({
       ...base,
       includeOhlcv: true,
       includeContext: false,
     });
-    // The subquery and outer WHERE must both reference $1/$2/$3; no $4.
-    expect(sql).toContain("$1");
-    expect(sql).toContain("$2");
-    expect(sql).toContain("$3");
-    expect(sql).not.toContain("$4");
-    expect(params).toEqual(["SPX", "2025-01-01", "2025-01-06"]);
+    // Subquery and outer WHERE both reference inlined values; no positional params anywhere.
+    expect(sql).not.toMatch(/\$\d/);
+    // The inlined literals appear at least twice (outer + inner) when OHLCV is included.
+    const tickerMatches = sql.match(/'SPX'/g) ?? [];
+    expect(tickerMatches.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/packages/mcp-server/tests/unit/market/stores/quote-sql.test.ts
+++ b/packages/mcp-server/tests/unit/market/stores/quote-sql.test.ts
@@ -1,47 +1,49 @@
 /**
  * Unit tests for quote SQL builder (Phase 2 Wave 1 — Plan 02-01).
  *
- * The quote builder emits a multi-ticker IN (...) clause with positional
- * placeholders. Tests exercise placeholder math (N=1, N=2, N=5), empty-array
- * guard, and params ordering.
+ * The quote builder emits a multi-ticker IN (...) clause with inlined SQL
+ * literals (no positional placeholders — see `spot-sql.ts` header for the
+ * extract_statements GC leak rationale).
  */
 import { describe, it, expect } from "@jest/globals";
 import { buildReadQuotesSQL } from "../../../../src/test-exports.js";
 
 describe("buildReadQuotesSQL", () => {
-  it("queries market.option_quote_minutes and filters underlying + date range", () => {
-    const { sql, params } = buildReadQuotesSQL(
+  it("queries market.option_quote_minutes with inlined underlying + date range", () => {
+    const { sql } = buildReadQuotesSQL(
       "SPX",
       ["SPXW251219C05000000"],
       "2025-01-01",
       "2025-01-02",
     );
     expect(sql).toContain("FROM market.option_quote_minutes");
-    expect(sql).toContain("WHERE underlying = $1");
-    expect(sql).toContain("date >= $2");
-    expect(sql).toContain("date <= $3");
-    expect(sql).toContain("ticker IN ($4)");
-    expect(params).toEqual(["SPX", "2025-01-01", "2025-01-02", "SPXW251219C05000000"]);
+    expect(sql).toContain("underlying = 'SPX'");
+    expect(sql).toContain("date >= '2025-01-01'");
+    expect(sql).toContain("date <= '2025-01-02'");
+    expect(sql).toContain("ticker IN ('SPXW251219C05000000')");
   });
 
-  it("emits positional placeholders $4 and $5 for two OCC tickers", () => {
-    const { sql, params } = buildReadQuotesSQL(
+  it("emits no positional placeholders (leak-free runAndReadAll path)", () => {
+    const { sql } = buildReadQuotesSQL(
       "SPX",
       ["SPXW251219C05000000", "SPXW251219P05000000"],
       "2025-01-01",
       "2025-01-02",
     );
-    expect(sql).toContain("ticker IN ($4, $5)");
-    expect(params).toEqual([
-      "SPX",
-      "2025-01-01",
-      "2025-01-02",
-      "SPXW251219C05000000",
-      "SPXW251219P05000000",
-    ]);
+    expect(sql).not.toMatch(/\$\d/);
   });
 
-  it("scales placeholders correctly for a five-ticker basket", () => {
+  it("inlines a comma-separated IN list for a two-ticker basket", () => {
+    const { sql } = buildReadQuotesSQL(
+      "SPX",
+      ["SPXW251219C05000000", "SPXW251219P05000000"],
+      "2025-01-01",
+      "2025-01-02",
+    );
+    expect(sql).toContain("ticker IN ('SPXW251219C05000000', 'SPXW251219P05000000')");
+  });
+
+  it("scales the IN list correctly for a five-ticker basket", () => {
     const occTickers = [
       "SPXW251219C05000000",
       "SPXW251219C05100000",
@@ -49,9 +51,11 @@ describe("buildReadQuotesSQL", () => {
       "SPXW251219P04900000",
       "SPXW251219P04800000",
     ];
-    const { sql, params } = buildReadQuotesSQL("SPX", occTickers, "2025-01-01", "2025-01-02");
-    expect(sql).toContain("ticker IN ($4, $5, $6, $7, $8)");
-    expect(params).toEqual(["SPX", "2025-01-01", "2025-01-02", ...occTickers]);
+    const { sql } = buildReadQuotesSQL("SPX", occTickers, "2025-01-01", "2025-01-02");
+    for (const t of occTickers) {
+      expect(sql).toContain(`'${t}'`);
+    }
+    expect(sql).toContain("ticker IN (");
   });
 
   it("orders results by (ticker, date, time) for grouped-series consumers", () => {
@@ -65,6 +69,29 @@ describe("buildReadQuotesSQL", () => {
       expect(sql).toContain(col);
     }
   });
+
+  it("projects quote rate and gamma provenance columns after greek provenance", () => {
+    const { sql } = buildReadQuotesSQL("SPX", ["SPXW251219C05000000"], "2025-01-01", "2025-01-02");
+    const normalized = sql.replace(/\s+/g, " ");
+
+    expect(normalized).toContain(
+      "greeks_source, greeks_revision, rate_type, rate_value, gamma_source",
+    );
+    expect(sql).toContain("FROM market.option_quote_minutes");
+  });
+
+  it("inlines an optional time-window filter when timeStart/timeEnd are supplied", () => {
+    const { sql } = buildReadQuotesSQL(
+      "SPX",
+      ["SPXW251219C05000000"],
+      "2025-01-01",
+      "2025-01-02",
+      { timeStart: "09:30", timeEnd: "09:35" },
+    );
+    expect(sql).toContain("time >= '09:30'");
+    expect(sql).toContain("time <= '09:35'");
+  });
+
 
   it("throws when occTickers is empty (avoids emitting invalid `ticker IN ()`)", () => {
     expect(() => buildReadQuotesSQL("SPX", [], "2025-01-01", "2025-01-02")).toThrow(

--- a/packages/mcp-server/tests/unit/market/stores/spot-sql.test.ts
+++ b/packages/mcp-server/tests/unit/market/stores/spot-sql.test.ts
@@ -1,9 +1,15 @@
 /**
  * Unit tests for spot SQL builders (Phase 2 Wave 1 — Plan 02-01).
  *
- * These builders are pure: they emit `{ sql, params }` and never touch a
- * DuckDB connection. Tests therefore exercise string assertions and
- * positional-parameter equality only — no fixture is instantiated.
+ * These builders are pure: they emit `{ sql }` with all values inlined as
+ * SQL literals. Tests therefore exercise literal-presence assertions on the
+ * emitted string — no fixture, no connection.
+ *
+ * Why inline literals: the DuckDB Node-API binding leaks C++ handles on every
+ * `runAndReadAll(sql, params)` call (see `spot-sql.ts` header / project
+ * memory `feedback_duckdb_extract_statements_leak.md`). The builders moved
+ * off positional params on 2026-05-19 (issue #121) to kill the leak at the
+ * source.
  */
 import { describe, it, expect } from "@jest/globals";
 import {
@@ -14,13 +20,17 @@ import {
 
 describe("spot-sql builders", () => {
   describe("buildReadBarsSQL", () => {
-    it("binds ticker/from/to positionally and queries market.spot", () => {
-      const { sql, params } = buildReadBarsSQL("SPX", "2025-01-01", "2025-01-06");
+    it("queries market.spot with inlined ticker/from/to literals", () => {
+      const { sql } = buildReadBarsSQL("SPX", "2025-01-01", "2025-01-06");
       expect(sql).toContain("FROM market.spot");
-      expect(sql).toContain("WHERE ticker = $1");
-      expect(sql).toContain("date >= $2");
-      expect(sql).toContain("date <= $3");
-      expect(params).toEqual(["SPX", "2025-01-01", "2025-01-06"]);
+      expect(sql).toContain("ticker = 'SPX'");
+      expect(sql).toContain("date >= '2025-01-01'");
+      expect(sql).toContain("date <= '2025-01-06'");
+    });
+
+    it("emits no positional placeholders (leak-free runAndReadAll path)", () => {
+      const { sql } = buildReadBarsSQL("SPX", "2025-01-01", "2025-01-06");
+      expect(sql).not.toMatch(/\$\d/);
     });
 
     it("orders results deterministically by (date, time)", () => {
@@ -34,6 +44,12 @@ describe("spot-sql builders", () => {
       for (const col of ["ticker", "date", "time", "open", "high", "low", "close", "bid", "ask"]) {
         expect(sql).toContain(col);
       }
+    });
+
+    it("escapes embedded single quotes in ticker/date inputs", () => {
+      const { sql } = buildReadBarsSQL("SP'X", "2025-01-01", "2025-01-06");
+      expect(sql).toContain("ticker = 'SP''X'");
+      expect(sql).not.toMatch(/\$\d/);
     });
   });
 
@@ -49,35 +65,42 @@ describe("spot-sql builders", () => {
     });
 
     it("groups by ticker/date and filters to the RTH window", () => {
-      const { sql, params } = buildReadDailyBarsSQL("SPX", "2025-01-01", "2025-01-06");
+      const { sql } = buildReadDailyBarsSQL("SPX", "2025-01-01", "2025-01-06");
       expect(sql).toContain("GROUP BY ticker, date");
       expect(sql).toContain("time >= '09:30'");
       expect(sql).toContain("time <= '16:00'");
-      expect(params).toEqual(["SPX", "2025-01-01", "2025-01-06"]);
+      expect(sql).toContain("ticker = 'SPX'");
+      expect(sql).toContain("date >= '2025-01-01'");
+      expect(sql).toContain("date <= '2025-01-06'");
     });
 
     it("queries from market.spot (single source of truth)", () => {
       const { sql } = buildReadDailyBarsSQL("SPX", "2025-01-01", "2025-01-06");
       expect(sql).toContain("FROM market.spot");
     });
+
+    it("emits no positional placeholders (leak-free runAndReadAll path)", () => {
+      const { sql } = buildReadDailyBarsSQL("SPX", "2025-01-01", "2025-01-06");
+      expect(sql).not.toMatch(/\$\d/);
+    });
   });
 
   describe("buildReadRthOpensSQL", () => {
     it("projects date+open aggregate over RTH window", () => {
-      const { sql, params } = buildReadRthOpensSQL("VIX", "2025-01-01", "2025-01-31");
+      const { sql } = buildReadRthOpensSQL("VIX", "2025-01-01", "2025-01-31");
       expect(sql).toContain("first(open ORDER BY time)");
       expect(sql).toContain("FROM market.spot");
       expect(sql).toContain("GROUP BY date");
       expect(sql).toContain("time >= '09:30'");
       expect(sql).toContain("time <= '16:00'");
-      expect(params).toEqual(["VIX", "2025-01-01", "2025-01-31"]);
+      expect(sql).toContain("ticker = 'VIX'");
+      expect(sql).toContain("date >= '2025-01-01'");
+      expect(sql).toContain("date <= '2025-01-31'");
     });
 
-    it("binds positional $1 $2 $3 placeholders", () => {
+    it("emits no positional placeholders (leak-free runAndReadAll path)", () => {
       const { sql } = buildReadRthOpensSQL("VIX", "2025-01-01", "2025-01-31");
-      expect(sql).toContain("$1");
-      expect(sql).toContain("$2");
-      expect(sql).toContain("$3");
+      expect(sql).not.toMatch(/\$\d/);
     });
   });
 });

--- a/packages/mcp-server/tests/unit/market/stores/spot-sql.test.ts
+++ b/packages/mcp-server/tests/unit/market/stores/spot-sql.test.ts
@@ -6,10 +6,8 @@
  * emitted string — no fixture, no connection.
  *
  * Why inline literals: the DuckDB Node-API binding leaks C++ handles on every
- * `runAndReadAll(sql, params)` call (see `spot-sql.ts` header / project
- * memory `feedback_duckdb_extract_statements_leak.md`). The builders moved
- * off positional params on 2026-05-19 (issue #121) to kill the leak at the
- * source.
+ * `runAndReadAll(sql, params)` call (see `spot-sql.ts` header). The builders
+ * use inline literals to kill the leak at the source.
  */
 import { describe, it, expect } from "@jest/globals";
 import {

--- a/packages/mcp-server/tests/unit/providers/thetadata.test.ts
+++ b/packages/mcp-server/tests/unit/providers/thetadata.test.ts
@@ -322,6 +322,85 @@ describe("ThetaDataProvider.fetchBulkQuotes", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({ ticker: "NDX240823C19000000" });
   });
+
+  it("emits phase=complete when the final expiration in a (root, right) group NOT_FOUNDs", async () => {
+    // Regression guard: the per-(root, right) loop previously took a
+    // `continue` path on NOT_FOUND that bypassed the per-iteration
+    // notifyGroupComplete call. When the FINAL expiration in a non-empty
+    // group NOT_FOUNDed, MCP progress consumers never saw a phase="complete"
+    // event for that group even though the bulk fetch completed normally.
+    // The fix treats NOT_FOUND as an empty result and falls through to the
+    // existing per-iteration notify; the final-iteration completion check
+    // naturally upgrades the event to phase="complete".
+    const client = createClient();
+    const contractListEndpoint = jest.fn<ContractListEndpoint>(
+      async (): Promise<ThetaContractListRow[]> => [
+        { symbol: "NDX", expiration: "2024-08-16", strike: 19000, right: "call" },
+        { symbol: "NDX", expiration: "2024-08-23", strike: 19000, right: "call" },
+        { symbol: "NDX", expiration: "2024-08-30", strike: 19000, right: "call" },
+        { symbol: "NDX", expiration: "2024-08-16", strike: 19000, right: "put" },
+      ],
+    );
+    const quoteEndpoint = jest.fn<QuoteEndpoint>(
+      async (_client, params): Promise<ThetaQuoteRow[]> => {
+        if (params.strike !== "*") return [];
+        // FINAL call expiration NOT_FOUNDs; earlier two succeed.
+        if (params.right === "call" && params.expiration === "2024-08-30") {
+          throw new Error("NOT_FOUND: No data found for the specified request");
+        }
+        return [
+          quoteRow({
+            symbol: "NDX",
+            expiration: params.expiration,
+            strike: 19000,
+            right: params.right,
+            timestamp: "2024-08-05 09:30",
+          }),
+        ];
+      },
+    );
+    const firstOrderEndpoint = jest.fn<FirstOrderEndpoint>().mockResolvedValue([]);
+    const firstOrderBandEndpoint = jest.fn<FirstOrderBandEndpoint>().mockResolvedValue([]);
+    const onGroupComplete = jest.fn();
+    const provider = createProvider({
+      client,
+      quoteEndpoint,
+      firstOrderEndpoint,
+      firstOrderBandEndpoint,
+      contractListEndpoint,
+    });
+
+    const rows: unknown[] = [];
+    for await (const chunk of provider.fetchBulkQuotes({
+      underlying: "NDX",
+      date: "2024-08-05",
+      onGroupComplete,
+    })) {
+      rows.push(...chunk);
+    }
+
+    // 2 successful call expirations + 1 put = 3 rows; the NOT_FOUND
+    // expiration contributes none.
+    expect(rows).toHaveLength(3);
+
+    // The load-bearing assertion: the NDX/call group emits THREE events
+    // — two checkpoints for the successful expirations, then a complete
+    // for the final NOT_FOUND iteration. Pre-fix this group only emitted
+    // two checkpoints; the complete was dropped.
+    const callEvents = onGroupComplete.mock.calls
+      .map(([info]) => info)
+      .filter((info) => info.root === "NDX" && info.right === "call");
+    expect(callEvents).toHaveLength(3);
+    expect(callEvents[0]).toMatchObject({ phase: "checkpoint", completedContracts: 1, totalContracts: 3 });
+    expect(callEvents[1]).toMatchObject({ phase: "checkpoint", completedContracts: 2, totalContracts: 3 });
+    expect(callEvents[2]).toMatchObject({ phase: "complete", completedContracts: 3, totalContracts: 3 });
+
+    const putEvents = onGroupComplete.mock.calls
+      .map(([info]) => info)
+      .filter((info) => info.root === "NDX" && info.right === "put");
+    expect(putEvents).toHaveLength(1);
+    expect(putEvents[0]).toMatchObject({ phase: "complete", completedContracts: 1, totalContracts: 1 });
+  });
 });
 
 describe("ThetaDataProvider.fetchContractList", () => {


### PR DESCRIPTION
## Summary

Six hardening fixes for the market-ingestor + thetadata-provider paths. All forward-ported from a sibling repo where they shipped first under heavier production load. Each commit lands one logical change with its own regression test.

1. **enrichQuoteRows partial-status + DuckDB GC leak** — removes silent `.catch(() => [])` on enrichment reads, adds `status: \"partial\"` + `skipped[]` so callers see batch-level failures instead of silent null-greeks rot. Inlines SQL literals in the 15+ store builders to bypass a DuckDB extract_statements C++ handle leak that was producing flaky \"Failed to execute prepared statement\" errors under read pressure.

2. **Empty-read coverage_gap guard** — adds `COVERAGE_GAP_THRESHOLD = 0.5`; quote-ingest batches where more than half of attempted underlying-price lookups fail are dropped with reason=\"coverage_gap\" rather than persisted with intact bid/ask but null greeks. Closes the canonical empty-read silent-rot path on the greeks pipeline.

3. **Coverage-gap denominator sharpening** — swaps the denominator from `rowsVisited` to `missingUnderlyingRows + computedRows` so mixed-source partitions (some provider-greeks rows + some compute-mode rows) trigger the threshold correctly. Old denominator diluted compute-mode failures below the trip line.

4. **compute_failure reason channel** — adds `mathFailedRows` counter + `COMPUTE_FAILURE_THRESHOLD` for the sibling failure mode: underlying-price lookup succeeded but `computeQuoteGreeks` returned null (zero option price, negative DTE, malformed strike). Both guards can fire on the same partition; no dedupe — operators benefit from seeing both signals.

5. **Minute-resolution spot ingest in refresh()** — one-line fix: `refresh()` was hardcoded to `timespan: \"1d\"` for the spot ingest path, writing one daily bar per ticker per date and leaving every minute after 09:30 without an underlying-price lookup. Tripped coverage_gap on every option-quote partition.

6. **notifyGroupComplete on final NOT_FOUND** — restructures the per-(root, right) loop in fetchBulkQuotes so a NOT_FOUND on the final expiration in a non-empty group still emits `phase: \"complete\"` instead of bypassing the notify with `continue`. MCP progress consumers were dropping done lines for these groups.

## Tier

**Tier 3** — public-repo blast radius. Requires Worf gate + Admiral sign-off per the public-PR merge protocol.

## Worktree

`/home/romeo/code/tradeblocks-org/tradeblocks-romeo-240-forward-port-mcp-server-hotfixes/`

## Verification

- All 6 commits applied with conflict resolution; semantic translation verified against public-lib's divergent surrounding code (zero/null OHLC harden, columnar JSON, rate_type/rate_value/gamma_source provenance columns all preserved).
- Full test suite: **1584 passing** (120 suites), up from 1575 baseline — 9 new regression tests across the commits.
- `npm run build:mcp`: clean.
- `npm run lint`: clean.
- Codex peer review: **6/6 PASS** (one documentation note on `RefreshResult.skipped` docstring vs implementation — non-blocking, separate cleanup).
- All internal-ticket vocab scrubbed from src/ and tests/ files touched by the commits.

## Test plan

- [ ] Reviewer confirms the SQL-literal rewrite in stores/* preserves the public-lib direct-read API shape (no `params` second arg anywhere in mcp-server).
- [ ] Reviewer confirms the partial-status semantics on `IngestResult` / `RefreshResult` don't break downstream consumers expecting only `\"ok\" | \"skipped\" | \"unsupported\" | \"error\"`.
- [ ] Reviewer confirms the new `mathFailedRows` field on `QuoteGreeksStats` doesn't break public consumers of `applyQuoteGreeks` (it's an additive field, so should be backwards-compatible).
- [ ] Reviewer confirms the `timespan: \"1m\"` change in `refresh()` is acceptable given that some operator workflows may have been depending on the daily-resolution behavior (unlikely — that was the bug).

Closes: tradeblocks-org/enterprise#240

🤖 Generated with [Claude Code](https://claude.com/claude-code)