### PR TITLE
docs(schema): state vega is per-1% IV move in quote metadata

### DIFF
--- a/packages/mcp-server/src/utils/schema-metadata.ts
+++ b/packages/mcp-server/src/utils/schema-metadata.ts
@@ -599,7 +599,7 @@ export const SCHEMA_DESCRIPTIONS: SchemaMetadata = {
             hypothesis: false,
           },
           vega: {
-            description: "Option vega for the minute when available from provider data or computed fallback.",
+            description: "Option vega (per 1% IV move) for the minute when available from provider data or computed fallback.",
             hypothesis: false,
           },
           iv: {


### PR DESCRIPTION
One-line doc: the `option_quote_minutes.vega` schema description now states the **per 1% IV move** convention explicitly (it's the only user-visible surface for the stored column — `market-fetch.ts` raw passthrough — and previously had no published scale contract). Matches `computeLegGreeks`. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)