### PR TITLE
Use fs.realpath to resolve actual path instead of symlink of entrypoint

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -384,10 +384,27 @@ export async function startTradeBlocksMcp(
   process.on("SIGTERM", shutdown);
 }
 
-const entrypoint = process.argv[1] ? path.resolve(process.argv[1]) : "";
-const currentFile = fileURLToPath(import.meta.url);
+// Resolve the entrypoint path to the actual file that was executed
+// Needed in case command is executed via symlink, often used by node version managers.
+async function resolveEntrypointPath(filePath: string): Promise<string> {
+  const resolved = path.resolve(filePath);
+  try {
+    return await fs.realpath(resolved);
+  } catch {
+    return resolved;
+  }
+}
 
-if (entrypoint === currentFile) {
+async function isDirectEntrypoint(): Promise<boolean> {
+  if (!process.argv[1]) return false;
+
+  const entrypoint = await resolveEntrypointPath(process.argv[1]);
+  const currentFile = await resolveEntrypointPath(fileURLToPath(import.meta.url));
+
+  return entrypoint === currentFile;
+}
+
+if (await isDirectEntrypoint()) {
   startTradeBlocksMcp().catch((error) => {
     console.error("Error:", error.message || error);
     process.exit(1);


### PR DESCRIPTION
# TradeBlocks Pull Request

Tier: 3

## 🧱 What's Changed

The start command for the mcp server checks if `process.argv[1]` equals the server entrypoint file. However, NVM and probably other node version managers will use symlinks to point to different versions of package bins, depending on the version of node you are using. This breaks the MCP entrypoint because `import.meta.url` is the realpath while `process.argv[1]` is the symlink path.

This fix normalizes the path resolution so that it resolves symlinks to the path they point to.

## ✅ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 Code style/formatting changes
- [ ] ♻️ Refactoring (no functional changes)

## 🧪 Testing

- [x] I have tested these changes locally
- [x] The app starts without errors
- [x] All existing functionality still works
- [x] New features work as expected

## 📋 Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if needed

## 🚀 Deployment Notes

None

## 📸 Screenshots (if applicable)

None

---

**Ready to build! 🧱** This PR will automatically deploy a preview on Vercel.
