### PR TITLE
3.0 release prep: release notes, version bump to 3.0.0, tool-description accuracy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tradeblocks",
-  "version": "3.0.0-beta.5",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tradeblocks",
-      "version": "3.0.0-beta.5",
+      "version": "3.0.0",
       "workspaces": [
         "packages/*"
       ],
@@ -19817,7 +19817,7 @@
     },
     "packages/mcp-server": {
       "name": "tradeblocks-mcp",
-      "version": "3.0.0-beta.5",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@duckdb/node-api": "^1.4.4-r.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks",
-  "version": "3.0.0-beta.5",
+  "version": "3.0.0",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "private": true,
   "workspaces": [

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks-mcp",
-  "version": "3.0.0-beta.5",
+  "version": "3.0.0",
   "description": "MCP server for options trade analysis",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "type": "module",

--- a/packages/mcp-server/src/tools/batch-exit-analysis.ts
+++ b/packages/mcp-server/src/tools/batch-exit-analysis.ts
@@ -2,10 +2,10 @@
  * Batch Exit Analysis Tool
  *
  * MCP tool that evaluates a candidate exit policy across multiple trades in a
- * block. Queries trades from DuckDB, replays each one (checking the market.spot
- * cache before fetching from Massive), evaluates the candidate policy via the
- * pure batch exit analysis engine, and returns aggregate statistics with
- * per-trigger attribution.
+ * block. Queries trades from DuckDB, replays each one from the local
+ * market-data cache, evaluates the candidate policy via the pure batch exit
+ * analysis engine, and returns aggregate statistics with per-trigger
+ * attribution.
  *
  * Tools registered:
  *   - batch_exit_analysis -- Evaluate a candidate exit policy across an entire block
@@ -367,8 +367,9 @@ export function registerBatchExitAnalysisTools(
         "Replays each matching trade, evaluates exit triggers against the minute-level P&L path, " +
         "and returns aggregate statistics (win rate, Sharpe, profit factor, drawdown) comparable " +
         "to get_statistics. Includes per-trigger attribution showing which triggers drive outcomes. " +
-        "Uses cached bars from market.spot when available; fetches from Massive.com on cache miss " +
-        "(requires MASSIVE_API_KEY). Use with strategy profiles to iterate on exit rules.",
+        "Reads option-leg quotes via QuoteStore and underlying bars via SpotStore (cache only); " +
+        "trades with missing data are skipped. Use the data-pipeline tools to backfill cache, " +
+        "and strategy profiles to iterate on exit rules.",
       inputSchema: batchExitAnalysisSchema,
     },
     async (params) => {

--- a/packages/mcp-server/src/tools/exit-analysis.ts
+++ b/packages/mcp-server/src/tools/exit-analysis.ts
@@ -375,7 +375,7 @@ export async function handleDecomposeGreeks(
   // 2. Check greeks data availability
   if (pnlPath.length > 0 && !pnlPath[0].legGreeks) {
     throw new Error(
-      "No greeks data available. Ensure MASSIVE_API_KEY is set and underlying price data exists."
+      "No greeks data available. Use the data-pipeline tools to backfill the option-leg quotes and underlying price data into the local cache."
     );
   }
 

--- a/packages/mcp-server/src/tools/replay.ts
+++ b/packages/mcp-server/src/tools/replay.ts
@@ -2,7 +2,7 @@
  * Trade Replay Tools
  *
  * MCP tool for replaying trades using historical minute-level option bars
- * from Massive.com. Supports two modes:
+ * read from the local market-data cache. Supports two modes:
  *   A) Hypothetical replay — explicit legs with strikes/expiry/dates
  *   B) Tradelog replay — block_id + trade_index to replay from existing trade data
  *
@@ -532,7 +532,8 @@ export function registerReplayTools(
     {
       description:
         "Replay a trade using historical minute-level option bars. " +
-        "Uses cached bars from market.spot if available; fetches from Massive.com API on cache miss (requires MASSIVE_API_KEY). " +
+        "Reads option-leg quotes via QuoteStore and underlying bars via SpotStore (cache only); " +
+        "missing data yields a degenerate replay. Use the data-pipeline tools to backfill cache. " +
         "Returns minute-by-minute P&L path with MFE (Maximum Favorable Excursion) and MAE (Maximum Adverse Excursion). " +
         "Two modes: (A) Hypothetical — provide explicit legs with strikes, expiry, entry prices. " +
         "(B) Tradelog — provide block_id + trade_index to replay an existing trade from your data.",

--- a/releases/v3.0.md
+++ b/releases/v3.0.md
@@ -1,8 +1,49 @@
-# TradeBlocks MCP Server 3.0 — Market Data 3.0 Infrastructure (Beta)
+# TradeBlocks MCP Server 3.0 — Market Data 3.0 Infrastructure
 
-Market data can now live as Parquet files instead of DuckDB rows — readable by any tool that speaks Parquet (DuckDB, Polars, pandas, Arrow), inspectable as plain folders, and free from the single-writer lock that DuckDB enforces. ThetaData is a first-class provider alongside Massive, with wildcard-bulk quote streaming that turns what used to be thousands of API calls into one. And `import_flat_file` was rewritten so you can point it at any Parquet or CSV file and Claude figures out how to ingest it — no provider-specific paths required.
+Market data can now live as Parquet files instead of DuckDB rows — readable by any tool that speaks Parquet (DuckDB, Polars, pandas, Arrow), inspectable as plain folders, and free from the single-writer lock that DuckDB enforces. ThetaData is a first-class provider alongside Massive, with wildcard-bulk streaming — for quotes and now daily open interest — that turns what used to be thousands of API calls into one. And `import_flat_file` was rewritten so you can point it at any Parquet or CSV file and Claude figures out how to ingest it — no provider-specific paths required.
 
-This is **3.0 beta 5**. The schema is stable, but expect minor tool-signature refinements before a final 3.0 tag.
+This is **3.0**. The market-data schema and tool surface are stable; the sections below trace what landed across the betas on the way here, newest first.
+
+---
+
+# What's New Since Beta 5
+
+The changes that close out the road to 3.0: daily option open interest joins the market datasets, the greeks vega unit is pinned and documented, and a round of ingest/read-path hardening.
+
+## Daily option open interest
+
+Open interest is now a first-class market dataset. `market.option_oi_daily` (Hive-partitioned by underlying and date) stores end-of-day open interest per contract, fetched from ThetaData with the same single-wildcard-stream-per-root pattern that powers bulk quotes — one request returns every strike's OI for an underlying on a given date. It writes alongside `option_chain` and `option_quote_minutes` through the same store abstraction, so anything that already reads chains or quotes can join open interest by contract without a new access path.
+
+## Vega is per-1% IV move — pinned and documented
+
+`option_quote_minutes` stores vega normalized to a **1% change in implied volatility** (not a full 1.00 move), and the column metadata now states this explicitly. The value is uniform across every partition, so downstream consumers read vega directly without guessing the unit or rescaling — no per-row normalization needed.
+
+## Ingest and read-path hardening
+
+A round of robustness fixes for long historical backfills and multi-hour read workloads:
+
+- **Market ingestor + ThetaData hardening.** A batch of fixes to the ingest path and the ThetaData provider that remove failure modes hit during real backfills, so a long ingest is less likely to abort partway.
+- **Anomalous-quote detection.** A shared `isAnomalousQuote` check flags blown or crossed quotes (`bid > ask`, zero/garbage spreads), and the trade-replay path now guards its mark against blown spreads — falling back to an `HL2` midpoint when the tape is degenerate instead of trusting a bad print.
+- **Read-path resilience, continued.** The hot quote-read paths were further hardened against the long-session DuckDB driver flake first addressed in Beta 3, inlining typed literals on the remaining read queries so multi-hundred-call workloads run clean.
+
+---
+
+# Analysis & Replay Tools
+
+3.0 also changes how the trade-analysis and replay tools — `replay_trade`, `analyze_exit_triggers`, `batch_exit_analysis`, `decompose_greeks` — source their data and evaluate exit rules.
+
+## Replay and exit tools read local data only
+
+These tools now price exclusively from your **pre-ingested local market data** — option legs from stored mid quotes, underlying and VIX bars from the stored daily/minute datasets (with a daily-aggregate fallback). The previous fetch-on-cache-miss path is gone. Backfill the dates a trade spans with the market-data tools first; on missing data these tools return empty or degraded results rather than fetching in the background. Two related touch-ups: `replay_trade`'s `skip_quotes` argument is now a no-op for option legs (still accepted, ignored), and underlying bars with zero or non-finite prices are filtered before greeks, so bad spot data can't produce nonsense greeks.
+
+## Exit-trigger refinements
+
+Two changes to how candidate exit rules evaluate against a replayed P&L path:
+
+- **`slRatioMove`** now triggers on a **directional percentage move** (sign-aware) rather than an absolute distance — the threshold reads relative to the entry ratio, so exits fire at more intuitive points.
+- **`perLegDelta`** now sign-adjusts per-leg delta for short legs (negated when the leg is sold) before testing the threshold, so delta-based exits fire correctly on short legs.
+
+Mark pricing across these tools also gained the crossed/blown-quote `HL2` guard noted above, so a degenerate exchange print no longer distorts the replayed path.
 
 ---
 
@@ -419,13 +460,13 @@ The profile CRUD tools (`list_profiles`, `get_strategy_profile`, `profile_strate
 
 ---
 
-## What's Next (Post-Beta 4)
+## What's Next (Post-3.0)
 
-Stabilization work for 3.0 final:
+With 3.0 stable, the next round of work:
 
-- Tool-signature polish as we get feedback on the new flat-file shape
-- Removal of any 2.x compatibility seams that are no longer needed
-- Additional dataset types for `import_flat_file` if real-world sources need them
+- Additional dataset types for `import_flat_file` as real-world sources need them
+- Open-interest coverage on the Massive provider (ThetaData ships first)
+- Removal of any remaining 2.x compatibility seams
 - Stream-flush on bulk quote ingest to bound per-date heap regardless of row count
 
-Feedback on the beta is welcome — open an issue on [GitHub](https://github.com/davidromeo/tradeblocks/issues) if you hit any rough edges.
+Feedback is welcome — open an issue on [GitHub](https://github.com/davidromeo/tradeblocks/issues) if you hit any rough edges.


### PR DESCRIPTION
Tier: 3 — touches the public MCP tool-description surface (and ships the public release notes + version). No API/behavior change; text-accuracy + docs + version only.

Bundles the 3.0-final release-prep into one PR:

**1. Release notes (`releases/v3.0.md`)** — promoted from beta-5 framing to 3.0 final:
- New **"What's New Since Beta 5"**: daily option open interest (`option_oi_daily`), vega pinned per-1% IV move, ingest/read-path hardening.
- New **"Analysis & Replay Tools"** section: replay/exit tools now read local cache only; `slRatioMove` (directional %) and `perLegDelta` (short-leg sign) refinements.
- Features and functionality only — no dependency churn.

**2. Version bump** — `3.0.0-beta.5 → 3.0.0` in root + `packages/mcp-server` `package.json` and the matching `package-lock.json` fields. (`packages/lib` stays on its own `0.0.1` track.)

**3. Tool-description accuracy** (`0ec46829`) — `replay_trade` / `batch_exit_analysis` descriptions and the `decompose_greeks` error string claimed an on-demand fetch-on-cache-miss that 3.0 removed; corrected to accurate cache-only wording. Build + 1,618 mcp-server tests pass.

Verification: lockfile parses + version fields consistent; mcp-server build/lint/tests green on the tool-description commit.