### PR TITLE
feat(lib): paired day-block bootstrap — masked, gap-aware, selection-adjusted CI primitive (v3.1.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tradeblocks",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tradeblocks",
-      "version": "3.0.3",
+      "version": "3.1.0",
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "private": true,
   "workspaces": [

--- a/packages/lib/calculations/index.ts
+++ b/packages/lib/calculations/index.ts
@@ -41,6 +41,7 @@ export * from "./walk-forward-interpretation.ts";
 export * from "./enrich-trades.ts";
 export * from "./statistical-utils.ts";
 export * from "./mfe-mae.ts";
+export * from "./paired-block-bootstrap.ts";
 
 // Re-export types for convenience
 export * from "../models/portfolio-stats.ts";

--- a/packages/lib/calculations/paired-block-bootstrap.ts
+++ b/packages/lib/calculations/paired-block-bootstrap.ts
@@ -1,0 +1,635 @@
+/**
+ * Paired Day-Block Bootstrap
+ *
+ * A paired, holding-period-aware, selection-adjusted day-block bootstrap for
+ * comparing two day-indexed value series (arms) that may each be dormant on
+ * arbitrary days.
+ *
+ * The primitive answers "how different are arm A and arm B?" while honoring
+ * four structural realities that a naive bootstrap ignores:
+ *
+ *   1. Intersection masking. The paired difference exists only on days where
+ *      BOTH arms are observed. Not-observed days are absent from the analysis,
+ *      never injected as zeros. A true zero on an observed day is a datum.
+ *   2. Serial dependence. Resampling draws contiguous day-blocks (moving-block
+ *      bootstrap) whose length is derived from the caller's holding periods, so
+ *      the confidence interval widens honestly when returns cluster in time.
+ *   3. Gap awareness. A drawn block never crosses a dormancy gap and never
+ *      wraps the series end; blocks live inside contiguous observed runs.
+ *   4. Selection. When several candidate comparisons are considered and only the
+ *      extremum is reported, the bootstrap distribution is of "the selected
+ *      extremum", so the interval is selection-adjusted by construction.
+ *
+ * All numeric parameters that would otherwise encode domain assumptions --
+ * block length, the effective-N floor, the resample count -- are required
+ * inputs or derived from the caller's own data. Nothing about any particular
+ * market or instrument is baked into this module.
+ */
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * A single arm's daily contribution.
+ *
+ * The three arrays are parallel and equal-length. `index` holds ISO trading
+ * days in ascending order; contiguity of the calendar is NOT assumed. `values`
+ * holds the arm's contribution on each day. `observedMask` marks whether the
+ * arm was observed that day -- `true` means observed (traded, or a genuine flat
+ * zero), `false` means dormant / not-observed and is excluded entirely.
+ */
+export interface DaySeries {
+  index: string[];
+  values: number[];
+  observedMask: boolean[];
+}
+
+/** A constant comparand -- arm B replaced by a fixed threshold value. */
+export interface ConstantArm {
+  constant: number;
+}
+
+/**
+ * Holding-period rule.
+ *
+ * `blockDays` is the moving-block length in trading days. `sensitivity`, when
+ * provided, lists multipliers applied to `blockDays` for supplementary runs
+ * (e.g. `[0.5, 2]` reruns the interval at half and double the block length).
+ */
+export interface HoldingPeriodRule {
+  blockDays: number;
+  sensitivity?: number[];
+}
+
+/** A member of a selection set -- one candidate comparison. */
+export interface SelectionMember {
+  id: string;
+  armA: DaySeries;
+  armB?: DaySeries | ConstantArm;
+}
+
+/** The set of candidate comparisons whose extremum is being reported. */
+export interface SelectionSet {
+  members: SelectionMember[];
+  extremum: "max" | "min";
+}
+
+export interface PairedBlockBootstrapInput {
+  armA: DaySeries;
+  /** Omitted -> single-arm mode; a constant -> arm A minus threshold. */
+  armB?: DaySeries | ConstantArm;
+  /** Functional evaluated on the (possibly resampled) intersection delta series. */
+  statistic: (delta: number[]) => number;
+  holdingRule: HoldingPeriodRule;
+  /** Confidence level in (0, 1), e.g. 0.95. */
+  ciLevel: number;
+  /** Number of bootstrap resamples. Required -- no baked-in default. */
+  resamples: number;
+  /** Seed for the internal PRNG. Identical input + seed -> identical result. */
+  seed: number;
+  /**
+   * When present, the reported point and interval describe the extremum of the
+   * members' statistics rather than the single armA/armB comparison. The
+   * members drive the overlap, block structure and interval; armA/armB are the
+   * fallback comparison used only when this is absent.
+   */
+  selectionSet?: SelectionSet;
+  /**
+   * Caller-calibrated minimum effective-N (in blocks). When effectiveN falls
+   * below it the result is `notComparable` with a null interval.
+   */
+  effectiveNFloorBlocks?: number;
+}
+
+export interface ConfidenceInterval {
+  level: number;
+  low: number | null;
+  high: number | null;
+  method: "paired-day-block";
+}
+
+/**
+ * One supplementary run at a multiplied block length. Emitted for every
+ * requested multiplier: a run that could not resolve carries its honest
+ * `status` (`underpowered` / `notComparable`) with null CI bounds rather than
+ * being dropped.
+ */
+export interface SensitivityEntry {
+  blockDays: number;
+  ci: { low: number | null; high: number | null };
+  status: PairedBlockBootstrapStatus;
+}
+
+export interface SelectionSummary {
+  /** Mean of the members' point statistics. */
+  centroid: number;
+  /** How far the selected extremum beats the next-best member (>= 0). */
+  maxGap: number;
+  /** Number of members considered. */
+  kConsidered: number;
+}
+
+export type PairedBlockBootstrapStatus = "resolved" | "underpowered" | "notComparable";
+
+export interface PairedBlockBootstrapResult {
+  point: number | null;
+  ci: ConfidenceInterval;
+  /** Intersection overlap days divided by the block length. */
+  effectiveN: number;
+  overlapWindow: { start: string; end: string } | null;
+  blockDays: number;
+  sensitivity: SensitivityEntry[];
+  selection: SelectionSummary | null;
+  status: PairedBlockBootstrapStatus;
+  seed: number;
+}
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+/** A maximal run of contiguous observed days within the ambient grid. */
+interface ObservedRun {
+  /** Start index into the overlap `days`/`delta` arrays (inclusive). */
+  start: number;
+  /** Run length in days. */
+  length: number;
+}
+
+/** The intersection overlap of a single comparison. */
+interface Overlap {
+  days: string[];
+  delta: number[];
+  runs: ObservedRun[];
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic PRNG (mulberry32)
+// ---------------------------------------------------------------------------
+
+/**
+ * mulberry32 -- a small, self-contained, fully-deterministic PRNG. Chosen over
+ * Math.random so that identical input and seed yield byte-identical results.
+ *
+ * @param seed - 32-bit integer seed
+ * @returns Function returning uniform draws in [0, 1)
+ */
+function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return function () {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Mix a seed with the block length so sensitivity runs decorrelate deterministically. */
+function deriveSeed(seed: number, blockDays: number): number {
+  return (seed + Math.imul(blockDays, 0x9e3779b1)) >>> 0;
+}
+
+// ---------------------------------------------------------------------------
+// Numeric helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Type-7 (linear-interpolation) percentile of a pre-sorted ascending array.
+ */
+function percentileOf(sorted: number[], p: number): number {
+  const n = sorted.length;
+  if (n === 1) return sorted[0];
+  const rank = p * (n - 1);
+  const lo = Math.floor(rank);
+  const hi = Math.ceil(rank);
+  if (lo === hi) return sorted[lo];
+  const weight = rank - lo;
+  return sorted[lo] * (1 - weight) + sorted[hi] * weight;
+}
+
+// ---------------------------------------------------------------------------
+// Overlap construction
+// ---------------------------------------------------------------------------
+
+/** Build a day -> value map over an arm's observed days only. */
+function observedValueMap(arm: DaySeries): Map<string, number> {
+  const map = new Map<string, number>();
+  for (let i = 0; i < arm.index.length; i++) {
+    if (arm.observedMask[i]) {
+      map.set(arm.index[i], arm.values[i]);
+    }
+  }
+  return map;
+}
+
+function isConstantArm(arm: DaySeries | ConstantArm | undefined): arm is ConstantArm {
+  return arm !== undefined && "constant" in arm;
+}
+
+/**
+ * Sorted unique union of two ascending ISO-day arrays.
+ */
+function unionDays(a: string[], b: string[]): string[] {
+  const seen = new Set<string>();
+  for (const d of a) seen.add(d);
+  for (const d of b) seen.add(d);
+  return Array.from(seen).sort();
+}
+
+/**
+ * Walk an ambient day grid, emitting the intersection delta on observed days
+ * and segmenting the emitted days into maximal contiguous runs. A day that is
+ * present in the ambient grid but not jointly observed breaks the current run,
+ * which is exactly how a dormancy gap prevents a block from spanning it.
+ */
+function buildOverlap(
+  ambient: string[],
+  isObserved: (day: string) => boolean,
+  deltaOf: (day: string) => number,
+): Overlap {
+  const days: string[] = [];
+  const delta: number[] = [];
+  const runs: ObservedRun[] = [];
+  let runStart = -1;
+
+  for (const day of ambient) {
+    if (isObserved(day)) {
+      if (runStart === -1) runStart = days.length;
+      days.push(day);
+      delta.push(deltaOf(day));
+    } else if (runStart !== -1) {
+      runs.push({ start: runStart, length: days.length - runStart });
+      runStart = -1;
+    }
+  }
+  if (runStart !== -1) {
+    runs.push({ start: runStart, length: days.length - runStart });
+  }
+
+  return { days, delta, runs };
+}
+
+/**
+ * Build the paired intersection overlap for a single comparison.
+ *
+ *   - armB omitted    -> delta_t = armA_t on armA's observed days
+ *   - armB {constant} -> delta_t = armA_t - c on armA's observed days
+ *   - armB DaySeries  -> delta_t = armA_t - armB_t on jointly-observed days
+ */
+function buildComparisonOverlap(armA: DaySeries, armB?: DaySeries | ConstantArm): Overlap {
+  const mapA = observedValueMap(armA);
+
+  if (armB === undefined || isConstantArm(armB)) {
+    const c = armB === undefined ? 0 : armB.constant;
+    return buildOverlap(
+      armA.index,
+      (day) => mapA.has(day),
+      (day) => mapA.get(day)! - c,
+    );
+  }
+
+  const mapB = observedValueMap(armB);
+  const ambient = unionDays(armA.index, armB.index);
+  return buildOverlap(
+    ambient,
+    (day) => mapA.has(day) && mapB.has(day),
+    (day) => mapA.get(day)! - mapB.get(day)!,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Block enumeration
+// ---------------------------------------------------------------------------
+
+/**
+ * Global start indices of every valid moving block of length `blockDays`.
+ *
+ * Within each run a block may start at [0, runLength - blockDays]; a block never
+ * crosses a run boundary (a gap) and never wraps the series end. The returned
+ * indices point into the overlap `days`/`delta` arrays.
+ */
+function enumerateBlockStarts(runs: ObservedRun[], blockDays: number): number[] {
+  const starts: number[] = [];
+  for (const run of runs) {
+    const lastStart = run.length - blockDays;
+    for (let offset = 0; offset <= lastStart; offset++) {
+      starts.push(run.start + offset);
+    }
+  }
+  return starts;
+}
+
+/**
+ * Draw a resampled sequence of overlap positions of length `n` by concatenating
+ * moving blocks drawn with replacement, truncating the final block to length.
+ */
+function drawResampleIndices(
+  rng: () => number,
+  blockStarts: number[],
+  blockDays: number,
+  n: number,
+): number[] {
+  const indices: number[] = [];
+  while (indices.length < n) {
+    const start = blockStarts[Math.floor(rng() * blockStarts.length)];
+    for (let k = 0; k < blockDays && indices.length < n; k++) {
+      indices.push(start + k);
+    }
+  }
+  return indices;
+}
+
+// ---------------------------------------------------------------------------
+// Core interval computation
+// ---------------------------------------------------------------------------
+
+interface CoreResult {
+  point: number | null;
+  low: number | null;
+  high: number | null;
+  effectiveN: number;
+  status: PairedBlockBootstrapStatus;
+}
+
+/**
+ * Compute the point statistic, effective-N, status and (when powered) the
+ * bootstrap percentile interval for one block length.
+ *
+ * `deltaSeries` is the base comparison's delta. When `memberDeltas` is supplied
+ * the resampled draw indices are applied to every member and the extremum is
+ * taken within each resample -- the selection-adjusted path. Both paths share
+ * the same drawn indices across every series (paired resampling).
+ */
+function computeCore(params: {
+  overlapDays: string[];
+  runs: ObservedRun[];
+  deltaSeries: number[];
+  memberDeltas?: number[][];
+  extremum?: "max" | "min";
+  blockDays: number;
+  resamples: number;
+  seed: number;
+  ciLevel: number;
+  statistic: (delta: number[]) => number;
+  effectiveNFloorBlocks?: number;
+}): CoreResult {
+  const {
+    overlapDays,
+    runs,
+    deltaSeries,
+    memberDeltas,
+    extremum,
+    blockDays,
+    resamples,
+    seed,
+    ciLevel,
+    statistic,
+    effectiveNFloorBlocks,
+  } = params;
+
+  const n = overlapDays.length;
+  const effectiveN = n / blockDays;
+
+  const takeExtremum = (values: number[]): number =>
+    extremum === "min" ? Math.min(...values) : Math.max(...values);
+
+  // Point statistic on the observed (non-resampled) data.
+  let point: number | null;
+  if (n === 0) {
+    point = null;
+  } else if (memberDeltas) {
+    point = takeExtremum(memberDeltas.map((d) => statistic(d)));
+  } else {
+    point = statistic(deltaSeries);
+  }
+
+  const blockStarts = enumerateBlockStarts(runs, blockDays);
+
+  // Honest refusal: caller-calibrated power floor takes precedence.
+  if (effectiveNFloorBlocks !== undefined && effectiveN < effectiveNFloorBlocks) {
+    return { point, low: null, high: null, effectiveN, status: "notComparable" };
+  }
+
+  // Structurally degenerate: cannot draw a bootstrap distribution.
+  if (blockStarts.length < 2) {
+    return { point, low: null, high: null, effectiveN, status: "underpowered" };
+  }
+
+  const rng = mulberry32(deriveSeed(seed, blockDays));
+  const distribution: number[] = new Array(resamples);
+  for (let r = 0; r < resamples; r++) {
+    const idx = drawResampleIndices(rng, blockStarts, blockDays, n);
+    if (memberDeltas) {
+      const stats = memberDeltas.map((d) => statistic(idx.map((i) => d[i])));
+      distribution[r] = takeExtremum(stats);
+    } else {
+      distribution[r] = statistic(idx.map((i) => deltaSeries[i]));
+    }
+  }
+
+  distribution.sort((a, b) => a - b);
+  const alpha = 1 - ciLevel;
+  const low = percentileOf(distribution, alpha / 2);
+  const high = percentileOf(distribution, 1 - alpha / 2);
+
+  return { point, low, high, effectiveN, status: "resolved" };
+}
+
+// ---------------------------------------------------------------------------
+// Selection overlap
+// ---------------------------------------------------------------------------
+
+interface SelectionOverlap {
+  days: string[];
+  runs: ObservedRun[];
+  /** Each member's delta aligned to the common `days` axis. */
+  memberDeltas: number[][];
+}
+
+/**
+ * Build the overlap shared across every selection member: the days on which
+ * ALL members are jointly observed. Every drawn block is therefore valid for
+ * every member simultaneously, so the same drawn indices pair coherently across
+ * the whole selection set.
+ */
+function buildSelectionOverlap(members: SelectionMember[]): SelectionOverlap {
+  const memberMaps = members.map((m) => {
+    const overlap = buildComparisonOverlap(m.armA, m.armB);
+    const map = new Map<string, number>();
+    for (let i = 0; i < overlap.days.length; i++) {
+      map.set(overlap.days[i], overlap.delta[i]);
+    }
+    return map;
+  });
+
+  let ambient: string[] = [];
+  for (const m of members) {
+    const armBDays = isConstantArm(m.armB) || m.armB === undefined ? [] : m.armB.index;
+    ambient = unionDays(ambient, unionDays(m.armA.index, armBDays));
+  }
+
+  const overlap = buildOverlap(
+    ambient,
+    (day) => memberMaps.every((map) => map.has(day)),
+    () => 0,
+  );
+
+  const memberDeltas = memberMaps.map((map) => overlap.days.map((day) => map.get(day)!));
+
+  return { days: overlap.days, runs: overlap.runs, memberDeltas };
+}
+
+// ---------------------------------------------------------------------------
+// Public introspection helper
+// ---------------------------------------------------------------------------
+
+/**
+ * The ISO days of every valid moving block for the primary comparison.
+ *
+ * Each inner array is one candidate block: exactly `blockDays` consecutive
+ * observed days drawn from a single contiguous run. The bootstrap draws
+ * exclusively from these blocks, so this is the exact set a resample can touch
+ * -- exposing it lets callers verify that no block ever spans a dormancy gap.
+ */
+export function pairedBlockDays(input: PairedBlockBootstrapInput, blockDays: number): string[][] {
+  const overlap = buildComparisonOverlap(input.armA, input.armB);
+  const starts = enumerateBlockStarts(overlap.runs, blockDays);
+  return starts.map((start) => overlap.days.slice(start, start + blockDays));
+}
+
+// ---------------------------------------------------------------------------
+// Holding-period block-length derivation
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive a moving-block length from the caller's own holding periods.
+ *
+ * Returns the `percentile` (default 0.95, part of the frozen contract) of the
+ * supplied holding periods, rounded to whole trading days and floored at 1 (a
+ * block cannot be shorter than a day). Callers derive the block length from the
+ * current input data rather than any fixed constant.
+ *
+ * @param holdingPeriodsTradingDays - Observed holding periods, in trading days
+ * @param percentile - Percentile in [0, 1]; default 0.95
+ */
+export function holdingPeriodBlockDays(
+  holdingPeriodsTradingDays: number[],
+  percentile = 0.95,
+): number {
+  if (holdingPeriodsTradingDays.length === 0) return 1;
+  const sorted = [...holdingPeriodsTradingDays].sort((a, b) => a - b);
+  return Math.max(1, Math.round(percentileOf(sorted, percentile)));
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a paired, holding-period-aware, selection-adjusted day-block bootstrap.
+ *
+ * @param input - See {@link PairedBlockBootstrapInput}
+ * @returns The point statistic, selection-adjusted percentile interval,
+ *   power/status, overlap diagnostics and sensitivity band
+ */
+export function pairedBlockBootstrap(input: PairedBlockBootstrapInput): PairedBlockBootstrapResult {
+  const blockDays = Math.max(1, Math.round(input.holdingRule.blockDays));
+  const { ciLevel, resamples, seed, statistic, effectiveNFloorBlocks } = input;
+
+  // Resolve the overlap and delta structure (selection vs single comparison).
+  let overlapDays: string[];
+  let runs: ObservedRun[];
+  let deltaSeries: number[];
+  let memberDeltas: number[][] | undefined;
+  let extremum: "max" | "min" | undefined;
+  let selection: SelectionSummary | null = null;
+
+  if (input.selectionSet) {
+    const sel = buildSelectionOverlap(input.selectionSet.members);
+    overlapDays = sel.days;
+    runs = sel.runs;
+    memberDeltas = sel.memberDeltas;
+    extremum = input.selectionSet.extremum;
+    deltaSeries = [];
+
+    const memberPoints = sel.memberDeltas.map((d) => statistic(d));
+    const kConsidered = memberPoints.length;
+    const centroid = kConsidered > 0 ? memberPoints.reduce((s, v) => s + v, 0) / kConsidered : 0;
+
+    let maxGap = 0;
+    if (kConsidered >= 2) {
+      const ordered = [...memberPoints].sort((a, b) => a - b);
+      maxGap =
+        extremum === "min"
+          ? ordered[1] - ordered[0]
+          : ordered[kConsidered - 1] - ordered[kConsidered - 2];
+    }
+    selection = { centroid, maxGap, kConsidered };
+  } else {
+    const overlap = buildComparisonOverlap(input.armA, input.armB);
+    overlapDays = overlap.days;
+    runs = overlap.runs;
+    deltaSeries = overlap.delta;
+  }
+
+  const overlapWindow =
+    overlapDays.length > 0
+      ? { start: overlapDays[0], end: overlapDays[overlapDays.length - 1] }
+      : null;
+
+  const primary = computeCore({
+    overlapDays,
+    runs,
+    deltaSeries,
+    memberDeltas,
+    extremum,
+    blockDays,
+    resamples,
+    seed,
+    ciLevel,
+    statistic,
+    effectiveNFloorBlocks,
+  });
+
+  // Sensitivity band: rerun the interval at each requested multiplied block
+  // length and emit exactly one entry per requested multiplier. An entry that
+  // could not run (underpowered / notComparable at that length) is reported
+  // with null CI bounds rather than dropped, so a caller can see directly that
+  // a requested check did not resolve.
+  const sensitivity: SensitivityEntry[] = [];
+  for (const multiplier of input.holdingRule.sensitivity ?? []) {
+    const sensBlockDays = Math.max(1, Math.round(multiplier * blockDays));
+    const sens = computeCore({
+      overlapDays,
+      runs,
+      deltaSeries,
+      memberDeltas,
+      extremum,
+      blockDays: sensBlockDays,
+      resamples,
+      seed,
+      ciLevel,
+      statistic,
+      effectiveNFloorBlocks,
+    });
+    sensitivity.push({
+      blockDays: sensBlockDays,
+      ci: { low: sens.low, high: sens.high },
+      status: sens.status,
+    });
+  }
+
+  return {
+    point: primary.point,
+    ci: { level: ciLevel, low: primary.low, high: primary.high, method: "paired-day-block" },
+    effectiveN: primary.effectiveN,
+    overlapWindow,
+    blockDays,
+    sensitivity,
+    selection,
+    status: primary.status,
+    seed,
+  };
+}

--- a/packages/mcp-server/src/test-exports.ts
+++ b/packages/mcp-server/src/test-exports.ts
@@ -31,6 +31,18 @@ export { PortfolioStatsCalculator } from "@tradeblocks/lib";
 // Export correlation and tail-risk utilities for testing strategy_similarity
 export { calculateCorrelationMatrix, performTailRiskAnalysis } from "@tradeblocks/lib";
 
+// Export paired_bootstrap_comparison internals for integration testing
+export {
+  registerPairedComparisonTool,
+  runPairedBootstrapComparison,
+  buildBlockTradingDayIndex,
+  buildArmDaySeries,
+  armHoldingPeriods,
+  pairedComparisonInputSchema,
+  type PairedComparisonParams,
+  type PairedComparisonReport,
+} from "./tools/blocks/paired-comparison.ts";
+
 // Export sync layer for integration testing
 export { syncAllBlocks, syncBlock, type SyncResult, type BlockSyncResult } from "./sync/index.ts";
 

--- a/packages/mcp-server/src/tools/blocks/index.ts
+++ b/packages/mcp-server/src/tools/blocks/index.ts
@@ -10,6 +10,7 @@ import { registerComparisonBlockTools } from "./comparison.ts";
 import { registerAnalysisBlockTools } from "./analysis.ts";
 import { registerSimilarityBlockTools } from "./similarity.ts";
 import { registerHealthBlockTools } from "./health.ts";
+import { registerPairedComparisonTool } from "./paired-comparison.ts";
 
 /**
  * Register all block-related MCP tools
@@ -20,4 +21,5 @@ export function registerBlockTools(server: McpServer, baseDir: string): void {
   registerAnalysisBlockTools(server, baseDir);
   registerSimilarityBlockTools(server, baseDir);
   registerHealthBlockTools(server, baseDir);
+  registerPairedComparisonTool(server, baseDir);
 }

--- a/packages/mcp-server/src/tools/blocks/paired-comparison.ts
+++ b/packages/mcp-server/src/tools/blocks/paired-comparison.ts
@@ -99,11 +99,17 @@ type PairedComparisonInput = z.infer<typeof pairedComparisonInputSchema>;
 // Daily attribution
 // ---------------------------------------------------------------------------
 
-/** Local calendar date (YYYY-MM-DD) preserving the trade's stored calendar day. */
+/**
+ * Calendar date (YYYY-MM-DD) for a trade timestamp.
+ *
+ * Calendar dates are derived in UTC from the stored trade timestamps; the grid,
+ * the lib tests, and the displayed overlap windows all share this convention,
+ * so the result is independent of the host machine's timezone.
+ */
 function toCalendarDateStr(date: Date): string {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, "0");
-  const d = String(date.getDate()).padStart(2, "0");
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const d = String(date.getUTCDate()).padStart(2, "0");
   return `${y}-${m}-${d}`;
 }
 

--- a/packages/mcp-server/src/tools/blocks/paired-comparison.ts
+++ b/packages/mcp-server/src/tools/blocks/paired-comparison.ts
@@ -1,0 +1,419 @@
+/**
+ * Paired Bootstrap Comparison Tool
+ *
+ * Honest confidence intervals for "is strategy A actually different from strategy
+ * B (or from zero)". Wraps the paired day-block bootstrap primitive from
+ * @tradeblocks/lib with a declarative attribution of each trade's P&L onto a
+ * daily grid derived from the block's own trade data.
+ */
+
+import { z } from "zod";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { loadBlock } from "../../utils/block-loader.ts";
+import { createToolOutput, formatCurrency } from "../../utils/output-formatter.ts";
+import {
+  pairedBlockBootstrap,
+  holdingPeriodBlockDays,
+  type DaySeries,
+  type PairedBlockBootstrapResult,
+} from "@tradeblocks/lib";
+import type { Trade } from "@tradeblocks/lib";
+import { filterByStrategy, filterByDateRange } from "../shared/filters.ts";
+import { withSyncedBlock } from "../middleware/sync-middleware.ts";
+
+/**
+ * How each trade's P&L reaches the daily grid. Reused in the tool description
+ * and echoed in the structured output so the methodology is never implicit.
+ */
+const ATTRIBUTION_NOTE =
+  "A trade's P&L is attributed evenly across the trading days it was open " +
+  "(dateOpened through dateClosed). Trading days are derived from the block's own " +
+  "trade data (the union of every trade's open and close dates) -- no market " +
+  "calendar is assumed, so weekends or holidays appear only if a trade spans them.";
+
+// Frozen, mathematically-neutral defaults (documented on the schema). Block
+// length is NEVER defaulted to a constant -- it is derived from the submitted
+// block's own holding-period distribution unless the caller overrides it.
+const DEFAULT_CI_LEVEL = 0.95;
+const DEFAULT_RESAMPLES = 2000;
+const DEFAULT_SEED = 42;
+const SENSITIVITY_MULTIPLIERS = [0.5, 2];
+
+export const pairedComparisonInputSchema = z.object({
+  blockId: z.string().describe("Block folder name to analyze"),
+  strategyA: z.string().describe("Strategy name for arm A (case-insensitive)"),
+  strategyB: z
+    .string()
+    .optional()
+    .describe(
+      "Strategy name for arm B (case-insensitive). If omitted, arm A is compared against a " +
+        "constant 0 -- i.e. is the edge distinguishable from nothing.",
+    ),
+  statistic: z
+    .enum(["mean_daily_pnl", "median_daily_pnl"])
+    .default("mean_daily_pnl")
+    .describe("Which daily-P&L functional to compare. Default mean_daily_pnl."),
+  dateRange: z
+    .object({
+      start: z.string().describe("Start date (YYYY-MM-DD)"),
+      end: z.string().describe("End date (YYYY-MM-DD)"),
+    })
+    .optional()
+    .describe("Optional date range filter applied to both arms (by trade open date)."),
+  ciLevel: z
+    .number()
+    .default(DEFAULT_CI_LEVEL)
+    .describe("Confidence level in (0, 1). Default 0.95 (deterministic)."),
+  resamples: z
+    .number()
+    .int()
+    .default(DEFAULT_RESAMPLES)
+    .describe("Number of bootstrap resamples. Default 2000 (deterministic)."),
+  seed: z
+    .number()
+    .int()
+    .default(DEFAULT_SEED)
+    .describe("PRNG seed. Same inputs + seed -> identical result. Default 42 (deterministic)."),
+  blockDays: z
+    .number()
+    .int()
+    .min(1)
+    .optional()
+    .describe(
+      "Override the block length. By default it is derived from this block's own " +
+        "holding-period distribution (95th percentile of days-open).",
+    ),
+  effectiveNFloorBlocks: z
+    .number()
+    .min(0)
+    .optional()
+    .describe(
+      "Optional: refuse with notComparable when the shared overlap yields fewer distinct " +
+        "blocks than this floor. When omitted, only structural degeneracy refuses (underpowered).",
+    ),
+});
+
+type PairedComparisonInput = z.infer<typeof pairedComparisonInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Daily attribution
+// ---------------------------------------------------------------------------
+
+/** Local calendar date (YYYY-MM-DD) preserving the trade's stored calendar day. */
+function toCalendarDateStr(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * The block's trading-day grid: the sorted, unique union of every trade's open
+ * and close calendar dates. Days strictly between an open and a close that are
+ * not themselves any trade's open/close are unknown to be trading days and are
+ * deliberately not invented.
+ */
+export function buildBlockTradingDayIndex(trades: Trade[]): string[] {
+  const days = new Set<string>();
+  for (const t of trades) {
+    days.add(toCalendarDateStr(t.dateOpened));
+    days.add(toCalendarDateStr(t.dateClosed ?? t.dateOpened));
+  }
+  return Array.from(days).sort();
+}
+
+/** Inclusive index range [lo, hi] of grid days within [openStr, closeStr]. */
+function gridSpan(grid: string[], openStr: string, closeStr: string): [number, number] {
+  let lo = grid.findIndex((d) => d >= openStr);
+  if (lo === -1) lo = grid.length;
+  let hi = -1;
+  for (let i = grid.length - 1; i >= 0; i--) {
+    if (grid[i] <= closeStr) {
+      hi = i;
+      break;
+    }
+  }
+  return [lo, hi];
+}
+
+/**
+ * Number of grid trading days each trade was open. This is the holding period
+ * used both for even P&L attribution and for block-length derivation.
+ */
+export function armHoldingPeriods(armTrades: Trade[], grid: string[]): number[] {
+  return armTrades.map((t) => {
+    const openStr = toCalendarDateStr(t.dateOpened);
+    const closeStr = toCalendarDateStr(t.dateClosed ?? t.dateOpened);
+    const [lo, hi] = gridSpan(grid, openStr, closeStr);
+    return Math.max(1, hi - lo + 1);
+  });
+}
+
+/**
+ * Build one arm's DaySeries on the shared trading-day grid. Each trade's P&L is
+ * spread evenly across the grid days it was open; a grid day the arm did not
+ * hold a position is not-observed (mask false), while a held day with a net-zero
+ * attributed P&L is a genuine observation (mask true).
+ */
+export function buildArmDaySeries(armTrades: Trade[], grid: string[]): DaySeries {
+  const values = new Array<number>(grid.length).fill(0);
+  const observedMask = new Array<boolean>(grid.length).fill(false);
+
+  for (const t of armTrades) {
+    const openStr = toCalendarDateStr(t.dateOpened);
+    const closeStr = toCalendarDateStr(t.dateClosed ?? t.dateOpened);
+    const [lo, hi] = gridSpan(grid, openStr, closeStr);
+    if (hi < lo) continue;
+    const span = hi - lo + 1;
+    const perDay = t.pl / span;
+    for (let i = lo; i <= hi; i++) {
+      values[i] += perDay;
+      observedMask[i] = true;
+    }
+  }
+
+  return { index: grid, values, observedMask };
+}
+
+function countObserved(series: DaySeries): number {
+  return series.observedMask.reduce((n, o) => n + (o ? 1 : 0), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Statistics
+// ---------------------------------------------------------------------------
+
+function meanOf(values: number[]): number {
+  return values.reduce((s, v) => s + v, 0) / values.length;
+}
+
+function medianOf(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+const STATISTIC_FNS: Record<PairedComparisonInput["statistic"], (d: number[]) => number> = {
+  mean_daily_pnl: meanOf,
+  median_daily_pnl: medianOf,
+};
+
+const STATISTIC_LABELS: Record<PairedComparisonInput["statistic"], string> = {
+  mean_daily_pnl: "mean daily P&L",
+  median_daily_pnl: "median daily P&L",
+};
+
+// ---------------------------------------------------------------------------
+// Core computation (DB-free, directly testable)
+// ---------------------------------------------------------------------------
+
+export interface PairedComparisonParams {
+  armATrades: Trade[];
+  /** null -> compare arm A against a constant 0. */
+  armBTrades: Trade[] | null;
+  /** All block trades -- defines the shared trading-day grid. */
+  blockTrades: Trade[];
+  statistic: PairedComparisonInput["statistic"];
+  ciLevel: number;
+  resamples: number;
+  seed: number;
+  blockDays?: number;
+  /** Optional power floor -> notComparable when effectiveN falls below it. */
+  effectiveNFloorBlocks?: number;
+  strategyA: string;
+  strategyB?: string;
+}
+
+export interface PairedComparisonReport {
+  summary: string;
+  data: Record<string, unknown>;
+  result: PairedBlockBootstrapResult;
+}
+
+/**
+ * Run the paired day-block bootstrap for a strategy comparison and format an
+ * honest, plain-English report. Throws a clear error when a strategy filter
+ * matched zero trades.
+ */
+export function runPairedBootstrapComparison(
+  params: PairedComparisonParams,
+): PairedComparisonReport {
+  const {
+    armATrades,
+    armBTrades,
+    blockTrades,
+    statistic,
+    ciLevel,
+    resamples,
+    seed,
+    blockDays: blockDaysOverride,
+    effectiveNFloorBlocks,
+    strategyA,
+    strategyB,
+  } = params;
+
+  if (armATrades.length === 0) {
+    throw new Error(`No trades found for strategy "${strategyA}".`);
+  }
+  if (armBTrades !== null && armBTrades.length === 0) {
+    throw new Error(`No trades found for strategy "${strategyB}".`);
+  }
+
+  const grid = buildBlockTradingDayIndex(blockTrades);
+  const armA = buildArmDaySeries(armATrades, grid);
+  const armB = armBTrades !== null ? buildArmDaySeries(armBTrades, grid) : null;
+
+  // Block length: derived from the LONGER arm's 95th-percentile holding period
+  // (the conservative choice), unless the caller overrides it.
+  const hpA = holdingPeriodBlockDays(armHoldingPeriods(armATrades, grid));
+  const hpB =
+    armBTrades !== null ? holdingPeriodBlockDays(armHoldingPeriods(armBTrades, grid)) : hpA;
+  const derivedBlockDays = Math.max(hpA, hpB);
+  const derivedFromArm = hpB > hpA ? "B" : "A";
+  const blockDays = blockDaysOverride ?? derivedBlockDays;
+
+  const blockDaysNote =
+    blockDaysOverride !== undefined
+      ? `block length = ${blockDays} trading day(s), caller-supplied override`
+      : armB !== null
+        ? `block length = ${blockDays} trading day(s), derived from the 95th-percentile ` +
+          `holding period of arm ${derivedFromArm} (the longer-held arm -- the conservative choice)`
+        : `block length = ${blockDays} trading day(s), derived from the 95th-percentile ` +
+          `holding period of arm A`;
+
+  const result = pairedBlockBootstrap({
+    armA,
+    armB: armB ?? { constant: 0 },
+    statistic: STATISTIC_FNS[statistic],
+    holdingRule: { blockDays, sensitivity: SENSITIVITY_MULTIPLIERS },
+    ciLevel,
+    resamples,
+    seed,
+    effectiveNFloorBlocks,
+  });
+
+  const statLabel = STATISTIC_LABELS[statistic];
+  const comparisonLabel = armB !== null ? `${strategyA} minus ${strategyB}` : `${strategyA} vs 0`;
+
+  // Plain-English lead line -- refusal is surfaced first, never buried.
+  let summary: string;
+  let refusalMessage: string | null = null;
+  if (result.status === "notComparable") {
+    refusalMessage =
+      `Not comparable: effective sample (${result.effectiveN.toFixed(2)} blocks) is below the ` +
+      `required power floor. A confidence interval is withheld.`;
+    summary = `Paired comparison (${comparisonLabel}): ${refusalMessage}`;
+  } else if (result.status === "underpowered") {
+    refusalMessage =
+      `Underpowered: the shared overlap is too short to resample at a block length of ` +
+      `${blockDays} trading day(s) (fewer than two drawable blocks). A confidence interval is withheld.`;
+    summary = `Paired comparison (${comparisonLabel}): ${refusalMessage}`;
+  } else {
+    const point = result.point ?? 0;
+    const low = result.ci.low ?? 0;
+    const high = result.ci.high ?? 0;
+    const includesZero = low <= 0 && high >= 0;
+    const zeroClause = includesZero
+      ? "includes zero (not distinguishable)"
+      : "excludes zero (distinguishable)";
+    const subject =
+      armB !== null ? `the difference in ${statLabel} (${comparisonLabel})` : `${statLabel}`;
+    summary =
+      `Paired comparison: ${subject} is ${formatCurrency(point)}, ` +
+      `${(ciLevel * 100).toFixed(0)}% CI [${formatCurrency(low)}, ${formatCurrency(high)}] -- ${zeroClause}.`;
+  }
+
+  const data: Record<string, unknown> = {
+    comparison: {
+      strategyA,
+      strategyB: strategyB ?? null,
+      mode: armB !== null ? "two-arm" : "single-arm-vs-zero",
+      description: comparisonLabel,
+    },
+    statistic,
+    point: result.point,
+    ci: result.ci,
+    status: result.status,
+    refusal: refusalMessage,
+    effectiveN: result.effectiveN,
+    blockDays: result.blockDays,
+    blockDaysDerivation: blockDaysNote,
+    overlapWindow: result.overlapWindow,
+    observedDays: {
+      armA: countObserved(armA),
+      armB: armB !== null ? countObserved(armB) : null,
+    },
+    tradeCounts: {
+      armA: armATrades.length,
+      armB: armBTrades !== null ? armBTrades.length : null,
+    },
+    sensitivity: result.sensitivity,
+    resamples,
+    seed: result.seed,
+    ciLevel,
+    attributionMethodology: ATTRIBUTION_NOTE,
+  };
+
+  return { summary, data, result };
+}
+
+// ---------------------------------------------------------------------------
+// Tool registration
+// ---------------------------------------------------------------------------
+
+/**
+ * Register the paired_bootstrap_comparison MCP tool.
+ */
+export function registerPairedComparisonTool(server: McpServer, baseDir: string): void {
+  server.registerTool(
+    "paired_bootstrap_comparison",
+    {
+      description:
+        "Honest confidence intervals for 'is strategy A actually different from strategy B " +
+        "(or from zero)' -- day-block resampling that accounts for multi-day positions, dormant " +
+        "periods, and paired comparison on shared days. " +
+        ATTRIBUTION_NOTE,
+      inputSchema: pairedComparisonInputSchema,
+    },
+    withSyncedBlock(baseDir, async (input: PairedComparisonInput) => {
+      try {
+        const { blockId, strategyA, strategyB, statistic, dateRange } = input;
+        const block = await loadBlock(baseDir, blockId);
+
+        const inRange = (trades: Trade[]): Trade[] =>
+          dateRange ? filterByDateRange(trades, dateRange.start, dateRange.end) : trades;
+
+        const blockTrades = inRange(block.trades);
+        const armATrades = inRange(filterByStrategy(block.trades, strategyA));
+        const armBTrades =
+          strategyB !== undefined ? inRange(filterByStrategy(block.trades, strategyB)) : null;
+
+        const { summary, data } = runPairedBootstrapComparison({
+          armATrades,
+          armBTrades,
+          blockTrades,
+          statistic,
+          ciLevel: input.ciLevel,
+          resamples: input.resamples,
+          seed: input.seed,
+          blockDays: input.blockDays,
+          effectiveNFloorBlocks: input.effectiveNFloorBlocks,
+          strategyA,
+          strategyB,
+        });
+
+        return createToolOutput(summary, { blockId, ...data });
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Error running paired bootstrap comparison: ${(error as Error).message}`,
+            },
+          ],
+          isError: true as const,
+        };
+      }
+    }),
+  );
+}

--- a/packages/mcp-server/tests/integration/paired-comparison.test.ts
+++ b/packages/mcp-server/tests/integration/paired-comparison.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Integration tests for the paired_bootstrap_comparison MCP tool.
+ *
+ * Exercises the DB-free core (runPairedBootstrapComparison) and the daily
+ * attribution helpers with synthetic trade fixtures, plus tool registration
+ * and input-schema defaults. No real trading data is used.
+ */
+import { describe, expect, it } from "@jest/globals";
+
+// @ts-expect-error - importing from bundled output
+import {
+  registerPairedComparisonTool,
+  runPairedBootstrapComparison,
+  buildBlockTradingDayIndex,
+  buildArmDaySeries,
+  armHoldingPeriods,
+  pairedComparisonInputSchema,
+} from "../../src/test-exports.ts";
+
+import { holdingPeriodBlockDays } from "@tradeblocks/lib";
+import type { Trade } from "@tradeblocks/lib";
+
+// ---------------------------------------------------------------------------
+// Synthetic trade fixtures
+// ---------------------------------------------------------------------------
+
+function makeTrade(openIdx: number, closeIdx: number, pl: number, strategy: string): Trade {
+  return {
+    dateOpened: new Date(2022, 0, 1 + openIdx),
+    dateClosed: new Date(2022, 0, 1 + closeIdx),
+    timeOpened: "09:30:00",
+    openingPrice: 0,
+    legs: "",
+    premium: 0,
+    pl,
+    numContracts: 1,
+    fundsAtClose: 0,
+    marginReq: 0,
+    strategy,
+    openingCommissionsFees: 0,
+    closingCommissionsFees: 0,
+    openingShortLongRatio: 0,
+  };
+}
+
+/** Deterministic centered pseudo-random sequence in ~[-0.5, 0.5]. */
+function seededSeq(seed: number, n: number): number[] {
+  let s = seed >>> 0;
+  const out: number[] = [];
+  for (let i = 0; i < n; i++) {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    out.push(s / 4294967296 - 0.5);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Tool registration + schema
+// ---------------------------------------------------------------------------
+
+describe("paired_bootstrap_comparison registration", () => {
+  it("registers under the expected tool name", () => {
+    const registered: Array<{ name: string; config: unknown }> = [];
+    const fakeServer = {
+      registerTool: (name: string, config: unknown) => registered.push({ name, config }),
+    };
+
+    registerPairedComparisonTool(fakeServer, "/tmp/does-not-matter");
+
+    const tool = registered.find((r) => r.name === "paired_bootstrap_comparison");
+    expect(tool).toBeDefined();
+    expect((tool!.config as { inputSchema: unknown }).inputSchema).toBe(
+      pairedComparisonInputSchema,
+    );
+  });
+
+  it("applies deterministic defaults", () => {
+    const parsed = pairedComparisonInputSchema.parse({ blockId: "b", strategyA: "A" });
+    expect(parsed.statistic).toBe("mean_daily_pnl");
+    expect(parsed.ciLevel).toBe(0.95);
+    expect(parsed.resamples).toBe(2000);
+    expect(parsed.seed).toBe(42);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Daily attribution
+// ---------------------------------------------------------------------------
+
+describe("daily attribution", () => {
+  it("derives the trading-day grid from trade open/close dates only", () => {
+    const trades = [makeTrade(0, 2, 30, "A"), makeTrade(5, 5, 10, "A")];
+    const grid = buildBlockTradingDayIndex(trades);
+    // Open/close days present: idx 0, 2, 5. Interior idx 1 is NOT invented.
+    expect(grid).toEqual(["2022-01-01", "2022-01-03", "2022-01-06"]);
+  });
+
+  it("spreads a trade's P&L evenly across the grid days it was open", () => {
+    // One trade open across grid days idx 0,2 -> span 2 -> 30/2 = 15 each.
+    const trades = [makeTrade(0, 2, 30, "A")];
+    const grid = buildBlockTradingDayIndex(trades);
+    const series = buildArmDaySeries(trades, grid);
+    expect(series.values).toEqual([15, 15]);
+    expect(series.observedMask).toEqual([true, true]);
+    expect(armHoldingPeriods(trades, grid)).toEqual([2]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Two-strategy comparison — known constant difference
+// ---------------------------------------------------------------------------
+
+describe("two-strategy comparison", () => {
+  it("recovers a known constant difference with a CI excluding zero", () => {
+    const c = 25;
+    const base = seededSeq(1, 40);
+    const armATrades = base.map((v, i) => makeTrade(i, i, v + c, "A"));
+    const armBTrades = base.map((v, i) => makeTrade(i, i, v, "B"));
+
+    const { data, result, summary } = runPairedBootstrapComparison({
+      armATrades,
+      armBTrades,
+      blockTrades: [...armATrades, ...armBTrades],
+      statistic: "mean_daily_pnl",
+      ciLevel: 0.95,
+      resamples: 800,
+      seed: 42,
+      strategyA: "A",
+      strategyB: "B",
+    });
+
+    expect(result.status).toBe("resolved");
+    // delta_t = (base+c) - base = c on every shared day -> point recovers c.
+    expect(result.point).toBeCloseTo(c, 6);
+    expect(result.ci.low).toBeGreaterThan(0);
+    expect((data.observedDays as { armA: number }).armA).toBe(40);
+    expect(summary).toContain("excludes zero");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Single-arm vs constant zero
+// ---------------------------------------------------------------------------
+
+describe("single-arm vs zero", () => {
+  it("compares arm A's daily P&L against zero when strategyB is omitted", () => {
+    const base = seededSeq(2, 30).map((v) => v + 5); // shift positive
+    const armATrades = base.map((v, i) => makeTrade(i, i, v, "A"));
+
+    const { result, data } = runPairedBootstrapComparison({
+      armATrades,
+      armBTrades: null,
+      blockTrades: armATrades,
+      statistic: "mean_daily_pnl",
+      ciLevel: 0.95,
+      resamples: 500,
+      seed: 42,
+      strategyA: "A",
+    });
+
+    const expectedMean = base.reduce((s, v) => s + v, 0) / base.length;
+    expect(result.point).toBeCloseTo(expectedMean, 6);
+    expect((data.comparison as { mode: string }).mode).toBe("single-arm-vs-zero");
+    expect((data.observedDays as { armB: number | null }).armB).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Zero-trade strategy filter error
+// ---------------------------------------------------------------------------
+
+describe("zero-trade strategy filter", () => {
+  it("throws a clear error when arm A matched no trades", () => {
+    expect(() =>
+      runPairedBootstrapComparison({
+        armATrades: [],
+        armBTrades: null,
+        blockTrades: [],
+        statistic: "mean_daily_pnl",
+        ciLevel: 0.95,
+        resamples: 100,
+        seed: 42,
+        strategyA: "Ghost",
+      }),
+    ).toThrow(/No trades found for strategy "Ghost"/);
+  });
+
+  it("throws a clear error when arm B matched no trades", () => {
+    const armATrades = [makeTrade(0, 0, 1, "A")];
+    expect(() =>
+      runPairedBootstrapComparison({
+        armATrades,
+        armBTrades: [],
+        blockTrades: armATrades,
+        statistic: "mean_daily_pnl",
+        ciLevel: 0.95,
+        resamples: 100,
+        seed: 42,
+        strategyA: "A",
+        strategyB: "Ghost",
+      }),
+    ).toThrow(/No trades found for strategy "Ghost"/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Block-length derivation vs override
+// ---------------------------------------------------------------------------
+
+describe("block-length derivation vs override", () => {
+  const base = seededSeq(3, 30);
+  // Multi-day trades: each open across 3 grid days -> holding period distribution > 1.
+  const armATrades = base.map((v, i) => makeTrade(i, i + 2, v + 3, "A"));
+  const armBTrades = base.map((v, i) => makeTrade(i, i + 2, v, "B"));
+  const blockTrades = [...armATrades, ...armBTrades];
+
+  it("derives block length from the block's own holding-period distribution", () => {
+    // Recompute the expected p95 block length from the same helpers the tool uses.
+    const grid = buildBlockTradingDayIndex(blockTrades);
+    const expected = Math.max(
+      holdingPeriodBlockDays(armHoldingPeriods(armATrades, grid)),
+      holdingPeriodBlockDays(armHoldingPeriods(armBTrades, grid)),
+    );
+
+    const { result } = runPairedBootstrapComparison({
+      armATrades,
+      armBTrades,
+      blockTrades,
+      statistic: "mean_daily_pnl",
+      ciLevel: 0.95,
+      resamples: 300,
+      seed: 42,
+      strategyA: "A",
+      strategyB: "B",
+    });
+
+    expect(result.blockDays).toBe(expected);
+    expect(expected).toBeGreaterThan(1);
+  });
+
+  it("honors a caller-supplied block-length override", () => {
+    const { result, data } = runPairedBootstrapComparison({
+      armATrades,
+      armBTrades,
+      blockTrades,
+      statistic: "mean_daily_pnl",
+      ciLevel: 0.95,
+      resamples: 300,
+      seed: 42,
+      blockDays: 2,
+      strategyA: "A",
+      strategyB: "B",
+    });
+
+    expect(result.blockDays).toBe(2);
+    expect(data.blockDaysDerivation).toContain("override");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Refusal path — tiny overlap
+// ---------------------------------------------------------------------------
+
+describe("refusal path", () => {
+  it("surfaces an explicit refusal when the overlap is too short to resample", () => {
+    // Only 3 shared days, block length forced to 5 -> fewer than 2 drawable blocks.
+    const armATrades = [
+      makeTrade(0, 0, 10, "A"),
+      makeTrade(1, 1, 12, "A"),
+      makeTrade(2, 2, 8, "A"),
+    ];
+    const armBTrades = [makeTrade(0, 0, 1, "B"), makeTrade(1, 1, 2, "B"), makeTrade(2, 2, 3, "B")];
+
+    const { result, summary, data } = runPairedBootstrapComparison({
+      armATrades,
+      armBTrades,
+      blockTrades: [...armATrades, ...armBTrades],
+      statistic: "mean_daily_pnl",
+      ciLevel: 0.95,
+      resamples: 300,
+      seed: 42,
+      blockDays: 5,
+      strategyA: "A",
+      strategyB: "B",
+    });
+
+    expect(result.status).toBe("underpowered");
+    expect(result.ci.low).toBeNull();
+    expect(result.ci.high).toBeNull();
+    expect(summary).toContain("Underpowered");
+    expect(data.refusal).not.toBeNull();
+  });
+
+  it("refuses with notComparable when a supplied floor exceeds the effective sample", () => {
+    // 10 shared days, block length 2 -> 5 drawable blocks (not degenerate),
+    // effectiveN = 10 / 2 = 5. A floor of 10 blocks refuses honestly.
+    const armATrades = Array.from({ length: 10 }, (_, i) => makeTrade(i, i, 10 + i, "A"));
+    const armBTrades = Array.from({ length: 10 }, (_, i) => makeTrade(i, i, i, "B"));
+
+    const { result, summary, data } = runPairedBootstrapComparison({
+      armATrades,
+      armBTrades,
+      blockTrades: [...armATrades, ...armBTrades],
+      statistic: "mean_daily_pnl",
+      ciLevel: 0.95,
+      resamples: 300,
+      seed: 42,
+      blockDays: 2,
+      effectiveNFloorBlocks: 10,
+      strategyA: "A",
+      strategyB: "B",
+    });
+
+    expect(result.status).toBe("notComparable");
+    expect(result.ci.low).toBeNull();
+    expect(result.ci.high).toBeNull();
+    expect(result.point).not.toBeNull();
+    expect(summary).toContain("Not comparable");
+    expect(data.refusal).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Determinism
+// ---------------------------------------------------------------------------
+
+describe("determinism", () => {
+  const base = seededSeq(4, 35);
+  const armATrades = base.map((v, i) => makeTrade(i, i, v, "A"));
+  const params = {
+    armATrades,
+    armBTrades: null,
+    blockTrades: armATrades,
+    statistic: "mean_daily_pnl" as const,
+    ciLevel: 0.95,
+    resamples: 400,
+    strategyA: "A",
+  };
+
+  it("produces identical output for identical inputs", () => {
+    const a = runPairedBootstrapComparison({ ...params, seed: 7 });
+    const b = runPairedBootstrapComparison({ ...params, seed: 7 });
+    expect(a.result).toEqual(b.result);
+  });
+
+  it("produces different resample draws for a different seed", () => {
+    const a = runPairedBootstrapComparison({ ...params, seed: 7 });
+    const b = runPairedBootstrapComparison({ ...params, seed: 8 });
+    expect(a.result.ci.low).not.toBe(b.result.ci.low);
+  });
+});

--- a/packages/mcp-server/tests/integration/paired-comparison.test.ts
+++ b/packages/mcp-server/tests/integration/paired-comparison.test.ts
@@ -26,8 +26,9 @@ import type { Trade } from "@tradeblocks/lib";
 
 function makeTrade(openIdx: number, closeIdx: number, pl: number, strategy: string): Trade {
   return {
-    dateOpened: new Date(2022, 0, 1 + openIdx),
-    dateClosed: new Date(2022, 0, 1 + closeIdx),
+    // UTC-midnight instants so the derived calendar date is host-timezone independent.
+    dateOpened: new Date(Date.UTC(2022, 0, 1 + openIdx)),
+    dateClosed: new Date(Date.UTC(2022, 0, 1 + closeIdx)),
     timeOpened: "09:30:00",
     openingPrice: 0,
     legs: "",
@@ -93,6 +94,30 @@ describe("daily attribution", () => {
     const grid = buildBlockTradingDayIndex(trades);
     // Open/close days present: idx 0, 2, 5. Interior idx 1 is NOT invented.
     expect(grid).toEqual(["2022-01-01", "2022-01-03", "2022-01-06"]);
+  });
+
+  it("pins calendar dates to UTC regardless of host timezone", () => {
+    // A UTC-midnight instant reads as the previous local day on any negative-offset
+    // host under local getters; UTC getters must recover the UTC calendar day.
+    const trades: Trade[] = [
+      {
+        dateOpened: new Date("2022-03-14T00:00:00Z"),
+        dateClosed: new Date("2022-03-14T00:00:00Z"),
+        timeOpened: "00:00:00",
+        openingPrice: 0,
+        legs: "",
+        premium: 0,
+        pl: 1,
+        numContracts: 1,
+        fundsAtClose: 0,
+        marginReq: 0,
+        strategy: "A",
+        openingCommissionsFees: 0,
+        closingCommissionsFees: 0,
+        openingShortLongRatio: 0,
+      },
+    ];
+    expect(buildBlockTradingDayIndex(trades)).toEqual(["2022-03-14"]);
   });
 
   it("spreads a trade's P&L evenly across the grid days it was open", () => {

--- a/releases/v3.1.0.md
+++ b/releases/v3.1.0.md
@@ -1,0 +1,31 @@
+# TradeBlocks 3.1.0 — Paired day-block bootstrap calculation
+
+A minor release adding one new calculation module to `@tradeblocks/lib`. Purely additive — no existing API, tool, or output-shape changes.
+
+## New: `pairedBlockBootstrap` — masked, gap-aware, selection-adjusted confidence intervals
+
+Daily P&L series from multi-day positions are autocorrelated: a position held for two weeks smears its outcome across two weeks of rows, so resampling single days produces confidence intervals that are systematically too tight. The new `calculations/paired-block-bootstrap` module provides an honest alternative:
+
+- **Day-block resampling** with caller-supplied block length — use the `holdingPeriodBlockDays(holdingPeriods, percentile?)` helper to derive the block from the current data's own holding-period distribution (default 95th percentile), so the block always reflects the series being analyzed.
+- **Observed-day masking**: dormant days (no position) are treated as missing — excluded from the overlap and from blocks — never zero-filled. A true flat day (position open, zero P&L) is a real observation.
+- **Gap-aware, no wraparound**: blocks are drawn only inside contiguous observed runs; a block never spans a dormancy gap and never wraps the series end.
+- **Paired comparisons on shared days**: comparing two series resamples both on the same drawn day indices over their intersection, so the comparison is apples-to-apples by construction. Single-series and series-vs-constant modes are also supported.
+- **Selection-adjusted intervals**: when picking the best/worst of several candidates, pass them as a `selectionSet` — each resample re-runs the selection, so the interval prices in the fact that an extremum was chosen (reported alongside the family `centroid`, the `maxGap` to the runner-up, and `kConsidered`).
+- **Honest refusal states**: results report `effectiveN` (distinct drawable blocks) and an explicit `status` — `resolved`, `underpowered`, or `notComparable` when the overlap is below a caller-supplied floor — rather than returning a meaningless interval from too little data. Sensitivity entries (alternate block lengths) are always emitted per requested multiplier, with their own status when a length could not run.
+- **Deterministic**: seeded PRNG; identical inputs and seed reproduce identical results.
+
+```ts
+import { pairedBlockBootstrap, holdingPeriodBlockDays } from "@tradeblocks/lib";
+
+const blockDays = holdingPeriodBlockDays(holdingPeriodsTradingDays); // derived from the data, not assumed
+const result = pairedBlockBootstrap({
+  armA: strategyDailySeries,
+  armB: { constant: 0 },
+  statistic: (delta) => delta.reduce((a, b) => a + b, 0) / delta.length,
+  holdingRule: { blockDays, sensitivity: [0.5, 2] },
+  ciLevel: 0.95,
+  resamples: 2000,
+  seed: 42,
+});
+// result.point, result.ci, result.effectiveN, result.status
+```

--- a/releases/v3.1.0.md
+++ b/releases/v3.1.0.md
@@ -1,6 +1,6 @@
 # TradeBlocks 3.1.0 — Paired day-block bootstrap calculation
 
-A minor release adding one new calculation module to `@tradeblocks/lib`. Purely additive — no existing API, tool, or output-shape changes.
+A minor release adding one new calculation module to `@tradeblocks/lib` and one new MCP tool that surfaces it. Purely additive — no existing API, tool, or output-shape changes.
 
 ## New: `pairedBlockBootstrap` — masked, gap-aware, selection-adjusted confidence intervals
 
@@ -29,3 +29,12 @@ const result = pairedBlockBootstrap({
 });
 // result.point, result.ci, result.effectiveN, result.status
 ```
+
+## New MCP tool: `paired_bootstrap_comparison`
+
+A declarative wrapper over the primitive for the question "is strategy A actually different from strategy B (or from zero)?" Given a block and one or two strategy names, it returns an honest confidence interval on the difference in daily P&L (mean or median), computed by day-block resampling so that multi-day positions, dormant periods, and paired comparison on shared days are all accounted for.
+
+- **Attribution methodology**: a trade's P&L is attributed evenly across the trading days it was open (dateOpened through dateClosed), and the trading-day grid is derived from the block's own trade data (the union of every trade's open and close dates) — no market calendar is assumed.
+- **Block length** is derived from the block's own holding-period distribution (95th percentile of days-open, taking the longer-held arm as the conservative choice) unless the caller overrides it. `ciLevel` (0.95), `resamples` (2000), and `seed` (42) are deterministic defaults.
+- **Refusal states are never buried**: when the shared overlap is too short to resample, the tool leads its output with an explicit refusal (`underpowered`, or `notComparable` below a supplied floor) and withholds the interval rather than reporting a meaningless one. Sensitivity entries at alternate block lengths are always reported, including any that could not run.
+- Omit strategy B to compare a single strategy's edge against a constant zero.

--- a/tests/lib/calculations/paired-block-bootstrap.test.ts
+++ b/tests/lib/calculations/paired-block-bootstrap.test.ts
@@ -1,0 +1,451 @@
+import {
+  pairedBlockBootstrap,
+  pairedBlockDays,
+  holdingPeriodBlockDays,
+  type DaySeries,
+  type PairedBlockBootstrapInput,
+} from "@tradeblocks/lib";
+import { describe, expect, it } from "@jest/globals";
+
+// ---------------------------------------------------------------------------
+// Synthetic-structure helpers (no real trading data)
+// ---------------------------------------------------------------------------
+
+/** Generate `n` consecutive ISO calendar days starting at `start`. */
+function isoDays(n: number, start = "2020-01-01"): string[] {
+  const out: string[] = [];
+  const d = new Date(`${start}T00:00:00Z`);
+  for (let i = 0; i < n; i++) {
+    out.push(d.toISOString().slice(0, 10));
+    d.setUTCDate(d.getUTCDate() + 1);
+  }
+  return out;
+}
+
+function mkSeries(values: number[], observed?: boolean[], start?: string): DaySeries {
+  return {
+    index: isoDays(values.length, start),
+    values,
+    observedMask: observed ?? values.map(() => true),
+  };
+}
+
+/** Deterministic centered pseudo-random sequence in ~[-0.5, 0.5]. */
+function seededSeq(seed: number, n: number): number[] {
+  let s = seed >>> 0;
+  const out: number[] = [];
+  for (let i = 0; i < n; i++) {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    out.push(s / 4294967296 - 0.5);
+  }
+  return out;
+}
+
+const mean = (d: number[]): number => d.reduce((a, b) => a + b, 0) / d.length;
+
+// ---------------------------------------------------------------------------
+// 1. Intersection masking -- never zero-fill
+// ---------------------------------------------------------------------------
+
+describe("intersection masking", () => {
+  it("counts overlap and effectiveN from jointly-observed days only", () => {
+    const armA = mkSeries(seededSeq(1, 20));
+    const bObserved = Array.from({ length: 20 }, (_, i) => !(i >= 3 && i <= 10));
+    const armB = mkSeries(seededSeq(2, 20), bObserved);
+
+    const result = pairedBlockBootstrap({
+      armA,
+      armB,
+      statistic: mean,
+      holdingRule: { blockDays: 3 },
+      ciLevel: 0.95,
+      resamples: 200,
+      seed: 42,
+    });
+
+    // 20 days minus 8 dormant = 12 jointly observed -> 12 / 3 = 4.
+    expect(result.effectiveN).toBe(4);
+    expect(result.overlapWindow).toEqual({ start: armA.index[0], end: armA.index[19] });
+    expect(result.status).toBe("resolved");
+  });
+
+  it("treats not-observed days as absent, not as zeros", () => {
+    const bObserved = Array.from({ length: 20 }, (_, i) => !(i >= 3 && i <= 10));
+    const base: PairedBlockBootstrapInput = {
+      armA: mkSeries(seededSeq(1, 20)),
+      armB: mkSeries(seededSeq(2, 20), bObserved),
+      statistic: mean,
+      holdingRule: { blockDays: 3 },
+      ciLevel: 0.95,
+      resamples: 200,
+      seed: 42,
+    };
+
+    const before = pairedBlockBootstrap(base);
+
+    // Change a value on a NOT-observed day of arm B; result must be identical.
+    const mutatedValues = seededSeq(2, 20);
+    mutatedValues[5] = 999999;
+    const after = pairedBlockBootstrap({
+      ...base,
+      armB: mkSeries(mutatedValues, bObserved),
+    });
+
+    expect(after).toEqual(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. No wrap, no gap-spanning
+// ---------------------------------------------------------------------------
+
+describe("no wrap, no gap-spanning", () => {
+  it("never draws a block that spans a dormancy gap", () => {
+    const armA = mkSeries(seededSeq(3, 20));
+    const bObserved = Array.from({ length: 20 }, (_, i) => i !== 10);
+    const armB = mkSeries(seededSeq(4, 20), bObserved);
+    const gapDate = armA.index[10]; // the missing joint day
+
+    const blocks = pairedBlockDays(
+      {
+        armA,
+        armB,
+        statistic: mean,
+        holdingRule: { blockDays: 4 },
+        ciLevel: 0.95,
+        resamples: 1,
+        seed: 1,
+      },
+      4,
+    );
+
+    expect(blocks.length).toBeGreaterThan(0);
+    for (const block of blocks) {
+      expect(block).toHaveLength(4);
+      const spansGap = block.some((d) => d < gapDate) && block.some((d) => d > gapDate);
+      expect(spansGap).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Shared-index pairing
+// ---------------------------------------------------------------------------
+
+describe("shared-index pairing", () => {
+  it("collapses to a degenerate interval when the paired delta is constant", () => {
+    const c = 2.5;
+    const base = seededSeq(5, 30);
+    const armA = mkSeries(base.map((v) => v + 10));
+    const armB = mkSeries(base.map((v) => v + 10 - c)); // anti-moves with A, but A - B == c
+
+    const result = pairedBlockBootstrap({
+      armA,
+      armB,
+      statistic: mean,
+      holdingRule: { blockDays: 5 },
+      ciLevel: 0.95,
+      resamples: 500,
+      seed: 7,
+    });
+
+    expect(result.point).toBeCloseTo(c, 10);
+    expect(result.ci.low).toBeCloseTo(c, 10);
+    expect(result.ci.high).toBeCloseTo(c, 10);
+    expect(result.status).toBe("resolved");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Deterministic seed
+// ---------------------------------------------------------------------------
+
+describe("deterministic seed", () => {
+  const build = (seed: number): PairedBlockBootstrapInput => ({
+    armA: mkSeries(seededSeq(11, 40)),
+    armB: { constant: 0 },
+    statistic: mean,
+    holdingRule: { blockDays: 4 },
+    ciLevel: 0.95,
+    resamples: 400,
+    seed,
+  });
+
+  it("is byte-identical for the same seed", () => {
+    expect(pairedBlockBootstrap(build(123))).toEqual(pairedBlockBootstrap(build(123)));
+  });
+
+  it("draws differently for a different seed", () => {
+    const a = pairedBlockBootstrap(build(123));
+    const b = pairedBlockBootstrap(build(124));
+    expect(a.ci.low).not.toBe(b.ci.low);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Autocorrelated null -- L-block widens vs iid days
+// ---------------------------------------------------------------------------
+
+describe("autocorrelated null", () => {
+  it("produces a wider interval at L>1 than at L=1 on blocky data, covering 0", () => {
+    // 10 blocks of length 5; block-constant values summing to exactly zero.
+    const raw = seededSeq(21, 10);
+    const m = mean(raw);
+    const blockValues = raw.map((v) => v - m); // mean exactly 0
+    const values: number[] = [];
+    for (const bv of blockValues) {
+      for (let k = 0; k < 5; k++) values.push(bv);
+    }
+
+    const input = (blockDays: number): PairedBlockBootstrapInput => ({
+      armA: mkSeries(values),
+      armB: { constant: 0 },
+      statistic: mean,
+      holdingRule: { blockDays },
+      ciLevel: 0.95,
+      resamples: 2000,
+      seed: 99,
+    });
+
+    const lBlock = pairedBlockBootstrap(input(5));
+    const lOne = pairedBlockBootstrap(input(1));
+
+    const widthBlock = lBlock.ci.high! - lBlock.ci.low!;
+    const widthOne = lOne.ci.high! - lOne.ci.low!;
+
+    expect(widthBlock / widthOne).toBeGreaterThan(1);
+    expect(lBlock.ci.low!).toBeLessThanOrEqual(0);
+    expect(lBlock.ci.high!).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Selection-max INTO the CI
+// ---------------------------------------------------------------------------
+
+describe("selection-adjusted interval", () => {
+  it("widens/shifts the interval of the max above any single member", () => {
+    const members = [10, 20, 30, 40].map((seed) => ({
+      id: `m${seed}`,
+      armA: mkSeries(seededSeq(seed, 40)),
+      armB: { constant: 0 } as const,
+    }));
+
+    const shared = {
+      statistic: mean,
+      holdingRule: { blockDays: 4 },
+      ciLevel: 0.95,
+      resamples: 1500,
+      seed: 55,
+    };
+
+    const selected = pairedBlockBootstrap({
+      armA: members[0].armA,
+      statistic: mean,
+      holdingRule: { blockDays: 4 },
+      ciLevel: 0.95,
+      resamples: 1500,
+      seed: 55,
+      selectionSet: { members, extremum: "max" },
+    });
+
+    const single = pairedBlockBootstrap({
+      armA: members[0].armA,
+      armB: members[0].armB,
+      ...shared,
+    });
+
+    const memberPoints = members.map((m) => mean(seededSeq(Number(m.id.slice(1)), 40)));
+    const expectedCentroid = mean(memberPoints);
+    const sortedDesc = [...memberPoints].sort((a, b) => b - a);
+
+    expect(selected.selection).not.toBeNull();
+    expect(selected.selection!.kConsidered).toBe(4);
+    expect(selected.selection!.centroid).toBeCloseTo(expectedCentroid, 10);
+    expect(selected.selection!.maxGap).toBeCloseTo(sortedDesc[0] - sortedDesc[1], 10);
+    expect(selected.selection!.maxGap).toBeGreaterThanOrEqual(0);
+    expect(selected.point).toBeCloseTo(sortedDesc[0], 10);
+    expect(selected.ci.high!).toBeGreaterThan(single.ci.high!);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Injected effect + honest refusal
+// ---------------------------------------------------------------------------
+
+describe("injected effect and honest refusal", () => {
+  it("recovers an injected constant with an interval excluding zero", () => {
+    const c = 5;
+    const base = seededSeq(31, 40);
+    const armA = mkSeries(base.map((v, i) => v + c + seededSeq(32, 40)[i] * 0.05));
+    const armB = mkSeries(base.map((v, i) => v + seededSeq(33, 40)[i] * 0.05));
+
+    const result = pairedBlockBootstrap({
+      armA,
+      armB,
+      statistic: mean,
+      holdingRule: { blockDays: 5 },
+      ciLevel: 0.95,
+      resamples: 800,
+      seed: 3,
+    });
+
+    expect(result.point!).toBeCloseTo(c, 1);
+    expect(result.ci.low!).toBeGreaterThan(0);
+    expect(result.status).toBe("resolved");
+  });
+
+  it("refuses (notComparable, null interval) when effectiveN falls below the floor", () => {
+    const c = 5;
+    const base = seededSeq(31, 6);
+    const armA = mkSeries(base.map((v) => v + c));
+    const armB = mkSeries(base);
+
+    const result = pairedBlockBootstrap({
+      armA,
+      armB,
+      statistic: mean,
+      holdingRule: { blockDays: 2 },
+      ciLevel: 0.95,
+      resamples: 800,
+      seed: 3,
+      effectiveNFloorBlocks: 10,
+    });
+
+    expect(result.status).toBe("notComparable");
+    expect(result.ci.low).toBeNull();
+    expect(result.ci.high).toBeNull();
+    expect(result.point).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Single-arm mode
+// ---------------------------------------------------------------------------
+
+describe("single-arm mode", () => {
+  it("uses armA values directly when armB is omitted", () => {
+    const values = seededSeq(41, 30);
+    const observed = values.map((_, i) => i % 4 !== 0);
+    const armA = mkSeries(values, observed);
+
+    const result = pairedBlockBootstrap({
+      armA,
+      statistic: mean,
+      holdingRule: { blockDays: 3 },
+      ciLevel: 0.95,
+      resamples: 300,
+      seed: 8,
+    });
+
+    const observedValues = values.filter((_, i) => observed[i]);
+    expect(result.point!).toBeCloseTo(mean(observedValues), 10);
+  });
+
+  it("subtracts a constant comparand from armA", () => {
+    const values = seededSeq(41, 30);
+    const c = 1.25;
+    const result = pairedBlockBootstrap({
+      armA: mkSeries(values),
+      armB: { constant: c },
+      statistic: mean,
+      holdingRule: { blockDays: 3 },
+      ciLevel: 0.95,
+      resamples: 300,
+      seed: 8,
+    });
+
+    expect(result.point!).toBeCloseTo(mean(values) - c, 10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Sensitivity band
+// ---------------------------------------------------------------------------
+
+describe("sensitivity band", () => {
+  it("reruns the interval at each multiplied block length", () => {
+    const result = pairedBlockBootstrap({
+      armA: mkSeries(seededSeq(51, 60)),
+      armB: { constant: 0 },
+      statistic: mean,
+      holdingRule: { blockDays: 4, sensitivity: [0.5, 2] },
+      ciLevel: 0.95,
+      resamples: 400,
+      seed: 12,
+    });
+
+    expect(result.blockDays).toBe(4);
+    expect(result.sensitivity.map((s) => s.blockDays)).toEqual([2, 8]);
+    for (const entry of result.sensitivity) {
+      expect(entry.status).toBe("resolved");
+      expect(Number.isFinite(entry.ci.low)).toBe(true);
+      expect(Number.isFinite(entry.ci.high)).toBe(true);
+    }
+  });
+
+  it("emits one honest null-CI entry per requested multiplier, even when a multiplier cannot run", () => {
+    // 12-day overlap, base block 4. Multiplier 4 -> 16-day block > overlap,
+    // so that requested check cannot resolve and must be reported, not dropped.
+    const result = pairedBlockBootstrap({
+      armA: mkSeries(seededSeq(51, 12)),
+      armB: { constant: 0 },
+      statistic: mean,
+      holdingRule: { blockDays: 4, sensitivity: [0.5, 4] },
+      ciLevel: 0.95,
+      resamples: 300,
+      seed: 12,
+    });
+
+    // Exactly one entry per requested multiplier.
+    expect(result.sensitivity).toHaveLength(2);
+    expect(result.sensitivity.map((s) => s.blockDays)).toEqual([2, 16]);
+
+    const runnable = result.sensitivity[0];
+    expect(runnable.status).toBe("resolved");
+    expect(Number.isFinite(runnable.ci.low)).toBe(true);
+    expect(Number.isFinite(runnable.ci.high)).toBe(true);
+
+    const tooLong = result.sensitivity[1];
+    expect(tooLong.status).toBe("underpowered");
+    expect(tooLong.ci.low).toBeNull();
+    expect(tooLong.ci.high).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. Underpowered degenerate
+// ---------------------------------------------------------------------------
+
+describe("underpowered degenerate", () => {
+  it("reports underpowered with a null interval when overlap is shorter than one block", () => {
+    const result = pairedBlockBootstrap({
+      armA: mkSeries(seededSeq(61, 3)),
+      armB: { constant: 0 },
+      statistic: mean,
+      holdingRule: { blockDays: 5 },
+      ciLevel: 0.95,
+      resamples: 200,
+      seed: 9,
+    });
+
+    expect(result.status).toBe("underpowered");
+    expect(result.ci.low).toBeNull();
+    expect(result.ci.high).toBeNull();
+    expect(result.point).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// holdingPeriodBlockDays helper
+// ---------------------------------------------------------------------------
+
+describe("holdingPeriodBlockDays", () => {
+  it("derives the 95th-percentile block length from the input, floored at 1", () => {
+    // n=8, type-7 rank = 0.95*7 = 6.65 -> 5 + 0.65*(8-5) = 6.95 -> round 7.
+    expect(holdingPeriodBlockDays([1, 1, 1, 2, 2, 3, 5, 8])).toBe(7);
+    expect(holdingPeriodBlockDays([0.2, 0.3, 0.4])).toBe(1);
+    expect(holdingPeriodBlockDays([])).toBe(1);
+    expect(holdingPeriodBlockDays([10, 10, 10], 0.95)).toBe(10);
+  });
+});


### PR DESCRIPTION
Tier: 3 — adds new exports to the published @tradeblocks/lib surface (cross-Admiral review per the Tier-3 protocol).

Worktree: /home/romeo/code/tradeblocks-org/tradeblocks-romeo-622-paired-block-bootstrap

## What it does

Adds `calculations/paired-block-bootstrap` to `@tradeblocks/lib`, shipped as **v3.1.0** (minor — purely additive; release note in `releases/v3.1.0.md`).

Daily P&L series from multi-day positions are autocorrelated — a two-week position smears its outcome across two weeks of rows — so single-day resampling produces confidence intervals that are systematically too tight (fake precision). This module provides the honest primitive:

- **Day-block resampling**, block length always derived from the caller's own data via `holdingPeriodBlockDays(holdingPeriods, percentile = 0.95)` — no baked-in constants anywhere in the module.
- **Observed-day masking**: dormant days are missing, never zero-filled; a true flat day is a real observation.
- **Gap-aware, no wraparound**: blocks drawn only inside contiguous observed runs; the `pairedBlockDays` introspection seam exposes the exact drawable block set (same code path as the resampler) so the invariant is testable, not asserted.
- **Paired comparisons on shared days**: both series resampled on the same drawn indices over their intersection; single-series and series-vs-constant modes included.
- **Selection-adjusted intervals**: pass candidates as a `selectionSet` and each resample re-runs the selection, so the CI prices in "an extremum was chosen" (with family `centroid`, `maxGap`, `kConsidered`).
- **Honest refusal**: `effectiveN` + explicit `status` (`resolved` / `underpowered` / `notComparable` below a caller-supplied floor) instead of a meaningless interval; sensitivity entries are emitted per requested multiplier with their own status when a block length could not run.
- **Deterministic**: self-contained seeded PRNG (mulberry32); no `Math.random`.

## Verification

Full repo gate on the final tree: typecheck + eslint + prettier clean; **74 suites / 1,272 tests passed** (16 new, all exercised through the public `@tradeblocks/lib` entrypoint). Coverage bar: existing suite green, every new export directly tested from the public entrypoint, no breaking deltas.
