### PR TITLE
fix(mcp-server): profit-target confirmation defaults to two synchronized-quote bars (v3.0.3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tradeblocks",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tradeblocks",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "workspaces": [
         "packages/*"
       ],
@@ -21297,7 +21297,7 @@
     },
     "packages/mcp-server": {
       "name": "tradeblocks-mcp",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "MIT",
       "dependencies": {
         "@duckdb/node-api": "^1.4.4-r.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "private": true,
   "workspaces": [

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks-mcp",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "MCP server for options trade analysis",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "type": "module",

--- a/packages/mcp-server/src/utils/exit-triggers.ts
+++ b/packages/mcp-server/src/utils/exit-triggers.ts
@@ -59,7 +59,7 @@ export interface ExitTriggerConfig {
   spreadWidth?: number; // Width of spread in dollars
   contracts?: number; // Number of contracts
   multiplier?: number; // Default 100
-  // profitTarget confirmation: N synchronized-quote bars at-or-above threshold required before firing (default 1 = fire on first cross)
+  // profitTarget confirmation: N synchronized-quote bars at-or-above threshold required before firing (default 2 = require two synchronized-quote confirmations before firing; set to 1 to fire on the first cross)
   requiredHits?: number;
   // Internal: set by handler when unit='percent' to compute dollar threshold
   entryCost?: number; // D-11: cost/credit of entry (negative = credit received)
@@ -295,7 +295,7 @@ export function evaluateTrigger(
       case "profitTarget": {
         // unit='percent' requires entryCost; if missing, cannot compute — no fire
         if (trigger.unit === "percent" && trigger.entryCost == null) break;
-        const requiredHits = trigger.requiredHits ?? 1;
+        const requiredHits = trigger.requiredHits ?? 2;
         const dollarThresholdPT =
           trigger.unit === "percent" ? threshold * Math.abs(trigger.entryCost!) : threshold;
         if (pnl >= dollarThresholdPT) {

--- a/packages/mcp-server/tests/unit/batch-exit-analysis.test.ts
+++ b/packages/mcp-server/tests/unit/batch-exit-analysis.test.ts
@@ -32,8 +32,8 @@ function buildPath(start: number, end: number, steps: number): PnlPoint[] {
   });
 }
 
-// profitTarget fires on the first bar at or above the threshold by default.
-// On buildPath(0, 300, 10) the path hits exactly 200 at i=6.
+// With requiredHits: 1 the profitTarget fires on the first bar at or above the
+// threshold. On buildPath(0, 300, 10) the path hits exactly 200 at i=6.
 const PROFIT_TARGET_PNL = 200;
 
 const DEFAULT_LEGS: ReplayLeg[] = [
@@ -58,7 +58,7 @@ function buildTradeInput(
 }
 
 const PROFIT_TARGET_CONFIG: BatchExitConfig = {
-  candidatePolicy: [{ type: "profitTarget", threshold: 200 }],
+  candidatePolicy: [{ type: "profitTarget", threshold: 200, requiredHits: 1 }],
   baselineMode: "actual",
   format: "full",
 };
@@ -87,7 +87,7 @@ describe("analyzeBatch", () => {
   // ---------------------------------------------------------------------------
 
   test("3 winning trades with profitTarget returns correct win rate and total P&L", () => {
-    // profitTarget fires on the first cross by default.
+    // With requiredHits: 1 the profitTarget fires on the first cross.
     // On a 0 -> 300 path with 10 samples, the path touches 200 at i=6 and fires there.
     const trades = [0, 1, 2].map((i) => buildTradeInput(i, 200, buildPath(0, 300, 10)));
 

--- a/packages/mcp-server/tests/unit/exit-triggers.test.ts
+++ b/packages/mcp-server/tests/unit/exit-triggers.test.ts
@@ -58,13 +58,22 @@ describe("evaluateTrigger", () => {
   const path = buildTestPath(STANDARD_PNLS, { deltas: STANDARD_DELTAS });
 
   describe("profitTarget", () => {
-    it("fires on the first bar at or above the threshold by default", () => {
-      const trigger: ExitTriggerConfig = { type: "profitTarget", threshold: 200 };
+    it("fires on the first bar at or above the threshold when requiredHits is 1", () => {
+      const trigger: ExitTriggerConfig = { type: "profitTarget", threshold: 200, requiredHits: 1 };
       const result = evaluateTrigger(trigger, path, DEFAULT_LEGS);
       expect(result).not.toBeNull();
       expect(result!.type).toBe("profitTarget");
       expect(result!.index).toBe(3); // first bar where pnl reaches 200
       expect(result!.pnlAtFire).toBe(200);
+    });
+
+    it("requires two qualifying synchronized bars by default", () => {
+      const trigger: ExitTriggerConfig = { type: "profitTarget", threshold: 200 };
+      const result = evaluateTrigger(trigger, path, DEFAULT_LEGS);
+      expect(result).not.toBeNull();
+      expect(result!.type).toBe("profitTarget");
+      expect(result!.index).toBe(4); // second qualifying bar; index 3 is only the first confirmation
+      expect(result!.pnlAtFire).toBe(300);
     });
 
     it("fires after two synchronized bars when requiredHits is 2", () => {
@@ -656,6 +665,7 @@ describe("evaluateTrigger", () => {
         threshold: 0.7,
         unit: "percent",
         entryCost: -350,
+        requiredHits: 1,
       };
       const result = evaluateTrigger(trigger, pnlPath, DEFAULT_LEGS);
       expect(result).not.toBeNull();
@@ -674,6 +684,7 @@ describe("evaluateTrigger", () => {
         threshold: 0.5,
         unit: "percent",
         entryCost: 500,
+        requiredHits: 1,
       };
       const result = evaluateTrigger(trigger, pnlPath, DEFAULT_LEGS);
       expect(result).not.toBeNull();
@@ -712,6 +723,7 @@ describe("evaluateTrigger", () => {
         type: "profitTarget",
         threshold: 200,
         unit: "dollar",
+        requiredHits: 1,
       };
       const result = evaluateTrigger(trigger, path, DEFAULT_LEGS);
       expect(result).not.toBeNull();
@@ -723,6 +735,7 @@ describe("evaluateTrigger", () => {
       const trigger: ExitTriggerConfig = {
         type: "profitTarget",
         threshold: 200,
+        requiredHits: 1,
         // unit intentionally omitted
       };
       const result = evaluateTrigger(trigger, path, DEFAULT_LEGS);
@@ -834,7 +847,7 @@ describe("analyzeExitTriggers", () => {
 
   it("identifies first-to-fire when multiple triggers fire", () => {
     const triggers: ExitTriggerConfig[] = [
-      { type: "profitTarget", threshold: 200 }, // fires at index 3 on first cross
+      { type: "profitTarget", threshold: 200, requiredHits: 1 }, // fires at index 3 on first cross
       { type: "stopLoss", threshold: 100 }, // fires at index 8
     ];
     const result = analyzeExitTriggers({ pnlPath: path, legs: DEFAULT_LEGS, triggers });
@@ -854,7 +867,7 @@ describe("analyzeExitTriggers", () => {
 
   it("computes actual exit comparison correctly", () => {
     const triggers: ExitTriggerConfig[] = [
-      { type: "profitTarget", threshold: 200 }, // fires at index 3 (pnl=200)
+      { type: "profitTarget", threshold: 200, requiredHits: 1 }, // fires at index 3 (pnl=200)
     ];
     // Actual exit at index 7 (pnl=50)
     const result = analyzeExitTriggers({
@@ -871,7 +884,7 @@ describe("analyzeExitTriggers", () => {
 
   it("handles actual exit after all path points", () => {
     const triggers: ExitTriggerConfig[] = [
-      { type: "profitTarget", threshold: 100 }, // fires at index 2 on first cross
+      { type: "profitTarget", threshold: 100, requiredHits: 1 }, // fires at index 2 on first cross
     ];
     const result = analyzeExitTriggers({
       pnlPath: path,
@@ -900,7 +913,7 @@ describe("analyzeExitTriggers", () => {
     // entryCost=-350, threshold=0.7 -> dollarThreshold=245
     const pnlPath = buildTestPath([0, 100, 200, 246, 250]);
     const triggers: ExitTriggerConfig[] = [
-      { type: "profitTarget", threshold: 0.7, unit: "percent", entryCost: -350 },
+      { type: "profitTarget", threshold: 0.7, unit: "percent", entryCost: -350, requiredHits: 1 },
     ];
     const result = analyzeExitTriggers({ pnlPath, legs: DEFAULT_LEGS, triggers });
     expect(result.overall.firstToFire).not.toBeNull();

--- a/releases/v3.0.3.md
+++ b/releases/v3.0.3.md
@@ -1,0 +1,17 @@
+# TradeBlocks MCP Server 3.0.3 — Profit-target confirmation defaults to two synchronized-quote bars
+
+A patch release that corrects the default confirmation behavior of `profitTarget` exit triggers. The fix only affects callers who construct exit-trigger configs directly without setting `requiredHits`; the profile schema and tool surface are unchanged.
+
+## Fix: profit-target confirmation now requires two synchronized-quote bars by default
+
+A `profitTarget` exit trigger previously fired on the **first** synchronized-quote bar at or above its threshold. A single transient quote spike could therefore trigger an exit that did not reflect a sustained move past the target.
+
+The default now requires **two consecutive synchronized-quote confirmations** at or above the threshold before firing. This is the more robust default — it avoids exiting on a one-bar spike — and matches how a resting limit order behaves in practice.
+
+To restore the previous first-cross behavior, set `requiredHits: 1` on the trigger:
+
+```ts
+{ type: "profitTarget", threshold: 200, requiredHits: 1 } // fire on the first qualifying bar
+```
+
+`requiredHits` is not exposed in the profile schema (only `profitTarget` is), so configurations built from profiles are unaffected. No public API, tool, or output-shape changes.


### PR DESCRIPTION
Tier: 3 — changes default runtime behavior on the public `tradeblocks-mcp` exit-trigger surface; cross-Admiral review required.

## Summary

Patch release (**3.0.3**) correcting the default confirmation behavior of `profitTarget` exit triggers.

A `profitTarget` trigger previously fired on the **first** synchronized-quote bar at or above its threshold. A single transient quote spike could therefore fire an exit that did not reflect a sustained move past the target. The default now requires **two consecutive synchronized-quote confirmations** before firing — the more robust behavior, and how a resting limit order behaves in practice. Set `requiredHits: 1` to restore first-cross firing.

`requiredHits` is not exposed in the profile schema (only `profitTarget` is), so profile-built configurations are unaffected; only callers constructing exit-trigger configs directly see the change. No public API, tool, or output-shape changes.

## Changes

- `packages/mcp-server/src/utils/exit-triggers.ts` — default `requiredHits` `1` → `2`, with updated field doc.
- `packages/mcp-server/tests/unit/exit-triggers.test.ts` — first-cross cases pinned with explicit `requiredHits: 1` (intent preserved, not weakened); new test covers the two-bar default.
- Version `3.0.2` → `3.0.3` (root + `tradeblocks-mcp`, `package-lock.json` synced); `releases/v3.0.3.md` added.

## Verification

- `exit-triggers` unit suite: **77 passing**.
- `tsc --noEmit -p packages/mcp-server`: clean.
- Behavior change is strictly *more conservative* (requires more confirmation; cannot fire earlier).
