### PR TITLE
feat(db): add openMarketOnlyConnection helper

### DIFF
--- a/packages/mcp-server/src/db/connection.ts
+++ b/packages/mcp-server/src/db/connection.ts
@@ -622,6 +622,98 @@ export async function downgradeToReadOnly(dataDir: string): Promise<void> {
 }
 
 /**
+ * Open a DuckDB connection scoped to writes against market.duckdb only, with
+ * NO host file opened against analytics.duckdb.
+ *
+ * Shape: in-memory host instance, market.duckdb ATTACHed as `market` in
+ * READ_WRITE mode, market parquet views registered on the connection. Writes
+ * resolve to the attached market catalog; reads against the `market.*` views
+ * are served from the canonical parquet files under `<dataRoot>/market/`.
+ *
+ * Why this helper exists: callers whose only job is to write market data
+ * (intraday bar ingest, option-chain refresh, quote backfill) should not
+ * acquire any lock on analytics.duckdb. Holding analytics RW for a
+ * long-running market refresh blocks every parallel reader (other shells,
+ * dashboards, evaluation processes) from even opening analytics READ_ONLY —
+ * DuckDB rejects RO opens against a file that has an active WAL written by
+ * another process. Routing market writes through a `:memory:` host with
+ * market attached RW leaves analytics.duckdb completely untouched for the
+ * duration of the ingest, so concurrent processes keep their normal RO
+ * access. Market writes are still single-writer (the OS-level file lock on
+ * market.duckdb is unchanged) — this helper trades only the analytics lock.
+ *
+ * Important: the returned connection is NOT shared via the module-level
+ * singleton. `getCurrentConnection()` is not affected. The caller owns the
+ * lifecycle and must call `close()` to flush the market WAL and release the
+ * market.duckdb file lock.
+ *
+ * @param baseDir - Directory passed to the rest of the db/ module (the same
+ *   directory that `getConnection(baseDir)` would receive). Used as the
+ *   fallback parent for market.duckdb when neither `--market-db` nor
+ *   `MARKET_DB_PATH` is set, and as the fallback for `getDataRoot()`.
+ */
+export interface MarketOnlyConnection {
+  /** The active DuckDB connection. Backed by a `:memory:` host with `market` attached RW. */
+  conn: DuckDBConnection;
+  /** Resolved path to the market.duckdb file that was attached. */
+  marketDbPath: string;
+  /**
+   * Flush the market WAL, detach the market catalog, and close the connection
+   * + in-memory host instance. Best-effort on each step — surfaces no errors;
+   * the goal is to release the market.duckdb file lock for the next writer.
+   * Safe to call multiple times (subsequent calls are no-ops).
+   */
+  close(): Promise<void>;
+}
+
+export async function openMarketOnlyConnection(
+  baseDir: string,
+): Promise<MarketOnlyConnection> {
+  const marketDbPath = resolveMarketDbPath(baseDir);
+
+  // `:memory:` host means the connection does not open any on-disk database
+  // as the catalog root — analytics.duckdb is never touched by this code
+  // path. `enable_external_access: "true"` is required at instance creation
+  // to permit the ATTACH of a local file (DuckDB 1.4+ otherwise blocks all
+  // filesystem operations from within the connection).
+  const memoryInstance = await DuckDBInstance.create(":memory:", {
+    enable_external_access: "true",
+  });
+  const conn = await memoryInstance.connect();
+
+  // ATTACH market.duckdb as RW. Reuses the same path-resolution +
+  // corruption-recovery logic as the regular RW path so callers see
+  // consistent behavior.
+  await attachMarketDb(conn, marketDbPath, "read_write");
+
+  // Register views over the canonical market parquet partitions on this
+  // fresh connection. Without this, `SELECT ... FROM market.option_chain`
+  // (and friends) resolve only against the physical tables inside the
+  // attached market.duckdb — which is empty in the parquet-mode deployment
+  // where the partition files are the source of truth. createMarketParquetViews
+  // uses CREATE OR REPLACE so this is idempotent against pre-existing views
+  // inside market.duckdb.
+  const dataRoot = getDataRoot(baseDir);
+  await createMarketParquetViews(conn, dataRoot);
+
+  let closed = false;
+  const close = async (): Promise<void> => {
+    if (closed) return;
+    closed = true;
+    // Flush the market WAL before detach so the file on disk is consistent
+    // for the next reader. DETACH is best-effort — if it fails (e.g. an
+    // in-flight statement still references the catalog), we still want to
+    // close the handle so subsequent processes can acquire the RW lock.
+    try { await conn.run("CHECKPOINT market"); } catch { /* non-fatal */ }
+    try { await detachMarketDb(conn); } catch { /* non-fatal */ }
+    try { conn.closeSync(); } catch { /* non-fatal */ }
+    try { memoryInstance.closeSync(); } catch { /* non-fatal */ }
+  };
+
+  return { conn, marketDbPath, close };
+}
+
+/**
  * Open a fresh read-only connection without going through `getConnection()`'s
  * RW-init phase. The standard `getConnection()` flow always opens RW briefly
  * to create schemas + parquet views before downgrading; that brief RW window

--- a/packages/mcp-server/src/db/index.ts
+++ b/packages/mcp-server/src/db/index.ts
@@ -5,7 +5,8 @@
  * (analytics.duckdb) and the market database (market.duckdb).
  */
 
-export { getConnection, closeConnection, isConnected, upgradeToReadWrite, downgradeToReadOnly, getConnectionMode, getCurrentConnection } from "./connection.ts";
+export { getConnection, closeConnection, isConnected, upgradeToReadWrite, downgradeToReadOnly, getConnectionMode, getCurrentConnection, openMarketOnlyConnection } from "./connection.ts";
+export type { MarketOnlyConnection } from "./connection.ts";
 export {
   ensureSyncTables,
   ensureTradeDataTable,

--- a/packages/mcp-server/src/test-exports.ts
+++ b/packages/mcp-server/src/test-exports.ts
@@ -35,7 +35,8 @@ export {
 } from './sync/index.ts';
 
 // Export DuckDB connection utilities for integration testing
-export { getConnection, getReadOnlyConnection, closeConnection, isConnected, getConnectionMode, upgradeToReadWrite, downgradeToReadOnly, getCurrentConnection } from './db/connection.ts';
+export { getConnection, getReadOnlyConnection, closeConnection, isConnected, getConnectionMode, upgradeToReadWrite, downgradeToReadOnly, getCurrentConnection, openMarketOnlyConnection } from './db/connection.ts';
+export type { MarketOnlyConnection } from './db/connection.ts';
 export { setDataRoot, getDataRoot, resetDataRoot } from './db/data-root.ts';
 export { yesterdayET } from './utils/trading-dates.ts';
 export {

--- a/packages/mcp-server/tests/unit/market-only-connection.test.ts
+++ b/packages/mcp-server/tests/unit/market-only-connection.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import { mkdirSync, rmSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  openMarketOnlyConnection,
+  getConnection,
+  closeConnection,
+  upgradeToReadWrite,
+  type MarketOnlyConnection,
+} from "../../src/db/connection.ts";
+
+/**
+ * Tests for `openMarketOnlyConnection` — a helper that opens a :memory: DuckDB
+ * host with market.duckdb attached read-write, so callers ingesting market
+ * data don't take any lock on analytics.duckdb. The invariant the helper
+ * exists to enable: while a market-only writer is active, other processes
+ * (or in-process callers) can still acquire connections against
+ * analytics.duckdb. That second invariant is the load-bearing one — the
+ * rest of the suite verifies the lifecycle around it.
+ */
+describe("openMarketOnlyConnection", () => {
+  let baseDir: string;
+
+  beforeEach(() => {
+    baseDir = join(
+      tmpdir(),
+      `market-only-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(baseDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    // Tear down any module-singleton connection a test opened against the
+    // tmp baseDir, then rm the tmp dir. Order matters: closeConnection
+    // releases the file lock on analytics.duckdb so rmSync can succeed on
+    // platforms that hold mandatory locks (Windows).
+    try { await closeConnection(); } catch { /* non-fatal */ }
+    try { rmSync(baseDir, { recursive: true, force: true }); } catch { /* non-fatal */ }
+  });
+
+  it("opens cleanly against a fresh baseDir and reports the resolved market path", async () => {
+    const mo = await openMarketOnlyConnection(baseDir);
+    try {
+      expect(mo.marketDbPath).toBe(join(baseDir, "market.duckdb"));
+      expect(existsSync(mo.marketDbPath)).toBe(true);
+      // The connection should be usable for a simple catalog probe.
+      const reader = await mo.conn.runAndReadAll("SELECT 1 AS v");
+      const rows = reader.getRows() as Array<Array<unknown>>;
+      expect(Number(rows[0][0])).toBe(1);
+    } finally {
+      await mo.close();
+    }
+  });
+
+  it("writes to market.* tables and persists them across reconnect", async () => {
+    const mo = await openMarketOnlyConnection(baseDir);
+    try {
+      await mo.conn.run(`
+        CREATE TABLE IF NOT EXISTS market.test_market_writes (
+          k VARCHAR PRIMARY KEY,
+          v INTEGER NOT NULL
+        )
+      `);
+      await mo.conn.run(
+        `INSERT INTO market.test_market_writes VALUES ('alpha', 1), ('beta', 2)`,
+      );
+      const reader = await mo.conn.runAndReadAll(
+        "SELECT count(*) AS n FROM market.test_market_writes",
+      );
+      const rows = reader.getRows() as Array<Array<unknown>>;
+      expect(Number(rows[0][0])).toBe(2);
+    } finally {
+      await mo.close();
+    }
+
+    // Reopen and confirm the rows landed in market.duckdb (not just in the
+    // :memory: host that just got dropped).
+    const mo2 = await openMarketOnlyConnection(baseDir);
+    try {
+      const reader = await mo2.conn.runAndReadAll(
+        "SELECT k, v FROM market.test_market_writes ORDER BY k",
+      );
+      const rows = reader.getRows() as Array<Array<unknown>>;
+      expect(rows.length).toBe(2);
+      expect(rows[0][0]).toBe("alpha");
+      expect(Number(rows[0][1])).toBe(1);
+      expect(rows[1][0]).toBe("beta");
+      expect(Number(rows[1][1])).toBe(2);
+    } finally {
+      await mo2.close();
+    }
+  });
+
+  it("does not open analytics.duckdb (no file created while the conn is held)", async () => {
+    const mo = await openMarketOnlyConnection(baseDir);
+    try {
+      // The whole point of the helper: analytics.duckdb is never touched.
+      // If a future regression accidentally re-introduces analytics handling
+      // on this path, the file will materialize here.
+      expect(existsSync(join(baseDir, "analytics.duckdb"))).toBe(false);
+    } finally {
+      await mo.close();
+    }
+  });
+
+  it("allows a concurrent analytics connection while the market-only conn is held", async () => {
+    // THE invariant the helper exists to enable. Open the market-only writer
+    // first, then open an analytics connection through the standard path.
+    // Without the :memory: host trick, `getConnection` would race against an
+    // analytics RW lock the writer was holding — and on a fresh baseDir,
+    // `getConnection` briefly opens RW to init schemas before downgrading,
+    // which would conflict if the writer held the analytics file lock.
+    const mo: MarketOnlyConnection = await openMarketOnlyConnection(baseDir);
+    try {
+      const analyticsConn = await getConnection(baseDir);
+      // Analytics is initialized to RO after getConnection completes its init
+      // (it briefly opens RW then downgrades). A trivial select should work.
+      const reader = await analyticsConn.runAndReadAll("SELECT 1 AS v");
+      const rows = reader.getRows() as Array<Array<unknown>>;
+      expect(Number(rows[0][0])).toBe(1);
+      // And analytics.duckdb now exists on disk (created by getConnection's
+      // RW-init phase) while the market-only conn is still open — proving
+      // the two coexist.
+      expect(existsSync(join(baseDir, "analytics.duckdb"))).toBe(true);
+    } finally {
+      await mo.close();
+    }
+  });
+
+  it("releases the market.duckdb lock cleanly on close (subsequent RW open succeeds)", async () => {
+    // Open + close the market-only conn, then attempt to acquire an
+    // exclusive analytics RW connection (which also ATTACHes market.duckdb
+    // RW). If the market lock was leaked on the close path, the second open
+    // would fail with a DuckDB "could not set lock" error.
+    const mo = await openMarketOnlyConnection(baseDir);
+    await mo.close();
+    // Calling close() again must be a safe no-op.
+    await mo.close();
+
+    await getConnection(baseDir);
+    const rwConn = await upgradeToReadWrite(baseDir);
+    // Sanity probe: the upgraded connection must be able to see the market
+    // catalog (i.e., ATTACH market RW succeeded).
+    const reader = await rwConn.runAndReadAll(
+      "SELECT count(*) AS n FROM information_schema.schemata WHERE catalog_name = 'market'",
+    );
+    const rows = reader.getRows() as Array<Array<unknown>>;
+    expect(Number(rows[0][0])).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a connection helper that opens a `:memory:` DuckDB host with `market.duckdb` attached read-write, leaving `analytics.duckdb` completely untouched. Callers whose job is market-data ingest (intraday bars, option chains, quote backfill) can now write to `market.*` without holding any analytics file lock — so concurrent processes keep their normal read-only access to analytics throughout the ingest window.

## API

```ts
openMarketOnlyConnection(baseDir: string)
  → { conn, marketDbPath, close() }
```

The returned connection owns its own lifecycle (`close()` flushes the market WAL, detaches, releases the `market.duckdb` lock) and is **not** shared via the module-level singleton — `getCurrentConnection()` is unaffected. Market writes remain single-writer; only the analytics lock is dropped from the access pattern.

Exported from `db/index.ts` and `test-exports.ts`.

## Lock semantics

Before: an ingest path that called `getConnection` + `upgradeToReadWrite` held an exclusive RW lock on `analytics.duckdb` for the full ingest duration, blocking every other process from opening analytics — even read-only.

After (via this helper): analytics.duckdb is never opened by the ingest path. A concurrent reader can open analytics RO throughout. Market writes still serialize via the OS file lock on `market.duckdb` (unchanged).

## Tests

`tests/unit/market-only-connection.test.ts` (5 new tests, all pass):

1. Opens cleanly against a fresh baseDir; `marketDbPath` resolves to the expected path
2. Writes to `market.*` persist across reconnect via the helper
3. `analytics.duckdb` is NOT created while the market-only connection is held
4. Concurrent `getConnection(baseDir)` (RO) succeeds while a market-only connection is held — the lock-coexistence invariant
5. `close()` releases the market.duckdb lock cleanly; idempotent; subsequent `upgradeToReadWrite` succeeds

Adjacent suites (`market-ingestor-progress`, `market-enricher`): 106/106 still pass.

## Implementation notes

- Reuses the existing private `resolveMarketDbPath` (line 243), `attachMarketDb` (line 267), `detachMarketDb` (line 295), and `createMarketParquetViews` helpers — no extraction needed.
- `:memory:` instance uses `enable_external_access: "true"` matching the existing connection pattern.
- `dataRoot` resolves via `getDataRoot(baseDir)` matching the upstream precedent (`openReadWriteConnection` at line 346–347). No `options.dataRoot` escape hatch; callers that want to override use the existing `setDataRoot` globalThis-based mechanism.

## Diff stats

- `packages/mcp-server/src/db/connection.ts` (+92)
- `packages/mcp-server/src/db/index.ts` (+1/-1)
- `packages/mcp-server/src/test-exports.ts` (+1/-1)
- `packages/mcp-server/tests/unit/market-only-connection.test.ts` (new, +150)

Total: +247/-2.

Dist is gitignored at `packages/mcp-server/.gitignore` — not committed (matches repo convention). Consumers rebuild via `npm run build` after pulling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
