### PR TITLE
fix(greeks): store quote-mid vega per 1% IV move (rev 6)

### DIFF
--- a/packages/mcp-server/src/utils/providers/thetadata/quote-mid-greeks.ts
+++ b/packages/mcp-server/src/utils/providers/thetadata/quote-mid-greeks.ts
@@ -9,7 +9,7 @@ import {
 import { buildTicker } from "./join.ts";
 import type { ThetaQuoteRow } from "./types.ts";
 
-export const OPTION_QUOTE_MID_GREEKS_REVISION = 5;
+export const OPTION_QUOTE_MID_GREEKS_REVISION = 6;
 export const OPTION_QUOTE_MID_GREEKS_DIVIDEND_YIELD = OPTION_QUOTE_GREEKS_DIVIDEND_YIELD;
 export const OPTION_QUOTE_MID_GREEKS_GAMMA_SOURCE = "computed_thetadata_quote_mid_sofr_q0";
 
@@ -70,7 +70,10 @@ export function computeThetaQuoteMidGreekRow(params: {
     delta: greeks.delta,
     gamma: greeks.gamma,
     theta: greeks.theta,
-    vega: greeks.vega * 100,
+    // vega is stored per 1% IV move, matching computeLegGreeks' convention and
+    // the rest of the emit path (the per-contract x100 multiplier belongs to the
+    // consumer, not the stored greek).
+    vega: greeks.vega,
     iv: greeks.iv,
     greeks_source: "computed",
     greeks_revision: OPTION_QUOTE_MID_GREEKS_REVISION,

--- a/packages/mcp-server/tests/unit/providers/thetadata-mdds/quote-mid-greeks.test.ts
+++ b/packages/mcp-server/tests/unit/providers/thetadata-mdds/quote-mid-greeks.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from "@jest/globals";
 import { getSofrRateByKey } from "@tradeblocks/lib";
 import {
   computeThetaQuoteMidGreekRow,
+  OPTION_QUOTE_MID_GREEKS_DIVIDEND_YIELD,
   OPTION_QUOTE_MID_GREEKS_GAMMA_SOURCE,
   OPTION_QUOTE_MID_GREEKS_REVISION,
 } from "../../../../src/utils/providers/thetadata/quote-mid-greeks.ts";
+import { computeLegGreeks } from "../../../../src/utils/black-scholes.ts";
+import { computeFractionalDte } from "../../../../src/utils/option-time.ts";
 import type { ThetaQuoteRow } from "../../../../src/utils/providers/thetadata/types.ts";
 
 function quote(overrides: Partial<ThetaQuoteRow> = {}): ThetaQuoteRow {
@@ -40,7 +43,31 @@ describe("ThetaData quote-mid computed greeks", () => {
     });
     expect(row?.delta).toBeCloseTo(0.309, 3);
     expect(row?.iv).toBeCloseTo(0.0989, 3);
-    expect(row?.vega).toBeGreaterThan(400);
+    expect(row?.vega).toBeCloseTo(4.794, 3);
+  });
+
+  it("stores vega per 1% IV move (equal to computeLegGreeks, not x100)", () => {
+    const q = quote();
+    const underlyingPrice = 5638.05;
+    const row = computeThetaQuoteMidGreekRow({ quote: q, underlyingPrice });
+
+    const mid = (q.bid! + q.ask!) / 2;
+    const dte = computeFractionalDte("2024-07-15", "09:45", q.expiration);
+    const rate = getSofrRateByKey("2024-07-15") / 100;
+    const canonical = computeLegGreeks(
+      mid,
+      underlyingPrice,
+      q.strike,
+      dte,
+      "C",
+      rate,
+      OPTION_QUOTE_MID_GREEKS_DIVIDEND_YIELD,
+    );
+
+    expect(canonical.vega).not.toBeNull();
+    expect(row?.vega).toBeCloseTo(canonical.vega!, 10);
+    expect(row!.vega! / canonical.vega!).toBeCloseTo(1, 6);
+    expect(row?.vega).toBeLessThan(20);
   });
 
   it("returns null without overwriting when quote or model inputs are unusable", () => {


### PR DESCRIPTION
## Problem
`computeThetaQuoteMidGreekRow` stored `vega: greeks.vega * 100`, while the canonical `computeLegGreeks` returns vega **per 1% IV move** (documented) — and delta/gamma/theta were already stored per-share/per-1%. So only vega diverged by 100×, inconsistent with the rest of the emit path and with the greeks the engine computes directly. The ×100 (per-contract) multiplier belongs to the *consumer*, not the stored greek.

## Change
- `quote-mid-greeks.ts`: `vega: greeks.vega * 100` → `vega: greeks.vega` (+ comment).
- Bump `OPTION_QUOTE_MID_GREEKS_REVISION` 5 → 6 (self-describing: rev 6 = canonical per-1% vega).
- Regression test asserting `computeThetaQuoteMidGreekRow(...).vega === computeLegGreeks(...).vega` (ratio 1.0, < 20, not ×100).

## Verification
- New + corrected tests pass (3/3); full mcp-server unit suite **1269/1269**.
- `dist` is gitignored — rebuilt locally and verified (`vega=4.7937`, `greeks_revision=6`); this PR is source + test only. Consumers that import the built dist must rebuild after merge.

Base is `feat/tradeblocks-3.0` (the active branch; `master` predates these revisions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)