### PR TITLE
fix(lib): StoredTrade/StoredDailyLogEntry type re-exports + reporting-trade docstring

### DIFF
--- a/packages/lib/db/index.ts
+++ b/packages/lib/db/index.ts
@@ -416,6 +416,7 @@ export {
   getDailyLogsByBlock,
   updateDailyLogsForBlock,
 } from "./daily-logs-store";
+export type { StoredDailyLogEntry } from "./daily-logs-store";
 export {
   addReportingTrades,
   deleteReportingTradesByBlock,
@@ -432,6 +433,7 @@ export {
   getTradesByBlockWithOptions,
   updateTradesForBlock,
 } from "./trades-store";
+export type { StoredTrade } from "./trades-store";
 export {
   saveWalkForwardAnalysis,
   getWalkForwardAnalysis,

--- a/packages/lib/models/reporting-trade.ts
+++ b/packages/lib/models/reporting-trade.ts
@@ -1,7 +1,7 @@
 /**
- * Reporting trade model represents backtested strategy executions coming from the
- * strategy-trade-log.csv export. These records are used to align theoretical
- * performance with the real trade log for a block.
+ * Reporting trade model represents live trading executions coming from the
+ * strategy-trade-log.csv export. These records are the actual OO trade log,
+ * used to compare live performance against backtested results for a block.
  */
 export interface ReportingTrade {
   strategy: string


### PR DESCRIPTION
## Summary

- Add `StoredTrade` and `StoredDailyLogEntry` type re-exports to `packages/lib/db/index.ts` so consumers don't need subpath imports to type fixtures
- Fix `reporting-trade.ts` docstring: ReportingTrade represents live trading executions, not backtested ones

## Verification

- `tsc --noEmit` clean
- Pre-commit lint passed (3 pre-existing warnings, no new issues)

## Test plan

- [ ] Confirm `StoredTrade` and `StoredDailyLogEntry` are importable from `@tradeblocks/lib/db`
- [ ] Confirm no type regressions

Closes tradeblocks-org/enterprise#210.
Closes tradeblocks-org/enterprise#211.