### PR TITLE
fix(market): eliminate DuckDB GC-handle leak in quote-store reads + correct skipped-batch docstrings

### DIFF
--- a/packages/mcp-server/src/market/ingestor/types.ts
+++ b/packages/mcp-server/src/market/ingestor/types.ts
@@ -64,8 +64,9 @@ export interface IngestResult {
   error?: string;
   /**
    * Batches that the ingest logged-and-skipped instead of aborting on. Present
-   * only when `status === "partial"`. Empty/undefined for clean runs.
-   * See `IngestSkippedBatch` for the producer surface.
+   * only when `status === "partial"` (i.e. there is at least one skipped
+   * batch); `undefined` when there are no skipped batches. See
+   * `IngestSkippedBatch` for the producer surface.
    */
   skipped?: IngestSkippedBatch[];
   details?: Record<string, unknown>;
@@ -225,10 +226,11 @@ export interface RefreshResult {
   coverage: Record<string, { totalDates: number; dateRange?: { from: string; to: string } }>;
   errors: string[];
   /**
-   * Aggregated `skipped` entries pulled up from every `perOperation.*` IngestResult.
-   * Present (possibly empty) on every non-skipped refresh so orchestrators can
-   * inspect partial-batch failures without traversing `perOperation`. When
-   * `status === "partial"`, this array has at least one entry.
+   * Aggregated `skipped` entries pulled up from every `perOperation.*`
+   * IngestResult so orchestrators can inspect partial-batch failures without
+   * traversing `perOperation`. Present only when there is at least one skipped
+   * batch (i.e. `status === "partial"`); `undefined` for clean runs. Callers
+   * should read `result.skipped?.length ?? 0`.
    */
   skipped?: IngestSkippedBatch[];
 }

--- a/packages/mcp-server/src/market/stores/duckdb-quote-store.ts
+++ b/packages/mcp-server/src/market/stores/duckdb-quote-store.ts
@@ -172,17 +172,25 @@ export class DuckdbQuoteStore extends QuoteStore {
     }
     const columns = await this.getQuoteTableColumns();
     const projection = quoteParquetCanonicalProjection(columns, "q");
-    const tickerPlaceholders = occTickers.map((_, i) => `$${i + 4}`).join(", ");
-    const params = [firstUnderlying, from, to, ...occTickers];
+    // Inline every value as a SQL literal and call the unbound
+    // runAndReadAll(sql) form — the bound (sql, values) path routes through
+    // node_bindings.extract_statements, which leaks a non-destroyable handle
+    // per call and eventually throws "Failed to execute prepared statement"
+    // under sustained read load. See spot-sql.ts header for the full writeup.
+    const underlyingLit = `'${escapeSqlLiteral(firstUnderlying)}'`;
+    const fromLit = `'${escapeSqlLiteral(from)}'`;
+    const toLit = `'${escapeSqlLiteral(to)}'`;
+    const tickerList = occTickers
+      .map((t) => `'${escapeSqlLiteral(t)}'`)
+      .join(", ");
     const reader = await this.ctx.conn.runAndReadAll(
       `SELECT ${projection}
          FROM market.option_quote_minutes AS q
-        WHERE q.underlying = $1
-          AND q.date >= $2
-          AND q.date <= $3
-          AND q.ticker IN (${tickerPlaceholders})
+        WHERE q.underlying = ${underlyingLit}
+          AND q.date >= ${fromLit}
+          AND q.date <= ${toLit}
+          AND q.ticker IN (${tickerList})
         ORDER BY q.ticker, q.date, q.time`,
-      params as (string | number | boolean | null | bigint)[],
     );
     const out = new Map<string, QuoteRow[]>();
     for (const row of reader.getRows()) {
@@ -224,6 +232,13 @@ export class DuckdbQuoteStore extends QuoteStore {
 
       const columns = await this.getQuoteTableColumns();
       const projection = quoteParquetCanonicalProjection(columns, "q");
+      // Underlying + time bounds inlined as SQL literals so the call takes the
+      // unbound runAndReadAll(sql) path (the (date, ticker) VALUES are already
+      // inlined above). The bound form leaks an extract_statements handle per
+      // call — see spot-sql.ts header for the full root-cause writeup.
+      const underlyingLit = `'${escapeSqlLiteral(underlying)}'`;
+      const timeStartLit = `'${escapeSqlLiteral(timeStart)}'`;
+      const timeEndLit = `'${escapeSqlLiteral(timeEnd)}'`;
       const sql = `WITH wanted(date, ticker) AS (
                      VALUES ${wantedPairs.join(", ")}
                    )
@@ -231,15 +246,12 @@ export class DuckdbQuoteStore extends QuoteStore {
                    FROM market.option_quote_minutes AS q
                    JOIN wanted AS w
                      ON q.date = w.date AND q.ticker = w.ticker
-                   WHERE q.underlying = $1
-                     AND q.time >= $2 AND q.time <= $3
+                   WHERE q.underlying = ${underlyingLit}
+                     AND q.time >= ${timeStartLit} AND q.time <= ${timeEndLit}
                    ORDER BY q.ticker, q.date, q.time`;
 
       const queryStart = perf ? Date.now() : 0;
-      const reader = await this.ctx.conn.runAndReadAll(
-        sql,
-        [underlying, timeStart, timeEnd] as (string | number | boolean | null | bigint)[],
-      );
+      const reader = await this.ctx.conn.runAndReadAll(sql);
       const rows = reader.getRows();
       if (perf) {
         console.log(
@@ -279,36 +291,28 @@ export class DuckdbQuoteStore extends QuoteStore {
     const { underlying, date, timeStart, timeEnd, legEnvelopes } = params;
     if (legEnvelopes.length === 0) return [];
 
-    // Bind positional `$N` parameters in the same style the rest of this file
-    // uses (readQuotes / getCoverage). Order: underlying, date, timeStart,
-    // timeEnd, then per-envelope (contract_type, dteMin, dteMax, [strikeMin,
-    // strikeMax]).
-    const bound: (string | number)[] = [underlying, date, timeStart, timeEnd];
-    let nextParam = bound.length + 1;
-    const placeholder = (): string => `$${nextParam++}`;
-    const pUnderlying = "$1";
-    const pDate = "$2";
-    const pTimeStart = "$3";
-    const pTimeEnd = "$4";
+    // Inline every value as a SQL literal and call the unbound
+    // runAndReadAll(sql) form — the bound (sql, values) path routes through
+    // node_bindings.extract_statements, which leaks a non-destroyable handle
+    // per call and eventually throws "Failed to execute prepared statement"
+    // under sustained read load. See spot-sql.ts header for the full writeup.
+    // String values (underlying, date, times, contract_type) are
+    // single-quote-escaped; dte/strike bounds are typed numbers from
+    // in-process strategy definitions, inlined directly — no injection vector.
+    const pUnderlying = `'${escapeSqlLiteral(underlying)}'`;
+    const pDate = `'${escapeSqlLiteral(date)}'`;
+    const pTimeStart = `'${escapeSqlLiteral(timeStart)}'`;
+    const pTimeEnd = `'${escapeSqlLiteral(timeEnd)}'`;
 
     const disjuncts: string[] = [];
     for (const env of legEnvelopes) {
-      const pCt = placeholder();
-      bound.push(env.contractType);
-      const pDteMin = placeholder();
-      bound.push(env.dteMin);
-      const pDteMax = placeholder();
-      bound.push(env.dteMax);
-      let clause = `(b.contract_type = ${pCt} AND b.dte BETWEEN ${pDteMin} AND ${pDteMax}`;
+      const ct = `'${escapeSqlLiteral(env.contractType)}'`;
+      let clause = `(b.contract_type = ${ct} AND b.dte BETWEEN ${env.dteMin} AND ${env.dteMax}`;
       if (env.strikeMin != null) {
-        const pStrikeMin = placeholder();
-        bound.push(env.strikeMin);
-        clause += ` AND b.strike >= ${pStrikeMin}`;
+        clause += ` AND b.strike >= ${env.strikeMin}`;
       }
       if (env.strikeMax != null) {
-        const pStrikeMax = placeholder();
-        bound.push(env.strikeMax);
-        clause += ` AND b.strike <= ${pStrikeMax}`;
+        clause += ` AND b.strike <= ${env.strikeMax}`;
       }
       clause += ")";
       disjuncts.push(clause);
@@ -336,10 +340,7 @@ export class DuckdbQuoteStore extends QuoteStore {
          AND q.time BETWEEN ${pTimeStart} AND ${pTimeEnd}
     `;
 
-    const reader = await this.ctx.conn.runAndReadAll(
-      sql,
-      bound as (string | number | boolean | null | bigint)[],
-    );
+    const reader = await this.ctx.conn.runAndReadAll(sql);
     return reader.getRows().map((r) => ({
       ticker: String(r[0]),
       time: String(r[1]),

--- a/packages/mcp-server/src/market/stores/parquet-quote-store.ts
+++ b/packages/mcp-server/src/market/stores/parquet-quote-store.ts
@@ -201,16 +201,23 @@ export class ParquetQuoteStore extends QuoteStore {
     const source = readParquetFilesSql(files);
     const columns = await describeReadParquetColumns(this.ctx.conn, source);
     const projection = quoteParquetCanonicalProjection(columns, "q");
-    const tickerPlaceholders = occTickers.map((_, i) => `$${i + 3}`).join(", ");
-    const params = [from, to, ...occTickers];
+    // Inline every value as a SQL literal and call the unbound
+    // runAndReadAll(sql) form — the bound (sql, values) path routes through
+    // node_bindings.extract_statements, which leaks a non-destroyable handle
+    // per call and eventually throws "Failed to execute prepared statement"
+    // under sustained read load. See readWindow below for the full writeup.
+    const fromLit = `'${escapeSqlLiteral(from)}'`;
+    const toLit = `'${escapeSqlLiteral(to)}'`;
+    const tickerList = occTickers
+      .map((t) => `'${escapeSqlLiteral(t)}'`)
+      .join(", ");
     const reader = await this.ctx.conn.runAndReadAll(
       `SELECT ${projection}
          FROM ${source} AS q
-        WHERE q.date >= $1
-          AND q.date <= $2
-          AND q.ticker IN (${tickerPlaceholders})
+        WHERE q.date >= ${fromLit}
+          AND q.date <= ${toLit}
+          AND q.ticker IN (${tickerList})
         ORDER BY q.ticker, q.date, q.time`,
-      params as (string | number | boolean | null | bigint)[],
     );
     const out = new Map<string, QuoteRow[]>();
     for (const row of reader.getRows()) {
@@ -264,6 +271,12 @@ export class ParquetQuoteStore extends QuoteStore {
       const source = readParquetFilesSql(filePaths);
       const columns = await describeReadParquetColumns(this.ctx.conn, source);
       const projection = quoteParquetCanonicalProjection(columns, "q");
+      // Time bounds inlined as SQL literals so the call takes the unbound
+      // runAndReadAll(sql) path (the (date, ticker) VALUES are already inlined
+      // above). The bound form leaks an extract_statements handle per call —
+      // see readWindow for the full root-cause writeup.
+      const timeStartLit = `'${escapeSqlLiteral(timeStart)}'`;
+      const timeEndLit = `'${escapeSqlLiteral(timeEnd)}'`;
       const sql = `WITH wanted(date, ticker) AS (
                      VALUES ${wantedPairs.join(", ")}
                    )
@@ -271,14 +284,11 @@ export class ParquetQuoteStore extends QuoteStore {
                    FROM ${source} AS q
                    JOIN wanted AS w
                      ON q.date = w.date AND q.ticker = w.ticker
-                   WHERE q.time >= $1 AND q.time <= $2
+                   WHERE q.time >= ${timeStartLit} AND q.time <= ${timeEndLit}
                    ORDER BY q.ticker, q.date, q.time`;
 
       const queryStart = perf ? Date.now() : 0;
-      const reader = await this.ctx.conn.runAndReadAll(
-        sql,
-        [timeStart, timeEnd] as (string | number | boolean | null | bigint)[],
-      );
+      const reader = await this.ctx.conn.runAndReadAll(sql);
       const rows = reader.getRows();
       if (perf) {
         console.log(


### PR DESCRIPTION
Tier: 3 — public-lib runtime change on the DuckDB read layer. Cross-Admiral review (Smith) per the public-PR merge protocol. Worf-cleared (gate verdict below).

Two bundled correctness follow-ups to PR #324.

## 1. DuckDB GC-handle leak — quote-store read paths
Calling `conn.runAndReadAll(sql, params)` with a second positional argument routes through the Node-API binding's `extract_statements`, which leaks a GC handle and surfaces as an intermittent **"Failed to execute prepared statement"** failure under sustained load. The unbound `conn.runAndReadAll(sql)` form (params inlined as escaped SQL literals) avoids it — the pattern PR #324 established. Even `[]` as the second arg triggers the leak, so it must be omitted entirely.

Migrated the 5 remaining leaking callsites on the quote-store read hot path:
- `parquet-quote-store.ts` — `readQuotes`, `readQuotesBulk`
- `duckdb-quote-store.ts` — `readQuotes`, `readQuotesBulk`, `readWindow`

Params are inlined via the existing `escapeSqlLiteral` helper (single-quote doubling) for strings/dates and direct numeric inlining for the typed numeric envelope bounds. **Query semantics — rows, types, `ORDER BY` — are byte-equivalent** to the prior bound-param form; only the param-delivery mechanism changed. Callsites already on the unbound form (e.g. `parquet readWindow`, `duckdb getCoverage`) were left as-is.

## 2. `skipped`-batch docstring drift
`RefreshResult.skipped` / `IngestResult.skipped` docstrings in `market/ingestor/types.ts` claimed the field is "present (possibly empty) on every non-skipped refresh." The implementation omits it when empty (`...(skipped.length > 0 ? { skipped } : {})`). Corrected the docstrings to match: present only when non-empty, `undefined` for clean runs, callers read `result.skipped?.length ?? 0`. **Docstring-only — zero behavior change.**

## Verification
- `tsc --noEmit` (packages/mcp-server) → clean
- Targeted jest (parquet-quote-store, duckdb-quote-store, quote-store, quote-store.contract, ingest-quotes) → 39 passed
- Broad market store + ingestor suites → 191 passed

## Worf gate
PASS on all items — SQL-literal injection safety (every inlined param type-guaranteed `string`/`number`, correct quote-doubling, no NULL path), leak fully eliminated, Tier 3 accurate, docstring fix verified against impl. Independent re-run of tsc + the 39 store tests confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)