### PR TITLE
feat(db): add parquet-backed read-only market connection helper

### DIFF
--- a/packages/mcp-server/src/db/connection.ts
+++ b/packages/mcp-server/src/db/connection.ts
@@ -714,6 +714,88 @@ export async function openMarketOnlyConnection(
 }
 
 /**
+ * Open a market-data connection scoped to READS, backed entirely by the
+ * canonical parquet partitions and WITHOUT attaching the shared market
+ * database file. No host file is opened against the analytics database
+ * either.
+ *
+ * Shape: in-memory host instance, a `market` schema created in-memory, and
+ * the market parquet views registered on that schema. Reads against the
+ * `market.*` views are served directly from the canonical parquet files under
+ * `<dataRoot>/market/`. Nothing is attached, so no OS-level file lock is taken
+ * on the shared market database — multiple readers (and a concurrent market
+ * writer) coexist without contention.
+ *
+ * Why this helper exists: the read path's only inputs are the parquet
+ * partitions. The shared market database file is never the source of truth on
+ * this path, so attaching it is pure liability — it makes a reader block (or
+ * be blocked by) a concurrent market writer that holds the database file lock.
+ * Routing reads through a `:memory:` host with parquet views registered leaves
+ * the shared market database completely untouched, so a reader can run while a
+ * writer ingests. This is the read-side mirror of `openMarketOnlyConnection`;
+ * the one structural difference is that this path must CREATE the `market`
+ * schema itself (no attach creates it) before registering the views.
+ *
+ * Important: the returned connection is NOT shared via the module-level
+ * singleton. `getCurrentConnection()` is not affected. The caller owns the
+ * lifecycle and must call `close()`.
+ *
+ * @param baseDir - Directory passed to the rest of the db/ module (the same
+ *   directory that `getConnection(baseDir)` would receive). Used as the
+ *   fallback for `getDataRoot()` when neither `--data-root` nor the data-root
+ *   env var is set.
+ */
+export interface MarketReadOnlyConnection {
+  /** The active DuckDB connection. Backed by a `:memory:` host with `market.*` parquet views. */
+  conn: DuckDBConnection;
+  /** Resolved data root the parquet views were registered against (for logging/parity). */
+  dataRoot: string;
+  /**
+   * Close the connection + in-memory host instance. Best-effort on each step.
+   * Nothing is attached on this path, so there is no WAL to flush and no
+   * catalog to detach. Safe to call multiple times (subsequent calls are
+   * no-ops).
+   */
+  close(): Promise<void>;
+}
+
+export async function openMarketReadOnlyConnection(
+  baseDir: string,
+): Promise<MarketReadOnlyConnection> {
+  // `:memory:` host means the connection does not open any on-disk database as
+  // the catalog root — neither the analytics database nor the shared market
+  // database file is touched by this code path. `enable_external_access:
+  // "true"` is required at instance creation to permit reads of local parquet
+  // files (DuckDB 1.4+ otherwise blocks all filesystem operations from within
+  // the connection).
+  const memoryInstance = await DuckDBInstance.create(":memory:", {
+    enable_external_access: "true",
+  });
+  const conn = await memoryInstance.connect();
+
+  // The `market.*` views target the `market` schema. On the attach-based
+  // paths the ATTACH creates that schema; here there is no attach, so we must
+  // create it before registering the views or every CREATE VIEW market.* fails
+  // with a catalog error.
+  await conn.run("CREATE SCHEMA IF NOT EXISTS market");
+
+  // Register views over the canonical market parquet partitions. These are the
+  // source of truth for reads; no physical market tables are consulted.
+  const dataRoot = getDataRoot(baseDir);
+  await createMarketParquetViews(conn, dataRoot);
+
+  let closed = false;
+  const close = async (): Promise<void> => {
+    if (closed) return;
+    closed = true;
+    try { conn.closeSync(); } catch { /* non-fatal */ }
+    try { memoryInstance.closeSync(); } catch { /* non-fatal */ }
+  };
+
+  return { conn, dataRoot, close };
+}
+
+/**
  * Open a fresh read-only connection without going through `getConnection()`'s
  * RW-init phase. The standard `getConnection()` flow always opens RW briefly
  * to create schemas + parquet views before downgrading; that brief RW window

--- a/packages/mcp-server/src/db/index.ts
+++ b/packages/mcp-server/src/db/index.ts
@@ -5,8 +5,8 @@
  * (analytics.duckdb) and the market database (market.duckdb).
  */
 
-export { getConnection, closeConnection, isConnected, upgradeToReadWrite, downgradeToReadOnly, getConnectionMode, getCurrentConnection, openMarketOnlyConnection } from "./connection.ts";
-export type { MarketOnlyConnection } from "./connection.ts";
+export { getConnection, closeConnection, isConnected, upgradeToReadWrite, downgradeToReadOnly, getConnectionMode, getCurrentConnection, openMarketOnlyConnection, openMarketReadOnlyConnection } from "./connection.ts";
+export type { MarketOnlyConnection, MarketReadOnlyConnection } from "./connection.ts";
 export {
   ensureSyncTables,
   ensureTradeDataTable,

--- a/packages/mcp-server/src/test-exports.ts
+++ b/packages/mcp-server/src/test-exports.ts
@@ -35,8 +35,8 @@ export {
 } from './sync/index.ts';
 
 // Export DuckDB connection utilities for integration testing
-export { getConnection, getReadOnlyConnection, closeConnection, isConnected, getConnectionMode, upgradeToReadWrite, downgradeToReadOnly, getCurrentConnection, openMarketOnlyConnection } from './db/connection.ts';
-export type { MarketOnlyConnection } from './db/connection.ts';
+export { getConnection, getReadOnlyConnection, closeConnection, isConnected, getConnectionMode, upgradeToReadWrite, downgradeToReadOnly, getCurrentConnection, openMarketOnlyConnection, openMarketReadOnlyConnection } from './db/connection.ts';
+export type { MarketOnlyConnection, MarketReadOnlyConnection } from './db/connection.ts';
 export { setDataRoot, getDataRoot, resetDataRoot } from './db/data-root.ts';
 export { yesterdayET } from './utils/trading-dates.ts';
 export {

--- a/packages/mcp-server/tests/unit/market-readonly-connection.test.ts
+++ b/packages/mcp-server/tests/unit/market-readonly-connection.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import { DuckDBInstance } from "@duckdb/node-api";
+import { mkdirSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  openMarketReadOnlyConnection,
+  openMarketOnlyConnection,
+  type MarketReadOnlyConnection,
+} from "../../src/db/connection.ts";
+
+/**
+ * Tests for `openMarketReadOnlyConnection` — a helper that opens a :memory:
+ * DuckDB host, creates the `market` schema, and registers parquet views over
+ * the canonical market partitions, WITHOUT attaching the shared market
+ * database file. Because nothing is attached, readers take no file lock and
+ * coexist with a concurrent market writer (the load-bearing invariant) and
+ * with each other.
+ */
+describe("openMarketReadOnlyConnection", () => {
+  let baseDir: string;
+
+  beforeEach(async () => {
+    baseDir = join(
+      tmpdir(),
+      `market-readonly-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(baseDir, { recursive: true });
+    await writeSpotFixture(baseDir);
+  });
+
+  afterEach(() => {
+    try { rmSync(baseDir, { recursive: true, force: true }); } catch { /* non-fatal */ }
+  });
+
+  /**
+   * Write a minimal `market.spot` parquet partition under
+   * `<baseDir>/market/spot/ticker=SPX/date=2024-01-02/data.parquet` using a
+   * throwaway :memory: host + COPY ... TO a single file. The read helper's view
+   * globs specifically on `data.parquet` (to skip mid-write tmp files), so we
+   * write that exact filename rather than relying on PARTITION_BY's `data0`
+   * naming.
+   */
+  async function writeSpotFixture(dir: string): Promise<void> {
+    const partitionDir = join(dir, "market", "spot", "ticker=SPX", "date=2024-01-02");
+    mkdirSync(partitionDir, { recursive: true });
+    const target = join(partitionDir, "data.parquet").replace(/'/g, "''");
+    const instance = await DuckDBInstance.create(":memory:", {
+      enable_external_access: "true",
+    });
+    const conn = await instance.connect();
+    try {
+      await conn.run(`
+        COPY (
+          SELECT * FROM (VALUES
+            ('SPX', DATE '2024-01-02', TIME '09:30', 4700.0, 4710.0, 4695.0, 4705.0, 4704.5, 4705.5),
+            ('SPX', DATE '2024-01-02', TIME '09:31', 4705.0, 4715.0, 4700.0, 4712.0, 4711.5, 4712.5)
+          ) AS t(ticker, date, time, open, high, low, close, bid, ask)
+        )
+        TO '${target}' (FORMAT parquet)
+      `);
+    } finally {
+      try { conn.closeSync(); } catch { /* non-fatal */ }
+      try { instance.closeSync(); } catch { /* non-fatal */ }
+    }
+  }
+
+  it("opens cleanly and serves market.spot from the parquet fixture", async () => {
+    const ro = await openMarketReadOnlyConnection(baseDir);
+    try {
+      expect(ro.dataRoot).toBe(baseDir);
+      const reader = await ro.conn.runAndReadAll(
+        "SELECT count(*) AS n FROM market.spot",
+      );
+      const rows = reader.getRows() as Array<Array<unknown>>;
+      expect(Number(rows[0][0])).toBe(2);
+    } finally {
+      await ro.close();
+    }
+  });
+
+  it("does NOT open or create the shared market database file (no attach)", async () => {
+    const ro = await openMarketReadOnlyConnection(baseDir);
+    try {
+      // The attach-free path must never materialize the shared market db file.
+      const probe = await ro.conn.runAndReadAll(
+        "SELECT count(*) AS n FROM information_schema.schemata WHERE catalog_name = 'market'",
+      );
+      const rows = probe.getRows() as Array<Array<unknown>>;
+      // `market` resolves as a SCHEMA in the :memory: catalog, not as an
+      // attached catalog — so there is no `market` catalog entry.
+      expect(Number(rows[0][0])).toBe(0);
+    } finally {
+      await ro.close();
+    }
+  });
+
+  it("reads concurrently while a market-only WRITER holds the shared market db (THE invariant)", async () => {
+    // Open the attach-based RW writer first; it takes the OS file lock on the
+    // shared market database. With the old read path (which ATTACHed the same
+    // file READ_ONLY) this could conflict. The parquet-backed read helper takes
+    // no lock at all, so it must open and read successfully while the writer is
+    // live.
+    const writer = await openMarketOnlyConnection(baseDir);
+    try {
+      await writer.conn.run(
+        "CREATE TABLE IF NOT EXISTS market.writer_probe (k VARCHAR)",
+      );
+      await writer.conn.run("INSERT INTO market.writer_probe VALUES ('held')");
+
+      const ro = await openMarketReadOnlyConnection(baseDir);
+      try {
+        const reader = await ro.conn.runAndReadAll(
+          "SELECT count(*) AS n FROM market.spot",
+        );
+        const rows = reader.getRows() as Array<Array<unknown>>;
+        expect(Number(rows[0][0])).toBe(2);
+      } finally {
+        await ro.close();
+      }
+    } finally {
+      await writer.close();
+    }
+  });
+
+  it("supports two concurrent read-only connections (regression)", async () => {
+    const a = await openMarketReadOnlyConnection(baseDir);
+    const b = await openMarketReadOnlyConnection(baseDir);
+    try {
+      const ra = await a.conn.runAndReadAll("SELECT count(*) AS n FROM market.spot");
+      const rb = await b.conn.runAndReadAll("SELECT count(*) AS n FROM market.spot");
+      expect(Number((ra.getRows() as Array<Array<unknown>>)[0][0])).toBe(2);
+      expect(Number((rb.getRows() as Array<Array<unknown>>)[0][0])).toBe(2);
+    } finally {
+      await a.close();
+      await b.close();
+    }
+  });
+
+  it("close() is clean and idempotent", async () => {
+    const ro: MarketReadOnlyConnection = await openMarketReadOnlyConnection(baseDir);
+    await ro.close();
+    await ro.close();
+    // A fresh open after close must still work — no lingering lock or state.
+    const again = await openMarketReadOnlyConnection(baseDir);
+    try {
+      const reader = await again.conn.runAndReadAll("SELECT count(*) AS n FROM market.spot");
+      expect(Number((reader.getRows() as Array<Array<unknown>>)[0][0])).toBe(2);
+    } finally {
+      await again.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds `openMarketReadOnlyConnection(baseDir)`: opens an in-memory DuckDB host, creates the `market` schema, and registers the `market.*` parquet views **without attaching the shared market database file**. Reads are served entirely from the canonical parquet partitions, so a reader takes no file lock and runs concurrently with a writer and with other readers.

Read-side mirror of `openMarketOnlyConnection` (#328). Where that helper lets a market *writer* avoid locking `analytics.duckdb`, this lets a market *reader* avoid locking `market.duckdb` — so a read workload can run concurrently with an in-flight market write.

## Why

With parquet as the source of truth, `market.*` names are views over `read_parquet(...)` — no read resolves to a physical table in the market database file. The attach was only providing the `market` catalog namespace. This helper creates that namespace on an in-memory host (`CREATE SCHEMA IF NOT EXISTS market`) and registers the same views, dropping the file attach entirely.

## API

```ts
openMarketReadOnlyConnection(baseDir: string)
  → { conn, dataRoot, close() }
```

Caller owns the connection lifecycle (`close()` closes the in-memory host; idempotent). Does not touch the module-level singleton — `getCurrentConnection()` is unaffected.

## Tests

`tests/unit/market-readonly-connection.test.ts` (5 tests, all pass):

1. Opens cleanly; serves `market.spot` from a temp parquet fixture
2. **Concurrent-with-writer invariant:** while a live `openMarketOnlyConnection` (writer) is held on the same baseDir, this helper opens + reads successfully — no lock conflict
3. Two concurrent readers both work
4. `close()` clean + idempotent
5. No market-database file is opened on this path

Temp-dir fixtures only. Adjacent suites unaffected.

## Notes

Additive — no existing exports change. Exported from `db/index.ts` and `test-exports.ts`. Dist is gitignored; consumers rebuild via `npm run build` after pulling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
