### PR TITLE
fix(exit-triggers): profit target fires on first cross by default

### DIFF
--- a/packages/mcp-server/src/utils/exit-triggers.ts
+++ b/packages/mcp-server/src/utils/exit-triggers.ts
@@ -47,7 +47,7 @@ export interface ExitTriggerConfig {
   openDate?: string;                            // YYYY-MM-DD for ditExit
   clockTime?: string;                           // "HH:MM" for clockTimeExit (threshold ignored)
   trailAmount?: number;                         // Dollar trail for trailingStop
-  // Directional delta fields (OO-style per-leg exits):
+  // Directional delta fields (per-leg directional exits):
   legIndex?: number;                            // 0-based leg index for perLegDelta — targets specific leg
   exitAbove?: number;                           // Fire when value > exitAbove (directional, no abs)
   exitBelow?: number;                           // Fire when value < exitBelow (directional, no abs)
@@ -59,7 +59,7 @@ export interface ExitTriggerConfig {
   spreadWidth?: number;                          // Width of spread in dollars
   contracts?: number;                            // Number of contracts
   multiplier?: number;                           // Default 100
-  // profitTarget confirmation: N synchronized-quote bars at-or-above threshold required before firing (default 2)
+  // profitTarget confirmation: N synchronized-quote bars at-or-above threshold required before firing (default 1 = fire on first cross)
   requiredHits?: number;
   // Internal: set by handler when unit='percent' to compute dollar threshold
   entryCost?: number;                            // D-11: cost/credit of entry (negative = credit received)
@@ -296,7 +296,7 @@ export function evaluateTrigger(
       case 'profitTarget': {
         // unit='percent' requires entryCost; if missing, cannot compute — no fire
         if (trigger.unit === 'percent' && trigger.entryCost == null) break;
-        const requiredHits = trigger.requiredHits ?? 2;
+        const requiredHits = trigger.requiredHits ?? 1;
         const dollarThresholdPT = trigger.unit === 'percent'
           ? threshold * Math.abs(trigger.entryCost!)
           : threshold;

--- a/packages/mcp-server/tests/unit/batch-exit-analysis.test.ts
+++ b/packages/mcp-server/tests/unit/batch-exit-analysis.test.ts
@@ -32,7 +32,9 @@ function buildPath(start: number, end: number, steps: number): PnlPoint[] {
   });
 }
 
-const TWO_HIT_PROFIT_TARGET_PNL = 233.33333333333334;
+// profitTarget fires on the first bar at or above the threshold by default.
+// On buildPath(0, 300, 10) the path hits exactly 200 at i=6.
+const PROFIT_TARGET_PNL = 200;
 
 const DEFAULT_LEGS: ReplayLeg[] = [
   { occTicker: 'SPY260105C00470000', quantity: -1, entryPrice: 5.0, multiplier: 100 },
@@ -85,8 +87,8 @@ describe('analyzeBatch', () => {
   // ---------------------------------------------------------------------------
 
   test('3 winning trades with profitTarget returns correct win rate and total P&L', () => {
-    // profitTarget uses 2-hit confirmation by default.
-    // On a 0 -> 300 path with 10 samples, the path touches 200, then confirms at 233.33.
+    // profitTarget fires on the first cross by default.
+    // On a 0 -> 300 path with 10 samples, the path touches 200 at i=6 and fires there.
     const trades = [0, 1, 2].map(i =>
       buildTradeInput(i, 200, buildPath(0, 300, 10))
     );
@@ -97,8 +99,8 @@ describe('analyzeBatch', () => {
     expect(result.aggregate.winningTrades).toBe(3);
     expect(result.aggregate.losingTrades).toBe(0);
     expect(result.aggregate.winRate).toBe(1.0);
-    expect(result.aggregate.totalPnl).toBeCloseTo(TWO_HIT_PROFIT_TARGET_PNL * 3, 5);
-    expect(result.aggregate.avgPnl).toBeCloseTo(TWO_HIT_PROFIT_TARGET_PNL, 5);
+    expect(result.aggregate.totalPnl).toBeCloseTo(PROFIT_TARGET_PNL * 3, 5);
+    expect(result.aggregate.avgPnl).toBeCloseTo(PROFIT_TARGET_PNL, 5);
   });
 
   // ---------------------------------------------------------------------------
@@ -106,7 +108,7 @@ describe('analyzeBatch', () => {
   // ---------------------------------------------------------------------------
 
   test('mixed wins/losses returns correct profit factor', () => {
-    // 2 winning trades at 233.33 after 2-hit confirmation, 1 losing trade at -$150
+    // 2 winning trades at 200 (first cross), 1 losing trade at -$150
     const winPath = buildPath(0, 300, 10);
     const lossPath = buildPath(0, -150, 10); // no trigger fires
 
@@ -123,8 +125,8 @@ describe('analyzeBatch', () => {
     expect(result.aggregate.losingTrades).toBe(1);
 
     // profitFactor = sum(wins) / abs(sum(losses))
-    // wins = 233.33 + 233.33, losses = |-150| = 150
-    expect(result.aggregate.profitFactor).toBeCloseTo((TWO_HIT_PROFIT_TARGET_PNL * 2) / 150, 5);
+    // wins = 200 + 200, losses = |-150| = 150
+    expect(result.aggregate.profitFactor).toBeCloseTo((PROFIT_TARGET_PNL * 2) / 150, 5);
   });
 
   // ---------------------------------------------------------------------------
@@ -132,10 +134,10 @@ describe('analyzeBatch', () => {
   // ---------------------------------------------------------------------------
 
   test('baseline=actual computes candidate P&L delta correctly', () => {
-    // Trade: path goes to $300. With 2-hit confirmation, the trigger confirms at 233.33.
+    // Trade: path goes to $300. The trigger fires on the first cross at 200.
     // actual P&L = $180
-    // candidatePnl = $233.33
-    // delta = $233.33 - $180 = $53.33
+    // candidatePnl = $200
+    // delta = $200 - $180 = $20
     const path = buildPath(0, 300, 10);
     const trade = buildTradeInput(0, 180, path);
 
@@ -144,9 +146,9 @@ describe('analyzeBatch', () => {
       baselineMode: 'actual',
     });
 
-    expect(result.perTrade[0].candidatePnl).toBeCloseTo(TWO_HIT_PROFIT_TARGET_PNL, 5);
+    expect(result.perTrade[0].candidatePnl).toBeCloseTo(PROFIT_TARGET_PNL, 5);
     expect(result.perTrade[0].baselinePnl).toBe(180);
-    expect(result.perTrade[0].pnlDelta).toBeCloseTo(TWO_HIT_PROFIT_TARGET_PNL - 180, 5);
+    expect(result.perTrade[0].pnlDelta).toBeCloseTo(PROFIT_TARGET_PNL - 180, 5);
   });
 
   // ---------------------------------------------------------------------------
@@ -155,9 +157,9 @@ describe('analyzeBatch', () => {
 
   test('baseline=holdToEnd uses last P&L path point as baseline', () => {
     // path goes from 0 to 300, last point = 300
-    // profit target uses 2-hit confirmation → candidatePnl = $233.33
+    // profit target fires on first cross → candidatePnl = $200
     // baselinePnl = $300 (last path point)
-    // delta = $233.33 - $300 = -$66.67
+    // delta = $200 - $300 = -$100
     const path = buildPath(0, 300, 10);
     const trade = buildTradeInput(0, 250, path);  // actual = $250 (ignored in this mode)
 
@@ -166,9 +168,9 @@ describe('analyzeBatch', () => {
       baselineMode: 'holdToEnd',
     });
 
-    expect(result.perTrade[0].candidatePnl).toBeCloseTo(TWO_HIT_PROFIT_TARGET_PNL, 5);
+    expect(result.perTrade[0].candidatePnl).toBeCloseTo(PROFIT_TARGET_PNL, 5);
     expect(result.perTrade[0].baselinePnl).toBeCloseTo(300, 0);
-    expect(result.perTrade[0].pnlDelta).toBeCloseTo(TWO_HIT_PROFIT_TARGET_PNL - 300, 5);
+    expect(result.perTrade[0].pnlDelta).toBeCloseTo(PROFIT_TARGET_PNL - 300, 5);
   });
 
   // ---------------------------------------------------------------------------

--- a/packages/mcp-server/tests/unit/exit-triggers.test.ts
+++ b/packages/mcp-server/tests/unit/exit-triggers.test.ts
@@ -58,8 +58,17 @@ describe('evaluateTrigger', () => {
   const path = buildTestPath(STANDARD_PNLS, { deltas: STANDARD_DELTAS });
 
   describe('profitTarget', () => {
-    it('fires after two synchronized bars at or above the threshold', () => {
+    it('fires on the first bar at or above the threshold by default', () => {
       const trigger: ExitTriggerConfig = { type: 'profitTarget', threshold: 200 };
+      const result = evaluateTrigger(trigger, path, DEFAULT_LEGS);
+      expect(result).not.toBeNull();
+      expect(result!.type).toBe('profitTarget');
+      expect(result!.index).toBe(3); // first bar where pnl reaches 200
+      expect(result!.pnlAtFire).toBe(200);
+    });
+
+    it('fires after two synchronized bars when requiredHits is 2', () => {
+      const trigger: ExitTriggerConfig = { type: 'profitTarget', threshold: 200, requiredHits: 2 };
       const result = evaluateTrigger(trigger, path, DEFAULT_LEGS);
       expect(result).not.toBeNull();
       expect(result!.type).toBe('profitTarget');
@@ -624,7 +633,7 @@ describe('evaluateTrigger', () => {
   describe('profitTarget with unit:percent', () => {
     it('fires when P&L >= threshold * abs(entryCost) for credit spread (entryCost negative)', () => {
       // entryCost=-350 (received $350 credit), threshold=0.7 -> dollarThreshold=245
-      // Requires two synchronized hits above threshold before firing.
+      // Fires on the first bar at or above threshold by default.
       const pnlPath = buildTestPath([0, 100, 200, 246, 250]);
       const trigger: ExitTriggerConfig = {
         type: 'profitTarget',
@@ -635,8 +644,8 @@ describe('evaluateTrigger', () => {
       const result = evaluateTrigger(trigger, pnlPath, DEFAULT_LEGS);
       expect(result).not.toBeNull();
       expect(result!.type).toBe('profitTarget');
-      expect(result!.index).toBe(4);
-      expect(result!.pnlAtFire).toBe(250);
+      expect(result!.index).toBe(3);
+      expect(result!.pnlAtFire).toBe(246);
       // Detail string should mention percentage context
       expect(result!.detail).toContain('70%');
     });
@@ -652,8 +661,8 @@ describe('evaluateTrigger', () => {
       };
       const result = evaluateTrigger(trigger, pnlPath, DEFAULT_LEGS);
       expect(result).not.toBeNull();
-      expect(result!.index).toBe(4);
-      expect(result!.pnlAtFire).toBe(300);
+      expect(result!.index).toBe(3);
+      expect(result!.pnlAtFire).toBe(250);
     });
 
     it('does not fire when P&L is just below percentage threshold', () => {
@@ -690,8 +699,8 @@ describe('evaluateTrigger', () => {
       };
       const result = evaluateTrigger(trigger, path, DEFAULT_LEGS);
       expect(result).not.toBeNull();
-      expect(result!.index).toBe(4);
-      expect(result!.pnlAtFire).toBe(300);
+      expect(result!.index).toBe(3);
+      expect(result!.pnlAtFire).toBe(200);
     });
 
     it('unit undefined behaves identically to dollar (backwards compat)', () => {
@@ -702,8 +711,8 @@ describe('evaluateTrigger', () => {
       };
       const result = evaluateTrigger(trigger, path, DEFAULT_LEGS);
       expect(result).not.toBeNull();
-      expect(result!.index).toBe(4);
-      expect(result!.pnlAtFire).toBe(300);
+      expect(result!.index).toBe(3);
+      expect(result!.pnlAtFire).toBe(200);
     });
   });
 
@@ -809,14 +818,14 @@ describe('analyzeExitTriggers', () => {
 
   it('identifies first-to-fire when multiple triggers fire', () => {
     const triggers: ExitTriggerConfig[] = [
-      { type: 'profitTarget', threshold: 200 }, // fires at index 4 after confirmation
+      { type: 'profitTarget', threshold: 200 }, // fires at index 3 on first cross
       { type: 'stopLoss', threshold: 100 },     // fires at index 8
     ];
     const result = analyzeExitTriggers({ pnlPath: path, legs: DEFAULT_LEGS, triggers });
     expect(result.overall.triggers).toHaveLength(2);
     expect(result.overall.firstToFire).not.toBeNull();
     expect(result.overall.firstToFire!.type).toBe('profitTarget');
-    expect(result.overall.firstToFire!.index).toBe(4);
+    expect(result.overall.firstToFire!.index).toBe(3);
   });
 
   it('returns null firstToFire when no triggers fire', () => {
@@ -831,7 +840,7 @@ describe('analyzeExitTriggers', () => {
 
   it('computes actual exit comparison correctly', () => {
     const triggers: ExitTriggerConfig[] = [
-      { type: 'profitTarget', threshold: 200 }, // fires at index 4 (pnl=300)
+      { type: 'profitTarget', threshold: 200 }, // fires at index 3 (pnl=200)
     ];
     // Actual exit at index 7 (pnl=50)
     const result = analyzeExitTriggers({
@@ -842,13 +851,13 @@ describe('analyzeExitTriggers', () => {
     });
     expect(result.overall.actualExit).toBeDefined();
     expect(result.overall.actualExit!.pnl).toBe(50);
-    expect(result.overall.actualExit!.pnlDifference).toBe(250); // 300 - 50
+    expect(result.overall.actualExit!.pnlDifference).toBe(150); // 200 - 50
     expect(result.overall.summary).toContain('better');
   });
 
   it('handles actual exit after all path points', () => {
     const triggers: ExitTriggerConfig[] = [
-      { type: 'profitTarget', threshold: 100 }, // fires at index 3 after confirmation
+      { type: 'profitTarget', threshold: 100 }, // fires at index 2 on first cross
     ];
     const result = analyzeExitTriggers({
       pnlPath: path,
@@ -859,7 +868,7 @@ describe('analyzeExitTriggers', () => {
     expect(result.overall.actualExit).toBeDefined();
     // Should use last point (index 9, pnl=-200)
     expect(result.overall.actualExit!.pnl).toBe(-200);
-    expect(result.overall.actualExit!.pnlDifference).toBe(400); // 200 - (-200)
+    expect(result.overall.actualExit!.pnlDifference).toBe(300); // 100 - (-200)
   });
 
   it('generates summary with trigger info', () => {
@@ -882,7 +891,7 @@ describe('analyzeExitTriggers', () => {
     const result = analyzeExitTriggers({ pnlPath, legs: DEFAULT_LEGS, triggers });
     expect(result.overall.firstToFire).not.toBeNull();
     expect(result.overall.firstToFire!.type).toBe('profitTarget');
-    expect(result.overall.firstToFire!.index).toBe(4);
+    expect(result.overall.firstToFire!.index).toBe(3);
   });
 
   it('two directional perLegDelta triggers targeting different legs fire independently', () => {
@@ -931,12 +940,12 @@ describe('leg groups', () => {
       {
         label: 'short_call',
         legIndices: [0],
-        triggers: [{ type: 'profitTarget', threshold: 40 }],
+        triggers: [{ type: 'profitTarget', threshold: 40, requiredHits: 2 }],
       },
       {
         label: 'long_call',
         legIndices: [1],
-        triggers: [{ type: 'profitTarget', threshold: 80 }],
+        triggers: [{ type: 'profitTarget', threshold: 80, requiredHits: 2 }],
       },
     ];
 


### PR DESCRIPTION
Tier: 3 — public-lib exported behavior change on the exit-trigger engine. Cross-Admiral review (Smith) per the public-PR merge protocol. Worf-cleared (gate verdict below).

## The change
`packages/mcp-server/src/utils/exit-triggers.ts`: the profitTarget trigger now fires on the **first** synchronized bar at-or-above the target by default — `requiredHits ?? 1` (was `?? 2`). Two-bar confirmation remains available as an explicit opt-in via `requiredHits: 2`.

## Why
The `feat/tradeblocks-3.0` branch introduced a 2-bar confirmation default (`?? 2`) along with the sync-bar counting machinery. That diverged from `master`'s long-standing semantics, where profitTarget fires on first cross (no multi-hit concept). Waiting for a second confirmation bar can miss an exit when price spikes through the target then retreats before the next bar — standard resting-limit-order semantics fire on first touch. This realigns the 3.0 default to first-cross; confirmation is now opt-in rather than the silent default.

## Fixture audit
Every profitTarget test path was traced:
- **Confirmation coverage preserved** — tests validating 2-bar behavior now set `requiredHits: 2` explicitly (a dedicated first-cross-default test was split out, and the leg-groups test pins `requiredHits: 2` on both groups). Net confirmation coverage increased.
- **Default-path assertions updated** to the correct first-cross values (verified arithmetically against the fixtures, e.g. PT@200 fires at idx3/pnl 200 rather than idx4/pnl 300; batch `PROFIT_TARGET_PNL` 233.33 → 200).

## Also folded in
Scrubbed a pre-existing non-public-friendly comment on the touched file (`exit-triggers.ts:50`) to keep the public surface clean.

## Verification
- `tsc --noEmit` (packages/mcp-server) → clean
- `exit-triggers` + `batch-exit-analysis` suites → 92 passed
- full mcp-server suite → 1600 passed, 0 failures

## Worf gate
PASS WITH NOTES → clear to open. Independently verified the master-divergence rationale (diffed exit-triggers.ts master vs 3.0), re-derived every updated assertion arithmetically (all correct first-cross values, none bent to pass), confirmed the confirmation path is not dead and its coverage survives, Tier 3 accurate, public boundary clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)