### PR TITLE
fix(deps): align react to 19.2.7 to match react-dom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "next": "16.2.6",
         "next-themes": "^0.4.6",
         "plotly.js": "^3.5.1",
-        "react": "19.2.6",
+        "react": "19.2.7",
         "react-day-picker": "^9.14.0",
         "react-dom": "19.2.7",
         "react-plotly.js": "^2.6.0",
@@ -16848,9 +16848,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "next": "16.2.6",
     "next-themes": "^0.4.6",
     "plotly.js": "^3.5.1",
-    "react": "19.2.6",
+    "react": "19.2.7",
     "react-day-picker": "^9.14.0",
     "react-dom": "19.2.7",
     "react-plotly.js": "^2.6.0",


### PR DESCRIPTION
Tier: 3 — touches the published package’s dependency set (public surface). Cross-Admiral review per the public-repo merge protocol.

## Problem
`react-dom` was bumped to `19.2.7` (#334) while `react` stayed at `19.2.6`. `react-dom@19.2.7` declares a peer dependency `react@^19.2.7`, so **every `npm install` on `master` fails with `ERESOLVE`**. That turns the **Frontend (Next.js)** and **MCP Server** CI jobs red on *all* open PRs — not just the one under test. Confirmed on the two open dependabot PRs (#338 hono, #320 @types/node): both fail with the identical `react@19.2.6` vs `react-dom@19.2.7` peer error, neither related to its own bump.

## Fix
Bump `react` to `19.2.7` so it matches `react-dom` (they ship as a matched pair). Lockfile regenerated; both packages now resolve to `19.2.7`. No other dependency changes — diff is 1 line in `package.json` + 4 lines in `package-lock.json`.

## Effect
Un-reds `master` CI. Once merged, #338 and #320 rebase clean and their checks go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)