### PR TITLE
ci(dependabot): auto-approve patch/minor bumps with a code-owner token

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,6 +10,10 @@ jobs:
   dependabot:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
+    # Map the secret into env so the "skip when unset" guard can be evaluated in
+    # step `if:` (the `secrets` context is not available in `if`, but `env` is).
+    env:
+      AUTOMERGE_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}
     steps:
       - name: Dependabot metadata
         id: metadata
@@ -17,9 +21,34 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      # master requires a *code-owner* approving review (and dismisses stale
+      # reviews on every push). GITHUB_TOKEN / the actions bot cannot satisfy a
+      # code-owner gate, so auto-merge alone leaves patch/minor bumps blocked on a
+      # review that never arrives. Approve with a code-owner PAT instead. Because
+      # `on: pull_request` includes `synchronize`, this re-runs on every rebase and
+      # re-approves, so dismiss-stale doesn't strand the PR.
+      #
+      # Setup (one-time): create a fine-grained PAT owned by a CODEOWNER with
+      # Pull requests: write + Contents: read on this repo, and store it as a
+      # *Dependabot* secret named DEPENDABOT_AUTOMERGE_TOKEN (Settings → Secrets and
+      # variables → Dependabot — NOT Actions; Dependabot-triggered runs only see
+      # Dependabot secrets). Until the secret exists this step is skipped, so the
+      # workflow degrades to the previous (blocked-on-review) behavior instead of
+      # erroring.
+      - name: Auto-approve patch and minor updates
+        if: >-
+          steps.metadata.outputs.update-type != 'version-update:semver-major'
+          && env.AUTOMERGE_TOKEN != ''
+        run: |
+          gh pr review --approve "$PR_URL" \
+            --body "Auto-approving patch/minor dependency bump via code-owner token to satisfy branch protection's required review. CI status checks still gate the merge."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ env.AUTOMERGE_TOKEN }}
+
       - name: Enable auto-merge for patch and minor updates
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ env.AUTOMERGE_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Tier: 3

CI/workflow change (public-surface protocol path), so flagging for Worf + cross-Admiral review.

## Problem
`master` requires a **code-owner** approving review and **dismisses stale reviews on every push**. The existing `dependabot-auto-merge.yml` only *enables* auto-merge — it never approves. `GITHUB_TOKEN` / the actions bot can't satisfy a code-owner gate, so every patch/minor Dependabot PR sat with auto-merge armed but **blocked on a review that never arrived**. Result: a 5-PR pileup (just cleared manually).

## Fix
Add an approve step that runs under a **code-owner PAT** (`DEPENDABOT_AUTOMERGE_TOKEN`). Because the workflow runs on every `pull_request` **synchronize**, it re-approves after each rebase, so dismiss-stale no longer strands the PR. The step is **guarded on the secret being present** (`env.AUTOMERGE_TOKEN != ''`), so until the secret is configured it no-ops and the workflow keeps its current behavior — no breakage on merge.

Majors are still excluded (unchanged) — they remain a deliberate human decision.

## ⚠️ Required one-time setup (without this, the workflow is a no-op)
1. Create a **fine-grained PAT** owned by a CODEOWNER (you) with **Pull requests: write + Contents: read** on this repo.
2. Add it as a **Dependabot secret** named `DEPENDABOT_AUTOMERGE_TOKEN` — *Settings → Secrets and variables → **Dependabot*** (NOT Actions; Dependabot-triggered runs only see Dependabot secrets).

## Notes
- Holodeck has the **identical** broken workflow + protection; it needs the same change (separate PR) — flagged as follow-up.
- This does not weaken gates: CI status checks still gate the merge; only the *review* is automated, and only for patch/minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)