### PR TITLE
fix: make IV solver worker pool exit-safe (unref idle workers)

### DIFF
--- a/packages/mcp-server/.gitignore
+++ b/packages/mcp-server/.gitignore
@@ -21,3 +21,8 @@ data/*.duckdb
 # (tests/global-setup.mjs) so the worker pool can spawn it under ts-jest.
 src/utils/iv-solver-worker.js
 src/utils/iv-solver-worker.js.map
+
+# Transient child entry bundled beside the pool source by the process-exit
+# safety test (tests/unit/iv-solver-pool-exit.test.ts); removed in afterAll,
+# ignored here so a crashed run never leaves it tracked.
+src/utils/iv-solver-pool-exit-child.built.mjs

--- a/packages/mcp-server/src/utils/iv-solver-pool.ts
+++ b/packages/mcp-server/src/utils/iv-solver-pool.ts
@@ -288,37 +288,52 @@ export class IvSolverPool {
       ok: new Uint8Array(cols.count),
     };
 
-    const base = Math.floor(cols.count / shardCount);
-    const remainder = cols.count % shardCount;
-    const shardPromises: Promise<void>[] = [];
-    let cursor = 0;
-    for (let s = 0; s < shardCount; s++) {
-      const size = base + (s < remainder ? 1 : 0);
-      const lo = cursor;
-      const hi = cursor + size;
-      cursor = hi;
-      if (size === 0) continue;
-      const request = shardRequest(cols, this.nextRequestId++, lo, hi);
-      shardPromises.push(
-        this.runOnWorker(request).then((reply) => {
-          out.delta.set(reply.delta, lo);
-          out.gamma.set(reply.gamma, lo);
-          out.theta.set(reply.theta, lo);
-          out.vega.set(reply.vega, lo);
-          out.iv.set(reply.iv, lo);
-          out.ok.set(reply.ok, lo);
-        }),
-      );
-    }
+    // Ref the workers for the duration of this in-flight solve so the event
+    // loop stays alive until every shard's result is back — the process can't
+    // exit mid-solve and lose results. Idle workers are unref'd (see
+    // ensureWorkers), so once the solve completes the pool stops pinning the
+    // loop and a one-shot process exits naturally.
+    this.refPool();
+    try {
+      const base = Math.floor(cols.count / shardCount);
+      const remainder = cols.count % shardCount;
+      const shardPromises: Promise<void>[] = [];
+      let cursor = 0;
+      for (let s = 0; s < shardCount; s++) {
+        const size = base + (s < remainder ? 1 : 0);
+        const lo = cursor;
+        const hi = cursor + size;
+        cursor = hi;
+        if (size === 0) continue;
+        const request = shardRequest(cols, this.nextRequestId++, lo, hi);
+        shardPromises.push(
+          this.runOnWorker(request).then((reply) => {
+            out.delta.set(reply.delta, lo);
+            out.gamma.set(reply.gamma, lo);
+            out.theta.set(reply.theta, lo);
+            out.vega.set(reply.vega, lo);
+            out.iv.set(reply.iv, lo);
+            out.ok.set(reply.ok, lo);
+          }),
+        );
+      }
 
-    await Promise.all(shardPromises);
-    return out;
+      await Promise.all(shardPromises);
+      return out;
+    } finally {
+      this.unrefPool();
+    }
   }
 
   private ensureWorkers(target: number): void {
     while (this.pool.length < target) {
       const worker = new Worker(this.workerUrl);
       worker.setMaxListeners(0);
+      // Idle workers must not keep the libuv event loop alive — otherwise a
+      // one-shot process that uses the pool and returns normally would hang
+      // forever. solveColumnsParallel ref's the pool for the duration of an
+      // in-flight solve and unref's it again when done.
+      worker.unref();
       // Surface a worker crash by failing loud; an unhandled worker error
       // would otherwise leave the pending shard promise hanging forever.
       worker.on("error", (err) => {
@@ -326,6 +341,16 @@ export class IvSolverPool {
       });
       this.pool.push({ worker, busy: false });
     }
+  }
+
+  /** Keep the event loop alive while a solve is in flight. */
+  private refPool(): void {
+    for (const { worker } of this.pool) worker.ref();
+  }
+
+  /** Release the event loop once a solve completes so idle workers don't pin it. */
+  private unrefPool(): void {
+    for (const { worker } of this.pool) worker.unref();
   }
 
   private runOnWorker(request: IvSolveBatchRequest): Promise<IvSolveBatchReply> {

--- a/packages/mcp-server/tests/fixtures/iv-solver-pool-exit-child.ts
+++ b/packages/mcp-server/tests/fixtures/iv-solver-pool-exit-child.ts
@@ -1,0 +1,51 @@
+/**
+ * Child process for the pool process-exit-safety test.
+ *
+ * Gets the shared pool, runs one parallel solve large enough to spawn real
+ * workers, then returns from main WITHOUT any teardown. If idle workers keep
+ * the event loop alive this process hangs; if they are unref'd it exits on its
+ * own. The parent asserts a clean self-exit within a short timeout.
+ *
+ * Markers on stdout let the parent confirm the pool actually went parallel
+ * (so the assertion isn't vacuously satisfied by an inline degrade).
+ */
+
+import { getSharedIvSolverPool } from "../../src/utils/iv-solver-pool.ts";
+import type { IvSolveJob } from "../../src/utils/iv-solver-pool.ts";
+
+async function main(): Promise<void> {
+  const pool = getSharedIvSolverPool();
+
+  // Comfortably above the inline threshold (2000) so the batch shards across
+  // real workers rather than solving inline on this thread.
+  const count = 8_000;
+  const jobs: IvSolveJob[] = Array.from({ length: count }, (_, i) => ({
+    optionPrice: 30 + (i % 40),
+    underlyingPrice: 5150,
+    strike: 5000 + (i % 300),
+    dte: 5 + (i % 60),
+    type: (i % 2 === 0 ? "C" : "P") as "C" | "P",
+    riskFreeRate: 0.045,
+    dividendYield: 0,
+  }));
+
+  const results = await pool.solve(jobs);
+
+  // Confirm the pool actually held workers (i.e. went parallel). The private
+  // `pool` array is read reflectively only to assert the test exercised the
+  // worker path; production code never reaches in like this.
+  const workerCount = (pool as unknown as { pool: unknown[] }).pool.length;
+  if (workerCount > 0) {
+    process.stdout.write(`SPAWNED_WORKERS=${workerCount}\n`);
+  }
+  process.stdout.write(`SOLVE_DONE=${results.length}\n`);
+
+  // Intentionally NO destroy()/destroySharedIvSolverPool() here. A correct,
+  // exit-safe pool leaves its idle workers unref'd, so returning from main
+  // lets the process exit naturally.
+}
+
+main().catch((err) => {
+  process.stderr.write(`${err?.stack ?? err}\n`);
+  process.exit(1);
+});

--- a/packages/mcp-server/tests/unit/iv-solver-pool-exit.test.ts
+++ b/packages/mcp-server/tests/unit/iv-solver-pool-exit.test.ts
@@ -1,0 +1,110 @@
+/**
+ * iv-solver-pool-exit.test.ts
+ *
+ * Process-exit safety for the shared worker pool.
+ *
+ * The shared pool spawns persistent worker_threads. If those workers keep the
+ * libuv event loop ref'd while idle, a one-shot process that uses the pool and
+ * then returns from main HANGS forever — the workers pin the loop and the
+ * process never exits unless something calls process.exit() or an explicit
+ * teardown. That is a latent hang for every clean-completion path.
+ *
+ * This test builds a small CHILD entry (esbuild → plain-Node .js so it loads on
+ * any Node version, mirroring tests/global-setup.mjs for the worker) that:
+ *   - gets the shared pool,
+ *   - runs one solve large enough to actually spawn workers,
+ *   - returns from main WITHOUT calling any destroy / teardown.
+ * It then asserts the child exits on its own within a short timeout. Idle
+ * workers must be unref'd so the process exits naturally when the real work is
+ * done; an in-flight solve must keep the loop alive so results are never lost.
+ */
+
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { resolve, dirname } from "node:path";
+import { rm } from "node:fs/promises";
+import { build } from "esbuild";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const childSrc = resolve(here, "../fixtures/iv-solver-pool-exit-child.ts");
+// Output beside the pool source (src/utils) so the bundled pool's
+// resolveWorkerUrl() finds the global-setup-built iv-solver-worker.js sibling.
+const childOut = resolve(here, "../../src/utils/iv-solver-pool-exit-child.built.mjs");
+
+interface ChildOutcome {
+  exited: boolean;
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+}
+
+function runChild(timeoutMs: number): Promise<ChildOutcome> {
+  return new Promise((resolvePromise) => {
+    const child = spawn(process.execPath, [childOut], {
+      cwd: here,
+      env: { ...process.env, TRADEBLOCKS_IV_WORKERS: "1" },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (b) => (stdout += b.toString()));
+    child.stderr.on("data", (b) => (stderr += b.toString()));
+
+    let settled = false;
+    const finish = (outcome: ChildOutcome) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolvePromise(outcome);
+    };
+
+    const timer = setTimeout(() => {
+      // The child never exited on its own — the hang we are guarding against.
+      child.kill("SIGKILL");
+      finish({ exited: false, code: null, signal: null, stdout, stderr });
+    }, timeoutMs);
+
+    child.on("exit", (code, signal) => {
+      finish({ exited: true, code, signal, stdout, stderr });
+    });
+  });
+}
+
+describe("IV solver pool — process-exit safety", () => {
+  beforeAll(async () => {
+    // Bundle the child to a plain-Node .mjs so it runs under any Node version
+    // (CI's Node 20 strips no types). The bundle pulls in the pool's .ts
+    // source; `packages: "external"` keeps node:* + deps external, same as the
+    // worker bundle built in tests/global-setup.mjs.
+    await build({
+      entryPoints: [childSrc],
+      outfile: childOut,
+      bundle: true,
+      format: "esm",
+      platform: "node",
+      target: "node18",
+      packages: "external",
+      logLevel: "silent",
+    });
+  });
+
+  afterAll(async () => {
+    await rm(childOut, { force: true });
+  });
+
+  test("a one-shot process exits on its own after a parallel solve (no teardown)", async () => {
+    const outcome = await runChild(5_000);
+
+    const detail = `\nstdout:\n${outcome.stdout}\nstderr:\n${outcome.stderr}`;
+    // The child must reach "spawned workers" — otherwise the solve degraded to
+    // inline and the test would pass vacuously without exercising the pool.
+    expect(outcome.stdout).toContain("SPAWNED_WORKERS");
+    expect(outcome.stdout).toContain("SOLVE_DONE");
+    // The load-bearing assertion: it exited on its own, cleanly, within budget.
+    expect(`${outcome.exited}${detail}`).toBe(`true${detail}`);
+    expect(outcome.signal).toBeNull();
+    expect(outcome.code).toBe(0);
+  }, 20_000);
+});


### PR DESCRIPTION
## Problem
The shared IV solver worker pool kept its `worker_threads` ref'd for the whole process lifetime. A short-lived (one-shot) process that used the pool and then returned normally would never exit — the idle workers pinned the libuv event loop. A process that happened to hit `process.exit()` on an error path exited; clean-completion paths hung, which made it look intermittent.

## Fix
Workers are now `unref()`'d when idle and `ref()`'d only for the duration of an in-flight parallel solve (`refPool()`/`unrefPool()` around the shard dispatch, in a `finally`). The loop stays alive while results are pending, and the process exits cleanly once the work is done. Solve output and the public API are unchanged; the long-running server is unaffected (it stays alive on its own transport handles).

## Test
Adds a regression test: a child process uses the shared pool, solves a batch large enough to spawn workers, and must self-exit within a timeout — it hangs without the fix, exits cleanly with it (verified it spawns real workers, not a vacuous inline-degrade pass). Existing IV/greeks parity tests confirm solve output stays bit-identical.

Tier: 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)