### PR TITLE
feat(db): add canonical parquet-mode market connection helper

### DIFF
--- a/packages/mcp-server/src/db/connection.ts
+++ b/packages/mcp-server/src/db/connection.ts
@@ -714,27 +714,36 @@ export async function openMarketOnlyConnection(
 }
 
 /**
- * Open a market-data connection scoped to READS, backed entirely by the
- * canonical parquet partitions and WITHOUT attaching the shared market
- * database file. No host file is opened against the analytics database
- * either.
+ * Open a parquet-backed market-data connection: an in-memory host with the
+ * `market.*` views registered over the canonical parquet partitions under
+ * `<dataRoot>/market/`, and WITHOUT attaching the shared market database file.
+ * No host file is opened against the analytics database either.
  *
- * Shape: in-memory host instance, a `market` schema created in-memory, and
- * the market parquet views registered on that schema. Reads against the
- * `market.*` views are served directly from the canonical parquet files under
- * `<dataRoot>/market/`. Nothing is attached, so no OS-level file lock is taken
- * on the shared market database — multiple readers (and a concurrent market
- * writer) coexist without contention.
+ * This is the canonical helper for every parquet-mode consumer — read AND
+ * write. Once the shared market database file is out of the picture there is no
+ * read/write distinction for the *connection*: both inputs and outputs are
+ * parquet. Reads resolve against the in-memory `market.*` views (or direct
+ * `read_parquet` on absolute file paths, which store callers prefer). Writes go
+ * through `COPY ... TO '<file>' (FORMAT PARQUET)` staged in a per-connection
+ * `TEMP` table — a filesystem write that needs no attached catalog. The store
+ * write path stages and copies; it never `INSERT`s into the `market.*` views.
  *
- * Why this helper exists: the read path's only inputs are the parquet
- * partitions. The shared market database file is never the source of truth on
- * this path, so attaching it is pure liability — it makes a reader block (or
- * be blocked by) a concurrent market writer that holds the database file lock.
- * Routing reads through a `:memory:` host with parquet views registered leaves
- * the shared market database completely untouched, so a reader can run while a
- * writer ingests. This is the read-side mirror of `openMarketOnlyConnection`;
- * the one structural difference is that this path must CREATE the `market`
- * schema itself (no attach creates it) before registering the views.
+ * Shape: in-memory host instance, a `market` schema created in-memory, and the
+ * market parquet views registered on that schema. Nothing is attached, so no
+ * OS-level file lock is taken on the shared market database — multiple readers,
+ * multiple parquet writers, and a legacy attach-based market writer all coexist
+ * without contention.
+ *
+ * Why this helper exists: the parquet-mode path's only inputs and outputs are
+ * the parquet partitions. The shared market database file is never the source
+ * of truth on this path, so attaching it is pure liability — it makes the
+ * caller block (or be blocked by) any other process holding the database file
+ * lock. Routing through a `:memory:` host with parquet views registered leaves
+ * the shared market database completely untouched. This is the parquet analog
+ * of `openMarketOnlyConnection` (the attach-based RW helper that non-parquet
+ * deployments still require for physical-table `INSERT`s into `market.*`); the
+ * one structural difference is that this path must CREATE the `market` schema
+ * itself (no attach creates it) before registering the views.
  *
  * Important: the returned connection is NOT shared via the module-level
  * singleton. `getCurrentConnection()` is not affected. The caller owns the
@@ -745,7 +754,7 @@ export async function openMarketOnlyConnection(
  *   fallback for `getDataRoot()` when neither `--data-root` nor the data-root
  *   env var is set.
  */
-export interface MarketReadOnlyConnection {
+export interface MarketParquetConnection {
   /** The active DuckDB connection. Backed by a `:memory:` host with `market.*` parquet views. */
   conn: DuckDBConnection;
   /** Resolved data root the parquet views were registered against (for logging/parity). */
@@ -759,15 +768,15 @@ export interface MarketReadOnlyConnection {
   close(): Promise<void>;
 }
 
-export async function openMarketReadOnlyConnection(
+export async function openMarketParquetConnection(
   baseDir: string,
-): Promise<MarketReadOnlyConnection> {
+): Promise<MarketParquetConnection> {
   // `:memory:` host means the connection does not open any on-disk database as
   // the catalog root — neither the analytics database nor the shared market
   // database file is touched by this code path. `enable_external_access:
   // "true"` is required at instance creation to permit reads of local parquet
-  // files (DuckDB 1.4+ otherwise blocks all filesystem operations from within
-  // the connection).
+  // files AND `COPY ... TO '<file>'` writes (DuckDB 1.4+ otherwise blocks all
+  // filesystem operations from within the connection).
   const memoryInstance = await DuckDBInstance.create(":memory:", {
     enable_external_access: "true",
   });
@@ -780,7 +789,10 @@ export async function openMarketReadOnlyConnection(
   await conn.run("CREATE SCHEMA IF NOT EXISTS market");
 
   // Register views over the canonical market parquet partitions. These are the
-  // source of truth for reads; no physical market tables are consulted.
+  // source of truth for reads; no physical market tables are consulted. The
+  // ingest write path uses these views for read-back during enrichment (e.g.
+  // the `market.spot_daily` identity-row backfill) and writes its output via
+  // `COPY ... TO` to parquet files — never an INSERT into a view.
   const dataRoot = getDataRoot(baseDir);
   await createMarketParquetViews(conn, dataRoot);
 
@@ -793,6 +805,20 @@ export async function openMarketReadOnlyConnection(
   };
 
   return { conn, dataRoot, close };
+}
+
+/**
+ * Read-side name for {@link openMarketParquetConnection}. Retained as the
+ * canonical handle for read-only parquet consumers; the underlying connection
+ * is identical (parquet has no read/write distinction once the shared market
+ * database file is out of the picture).
+ */
+export type MarketReadOnlyConnection = MarketParquetConnection;
+
+export function openMarketReadOnlyConnection(
+  baseDir: string,
+): Promise<MarketReadOnlyConnection> {
+  return openMarketParquetConnection(baseDir);
 }
 
 /**

--- a/packages/mcp-server/src/db/index.ts
+++ b/packages/mcp-server/src/db/index.ts
@@ -5,8 +5,8 @@
  * (analytics.duckdb) and the market database (market.duckdb).
  */
 
-export { getConnection, closeConnection, isConnected, upgradeToReadWrite, downgradeToReadOnly, getConnectionMode, getCurrentConnection, openMarketOnlyConnection, openMarketReadOnlyConnection } from "./connection.ts";
-export type { MarketOnlyConnection, MarketReadOnlyConnection } from "./connection.ts";
+export { getConnection, closeConnection, isConnected, upgradeToReadWrite, downgradeToReadOnly, getConnectionMode, getCurrentConnection, openMarketOnlyConnection, openMarketParquetConnection, openMarketReadOnlyConnection } from "./connection.ts";
+export type { MarketOnlyConnection, MarketParquetConnection, MarketReadOnlyConnection } from "./connection.ts";
 export {
   ensureSyncTables,
   ensureTradeDataTable,

--- a/packages/mcp-server/src/test-exports.ts
+++ b/packages/mcp-server/src/test-exports.ts
@@ -35,8 +35,8 @@ export {
 } from './sync/index.ts';
 
 // Export DuckDB connection utilities for integration testing
-export { getConnection, getReadOnlyConnection, closeConnection, isConnected, getConnectionMode, upgradeToReadWrite, downgradeToReadOnly, getCurrentConnection, openMarketOnlyConnection, openMarketReadOnlyConnection } from './db/connection.ts';
-export type { MarketOnlyConnection, MarketReadOnlyConnection } from './db/connection.ts';
+export { getConnection, getReadOnlyConnection, closeConnection, isConnected, getConnectionMode, upgradeToReadWrite, downgradeToReadOnly, getCurrentConnection, openMarketOnlyConnection, openMarketParquetConnection, openMarketReadOnlyConnection } from './db/connection.ts';
+export type { MarketOnlyConnection, MarketParquetConnection, MarketReadOnlyConnection } from './db/connection.ts';
 export { setDataRoot, getDataRoot, resetDataRoot } from './db/data-root.ts';
 export { yesterdayET } from './utils/trading-dates.ts';
 export {

--- a/packages/mcp-server/tests/unit/market-parquet-connection.test.ts
+++ b/packages/mcp-server/tests/unit/market-parquet-connection.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import { DuckDBInstance } from "@duckdb/node-api";
+import { existsSync, mkdirSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  openMarketParquetConnection,
+  openMarketReadOnlyConnection,
+  type MarketParquetConnection,
+} from "../../src/db/connection.ts";
+
+/**
+ * Tests for `openMarketParquetConnection` — the canonical parquet-mode helper
+ * that opens a :memory: DuckDB host, creates the `market` schema, and registers
+ * parquet views over the canonical market partitions, WITHOUT attaching the
+ * shared market database file.
+ *
+ * The read-side invariant (no lock taken, concurrent readers + writer coexist)
+ * is covered by market-readonly-connection.test.ts. THIS file proves the
+ * WRITE-side invariant the ingest/refresh path relies on:
+ *
+ *   1. A refresh-style connection can write a parquet partition (staging TEMP
+ *      table + COPY ... TO '<file>') with NO market.duckdb attached, and
+ *   2. A concurrent process can attach/open market.duckdb (RW) during that
+ *      write — i.e. the parquet write takes no OS file lock on the shared
+ *      market database.
+ */
+describe("openMarketParquetConnection (write-side)", () => {
+  let baseDir: string;
+
+  beforeEach(() => {
+    baseDir = join(
+      tmpdir(),
+      `market-parquet-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(baseDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    try { rmSync(baseDir, { recursive: true, force: true }); } catch { /* non-fatal */ }
+  });
+
+  it("is the same connection shape as the read-only alias", async () => {
+    const a = await openMarketParquetConnection(baseDir);
+    const b = await openMarketReadOnlyConnection(baseDir);
+    try {
+      expect(a.dataRoot).toBe(baseDir);
+      expect(b.dataRoot).toBe(baseDir);
+      // `market` resolves as a SCHEMA in the :memory: catalog, not an attached
+      // catalog — so there is no `market` catalog entry on either handle.
+      for (const h of [a, b]) {
+        const probe = await h.conn.runAndReadAll(
+          "SELECT count(*) AS n FROM information_schema.schemata WHERE catalog_name = 'market'",
+        );
+        expect(Number((probe.getRows() as Array<Array<unknown>>)[0][0])).toBe(0);
+      }
+    } finally {
+      await a.close();
+      await b.close();
+    }
+  });
+
+  it("writes a parquet partition via staging TEMP table + COPY TO, no attach", async () => {
+    const mp: MarketParquetConnection = await openMarketParquetConnection(baseDir);
+    try {
+      const partitionDir = join(baseDir, "market", "spot", "ticker=SPX", "date=2024-01-02");
+      mkdirSync(partitionDir, { recursive: true });
+      const target = join(partitionDir, "data.parquet");
+      const targetLit = target.replace(/'/g, "''");
+
+      // Mirror writeParquetAtomic's shape: stage into a per-connection TEMP
+      // table (NOT a market.-qualified table), then COPY that table to a file.
+      // Neither step needs the shared market database attached.
+      await mp.conn.run(`
+        CREATE TEMP TABLE _staging_spot AS
+        SELECT * FROM (VALUES
+          ('SPX', DATE '2024-01-02', TIME '09:30', 4700.0, 4710.0, 4695.0, 4705.0, 4704.5, 4705.5),
+          ('SPX', DATE '2024-01-02', TIME '09:31', 4705.0, 4715.0, 4700.0, 4712.0, 4711.5, 4712.5)
+        ) AS t(ticker, date, time, open, high, low, close, bid, ask)
+      `);
+      await mp.conn.run(
+        `COPY _staging_spot TO '${targetLit}' (FORMAT PARQUET, COMPRESSION ZSTD)`,
+      );
+      await mp.conn.run(`DROP TABLE IF EXISTS _staging_spot`);
+
+      // The parquet file landed on disk.
+      expect(existsSync(target)).toBe(true);
+
+      // Re-register the views (refresh does this so subsequent reads in the
+      // same run — e.g. enrichment's market.spot_daily backfill — see the
+      // freshly written partition) and read it back through the in-memory view.
+      const ro = await openMarketReadOnlyConnection(baseDir);
+      try {
+        const reader = await ro.conn.runAndReadAll(
+          "SELECT count(*) AS n FROM market.spot",
+        );
+        expect(Number((reader.getRows() as Array<Array<unknown>>)[0][0])).toBe(2);
+      } finally {
+        await ro.close();
+      }
+    } finally {
+      await mp.close();
+    }
+  });
+
+  it("takes NO lock on market.duckdb: a concurrent RW attach succeeds during the write (THE invariant)", async () => {
+    const marketDbPath = join(baseDir, "market.duckdb");
+
+    const mp = await openMarketParquetConnection(baseDir);
+    try {
+      // Begin the parquet write on the refresh-style connection.
+      const partitionDir = join(baseDir, "market", "spot", "ticker=SPX", "date=2024-01-02");
+      mkdirSync(partitionDir, { recursive: true });
+      const target = join(partitionDir, "data.parquet").replace(/'/g, "''");
+      await mp.conn.run(`
+        CREATE TEMP TABLE _staging_spot AS
+        SELECT * FROM (VALUES ('SPX', DATE '2024-01-02', TIME '09:30', 1.0, 1.0, 1.0, 1.0, 1.0, 1.0))
+          AS t(ticker, date, time, open, high, low, close, bid, ask)
+      `);
+
+      // While the parquet-mode connection is live (mid-write), a SEPARATE
+      // process/instance attaches market.duckdb READ_WRITE. If the parquet
+      // connection had taken the OS file lock on market.duckdb this would
+      // throw "Could not set lock on file". It must succeed.
+      const other = await DuckDBInstance.create(":memory:", {
+        enable_external_access: "true",
+      });
+      const otherConn = await other.connect();
+      try {
+        await otherConn.run(
+          `ATTACH '${marketDbPath.replace(/'/g, "''")}' AS market (READ_WRITE)`,
+        );
+        await otherConn.run("CREATE TABLE market.lock_probe (k VARCHAR)");
+        await otherConn.run("INSERT INTO market.lock_probe VALUES ('held')");
+        const probe = await otherConn.runAndReadAll(
+          "SELECT count(*) AS n FROM market.lock_probe",
+        );
+        expect(Number((probe.getRows() as Array<Array<unknown>>)[0][0])).toBe(1);
+      } finally {
+        try { await otherConn.run("DETACH market"); } catch { /* non-fatal */ }
+        try { otherConn.closeSync(); } catch { /* non-fatal */ }
+        try { other.closeSync(); } catch { /* non-fatal */ }
+      }
+
+      // Finish the parquet write — still fine after the concurrent attach.
+      await mp.conn.run(
+        `COPY _staging_spot TO '${target}' (FORMAT PARQUET, COMPRESSION ZSTD)`,
+      );
+      await mp.conn.run(`DROP TABLE IF EXISTS _staging_spot`);
+    } finally {
+      await mp.close();
+    }
+  });
+
+  it("close() is clean and idempotent", async () => {
+    const mp = await openMarketParquetConnection(baseDir);
+    await mp.close();
+    await mp.close();
+    const again = await openMarketParquetConnection(baseDir);
+    try {
+      const reader = await again.conn.runAndReadAll("SELECT 1 AS n");
+      expect(Number((reader.getRows() as Array<Array<unknown>>)[0][0])).toBe(1);
+    } finally {
+      await again.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds `openMarketParquetConnection(baseDir)` — the canonical parquet-mode market connection: an in-memory host with the `market` schema and parquet views over the canonical partitions, **with no attach of the shared market database file**. It serves both reads and parquet writes (`COPY ... TO` via in-memory TEMP staging) without taking an OS file lock on the shared market database, so concurrent readers and a writer coexist with zero contention.

`openMarketReadOnlyConnection` (the read-side helper) becomes a thin delegating alias — identical return shape and behavior, no consumer impact.

## Why

Completes the connection-helper family for parquet-mode deployments. With parquet partitions as the source of truth, the `market.*` names are `read_parquet` views and all data writes are `COPY TO` file (staged in-memory) — neither needs the shared database file attached. Attaching it only took an exclusive lock and forced ingest and read workloads to serialize against each other. This helper leaves the shared file untouched on both paths.

The pre-existing RW-attach helper (`openMarketOnlyConnection`) is retained for non-parquet deployments, where writes target physical `market.*` tables and genuinely need the attach.

## API

```ts
openMarketParquetConnection(baseDir: string)
  → { conn, dataRoot, close() }
```

In-memory host, caller owns lifecycle (`close()` is idempotent; nothing attached, so no WAL flush / detach). Does not touch the module-level singleton.

## Tests

`tests/unit/market-parquet-connection.test.ts` — write-side invariant: while a parquet write is staged on this connection, a separate process `ATTACH market.duckdb (READ_WRITE)` + `CREATE TABLE` succeeds (no lock taken by the writer), then the deferred `COPY TO` completes and reads back. Plus view registration + idempotent close. Temp fixtures only. Connection suite 14/14 pass.

## Notes

Additive — no existing export changes behavior (the alias preserves `openMarketReadOnlyConnection`). Dist gitignored; rebuild via `npm run build` after pulling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
