### PR TITLE
feat(db): shared resolveDbPath + split backtests schema DDL from the trades purge

### DIFF
--- a/packages/mcp-server/src/db/backtest-schemas.ts
+++ b/packages/mcp-server/src/db/backtest-schemas.ts
@@ -78,14 +78,20 @@ export async function detachBacktestsDb(conn: DuckDBConnection): Promise<void> {
 }
 
 /**
- * Ensure backtests tables exist in the attached backtests.duckdb.
+ * Ensure the backtests schema (tables + additive migrations) exists in the
+ * attached backtests.duckdb. **Pure DDL — requires ONLY the `backtests` catalog
+ * attached, never `trades`.** This is the standalone-safe primitive a bare
+ * `backtests.duckdb` bootstrap (a `db init` step) calls to mint an empty,
+ * correctly-schema'd DB with no other catalog present.
  *
- * Must be called AFTER `ATTACH '...' AS backtests` in openReadWriteConnection.
- * Uses CREATE TABLE IF NOT EXISTS for idempotency — safe to call on every RW open.
+ * Must be called AFTER `ATTACH '...' AS backtests`. Uses CREATE TABLE IF NOT
+ * EXISTS for idempotency — safe to call on every RW open. Does NOT run the
+ * Phase-b72 trades purge (that lives in ensureBacktestsTables / the callers that
+ * hold the `trades` catalog).
  *
  * @param conn - Active DuckDB connection with backtests catalog attached
  */
-export async function ensureBacktestsTables(conn: DuckDBConnection): Promise<void> {
+export async function ensureBacktestsSchema(conn: DuckDBConnection): Promise<void> {
   // Strategy definitions: one row per (strategy_name, underlying) pair.
   // definition_json stores the full StrategyDefinition object.
   await conn.run(`
@@ -181,7 +187,23 @@ export async function ensureBacktestsTables(conn: DuckDBConnection): Promise<voi
   } catch {
     // Column already exists — idempotent
   }
+}
 
+/**
+ * Ensure the backtests schema AND run the one-time Phase-b72 purge of stale
+ * `source='tradeblocks'` rows from `trades.trade_data`. Behavior is unchanged
+ * from before the schema/purge split — every existing caller keeps the same
+ * effect. **Requires the `trades` catalog attached RW** (via the purge), as
+ * every RW engine open has.
+ *
+ * New callers that need ONLY the schema (e.g. minting a standalone
+ * `backtests.duckdb` with no `trades` catalog attached) must call
+ * ensureBacktestsSchema instead — this wrapper would throw on the purge.
+ *
+ * @param conn - Active DuckDB connection with backtests AND trades catalogs attached (RW)
+ */
+export async function ensureBacktestsTables(conn: DuckDBConnection): Promise<void> {
+  await ensureBacktestsSchema(conn);
   // Purge stale backtest rows from trades.trade_data (Phase b72 one-time migration).
   // Removes all rows written by prior backtest runs (source = 'tradeblocks').
   // Idempotent — DELETE WHERE returns 0 rows when nothing matches.

--- a/packages/mcp-server/src/db/data-root.ts
+++ b/packages/mcp-server/src/db/data-root.ts
@@ -17,8 +17,30 @@
  * contexts, or sandboxed iframes will see the same divergence across realm
  * boundaries and must coordinate state another way.
  */
+import path from "node:path";
+
 const KEY = "__tradeblocks_data_root__";
 type GlobalSlot = { [KEY]?: string | null };
+
+/**
+ * The DuckDB files that live under a data root's `database/` subdirectory.
+ *   - `analytics` — the base DB hosting the `trades` schema (CSV-imported blocks)
+ *   - `market`    — attached market data (`market.duckdb`)
+ *   - `backtests` — the backtest run-persistence index (`backtests.duckdb`)
+ */
+export type DbKind = "analytics" | "market" | "backtests";
+
+/**
+ * Single source of truth for where a DuckDB file lives under a data root:
+ * `<dataRoot>/database/<kind>.duckdb`. Every writer and reader across the fleet
+ * (the engine's backtests-db resolver, the console reader, the calibration
+ * probe) MUST resolve through this so the `database/` segment can never drift —
+ * a missing segment silently splits reads from writes (runs succeed, the console
+ * shows an empty history forever). See tradeblocks-org/enterprise#983.
+ */
+export function resolveDbPath(dataRoot: string, kind: DbKind): string {
+  return path.join(dataRoot, "database", `${kind}.duckdb`);
+}
 
 export function setDataRoot(dir: string): void {
   (globalThis as GlobalSlot)[KEY] = dir;

--- a/packages/mcp-server/src/utils/calibration-probe.ts
+++ b/packages/mcp-server/src/utils/calibration-probe.ts
@@ -16,9 +16,9 @@
  * Manual-only — purposefully side-effectful (opens a live DuckDB, calls the
  * singleton provider). No unit test; exists for operator inspection.
  */
-import * as path from "path";
 import { DuckDBInstance } from "@duckdb/node-api";
 import { getProvider } from "./market-provider.ts";
+import { resolveDbPath } from "../db/data-root.ts";
 
 /** Per-date probe result returned alongside the summary deltas. */
 export interface CalibrationProbeDateResult {
@@ -59,7 +59,7 @@ export async function calibrateProviderFetch(
   dataRoot: string,
 ): Promise<CalibrationProbeResult> {
   const provider = getProvider();
-  const dbPath = path.join(dataRoot, "database", "market.duckdb");
+  const dbPath = resolveDbPath(dataRoot, "market");
   const instance = await DuckDBInstance.create(dbPath);
   const conn = await instance.connect();
 

--- a/packages/mcp-server/tests/integration/backtest-schemas.test.ts
+++ b/packages/mcp-server/tests/integration/backtest-schemas.test.ts
@@ -14,6 +14,7 @@ import { join } from "node:path";
 // @ts-expect-error - importing from src (not bundled output)
 import {
   attachBacktestsDb,
+  ensureBacktestsSchema,
   ensureBacktestsTables,
   detachBacktestsDb,
   TEMPLATE_BLOCK_ID,
@@ -89,6 +90,44 @@ describe("backtest-schemas integration", () => {
 
     conn.closeSync();
     inst2.closeSync();
+  });
+
+  it("ensureBacktestsSchema creates the schema with NO trades catalog attached (standalone-safe)", async () => {
+    // The bootstrap guarantee for a standalone `db init` (tradeblocks-org/enterprise#983):
+    // mint a standalone backtests.duckdb with no analytics/trades catalog present.
+    // Deliberately NO setupTradesSchema() here — the pure-DDL path must not need it.
+    const inst = await DuckDBInstance.create(":memory:");
+    const conn = await inst.connect();
+
+    const dbPath = join(tmpDir, "backtests-standalone.duckdb");
+    await attachBacktestsDb(conn, dbPath, "read_write");
+    await ensureBacktestsSchema(conn);
+
+    const tables = await conn.runAndReadAll(
+      "SELECT table_name FROM information_schema.tables WHERE table_catalog = 'backtests' ORDER BY table_name",
+    );
+    const names = tables.getRows().map((r: unknown[]) => String(r[0]));
+    expect(names).toEqual(["run_metadata", "skip_log", "strategies", "trade_data"]);
+
+    // Idempotent standalone, too.
+    await ensureBacktestsSchema(conn);
+
+    conn.closeSync();
+    inst.closeSync();
+  });
+
+  it("ensureBacktestsTables (schema + purge) still throws without a trades catalog", async () => {
+    // Guards the split: the wrapper keeps its trades-dependent purge, so callers
+    // that need the standalone path must use ensureBacktestsSchema, not this.
+    const inst = await DuckDBInstance.create(":memory:");
+    const conn = await inst.connect();
+
+    const dbPath = join(tmpDir, "backtests-wrapper-notrades.duckdb");
+    await attachBacktestsDb(conn, dbPath, "read_write");
+    await expect(ensureBacktestsTables(conn)).rejects.toThrow();
+
+    conn.closeSync();
+    inst.closeSync();
   });
 
   it("detachBacktestsDb detaches cleanly", async () => {

--- a/packages/mcp-server/tests/unit/data-root.test.ts
+++ b/packages/mcp-server/tests/unit/data-root.test.ts
@@ -4,11 +4,32 @@
  * Tests the setDataRoot/getDataRoot/resetDataRoot pattern
  * that allows --data-root CLI flag to override the data root directory.
  */
-import { setDataRoot, getDataRoot, resetDataRoot } from "../../src/db/data-root.ts";
+import { setDataRoot, getDataRoot, resetDataRoot, resolveDbPath } from "../../src/db/data-root.ts";
+import { join } from "node:path";
 
 describe("data-root", () => {
   afterEach(() => {
     resetDataRoot();
+  });
+
+  describe("resolveDbPath (single source of truth for <dataRoot>/database/<kind>.duckdb)", () => {
+    it("resolves each DuckDB kind under the database/ subdirectory", () => {
+      expect(resolveDbPath("/data", "backtests")).toBe(
+        join("/data", "database", "backtests.duckdb"),
+      );
+      expect(resolveDbPath("/data", "market")).toBe(join("/data", "database", "market.duckdb"));
+      expect(resolveDbPath("/data", "analytics")).toBe(
+        join("/data", "database", "analytics.duckdb"),
+      );
+    });
+
+    it("always includes the database/ segment (the drift guard — enterprise#983)", () => {
+      // The whole point: a writer that omits `database/` silently splits from a
+      // reader that includes it. Every path this resolver returns carries it.
+      for (const kind of ["backtests", "market", "analytics"] as const) {
+        expect(resolveDbPath("/x/y", kind).split("/")).toContain("database");
+      }
+    });
   });
 
   it("getDataRoot returns fallback when no data root is set", () => {


### PR DESCRIPTION
Tier: 3 — public library-surface change (additive exports on the published mcp-server db layer).

Foundation for tradeblocks-org/enterprise#983 (P2 of umbrella #980): make holodeck's `backtests.duckdb` bootstrap robust for the enterprise-console. This is the public-library half; the holodeck `db init` command (P2b) and the console preflight degrade (P2c) consume it and land separately.

## Changes (additive, backwards-compatible)
1. **`resolveDbPath(dataRoot, kind)`** in `db/data-root.ts` — single source of truth for `<dataRoot>/database/<kind>.duckdb`. The drift guard: the engine currently writes `<baseDir>/backtests.duckdb` while the console reads `<dataRoot>/database/backtests.duckdb`; a missing `database/` segment silently splits writes from reads (runs succeed, history shows empty forever). `calibration-probe.ts` now resolves `market.duckdb` through it. (Engine + console resolvers migrate onto it in P2b/P2c.)
2. **Split `ensureBacktestsTables` → `ensureBacktestsSchema` (pure DDL) + unchanged wrapper.** `ensureBacktestsSchema` needs ONLY the `backtests` catalog (never `trades`), so a bare `backtests.duckdb` can be minted standalone. `ensureBacktestsTables` is unchanged in signature and behavior (= `ensureBacktestsSchema` + `purgeStaleBacktestTrades`).

## Backwards-compat
Strictly additive: two new exports + one new type, all on already-published subpaths. No existing export changed. The sole production caller of `ensureBacktestsTables` (holodeck `initConnectionExt`, separate repo via `file:` dep) behaves identically — safe to land ahead of holodeck (no interim window).

## Verification
14 mcp-server tests green (incl. standalone-schema-without-trades, wrapper-throws-without-trades, resolveDbPath drift-guard cases); `tsc --noEmit` clean; prettier clean; `verify:exports` OK (28 entries).

## Worf gate
CLEAR (Tier 3 confirmed). Strictly additive, no existing behavior change, split verified by source reading, no interim-window risk. Cross-Admiral review requested per the public-repo Tier-3 protocol.

Refs tradeblocks-org/enterprise#983, #980.
