### PR TITLE
feat(lib): preserve and reconcile OO reporting logs (v3.2.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tradeblocks",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tradeblocks",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "private": true,
   "workspaces": [

--- a/packages/lib/calculations/index.ts
+++ b/packages/lib/calculations/index.ts
@@ -26,6 +26,7 @@ export * from "./rolling-metrics.ts";
 export * from "./mc-regime-comparison.ts";
 export * from "./walk-forward-degradation.ts";
 export * from "./trade-matching.ts";
+export * from "./trade-cost-reconciliation.ts";
 export * from "./live-alignment.ts";
 export * from "./edge-decay-synthesis.ts";
 // Re-export from cumulative-distribution excluding conflicting name

--- a/packages/lib/calculations/live-alignment.ts
+++ b/packages/lib/calculations/live-alignment.ts
@@ -96,6 +96,10 @@ export interface AlignmentDataQuality {
   backtestTradeCount: number;
   /** Total actual trades provided */
   actualTradeCount: number;
+  /** Backtest trades excluded because they fall outside the shared date window. */
+  outsideOverlapBacktestCount: number;
+  /** Actual trades excluded because they fall outside the shared date window. */
+  outsideOverlapActualCount: number;
   /** Total matched trade pairs */
   matchedTradeCount: number;
   /** Match rate: matched / min(backtest, actual) within overlap (0-1) */
@@ -162,7 +166,7 @@ function matchTradesWithScaledPl(
   const actualByKey = new Map<string, ReportingTrade[]>();
   for (const trade of actualTrades) {
     const dateKey = formatDateKey(new Date(trade.dateOpened));
-    const timeKey = truncateTimeToMinute(trade.timeOpened);
+    const timeKey = truncateTimeToMinute(trade.rawTimeOpened ?? trade.timeOpened);
     const key = `${dateKey}\t${trade.strategy}\t${timeKey}`;
     const existing = actualByKey.get(key) || [];
     existing.push(trade);
@@ -309,6 +313,14 @@ export function analyzeLiveAlignment(
     warnings.push("No overlapping date range between backtest and actual trades");
     filteredBacktest = [];
     filteredActual = [];
+  }
+
+  const outsideOverlapBacktestCount = backtestTrades.length - filteredBacktest.length;
+  const outsideOverlapActualCount = actualTrades.length - filteredActual.length;
+  if (overlapRange && (outsideOverlapBacktestCount > 0 || outsideOverlapActualCount > 0)) {
+    warnings.push(
+      `${outsideOverlapBacktestCount} backtest trade(s) and ${outsideOverlapActualCount} actual trade(s) fall outside the shared overlap window and are excluded from alignment metrics`,
+    );
   }
 
   if (backtestTrades.length === 0) {
@@ -543,6 +555,8 @@ export function analyzeLiveAlignment(
   const dataQuality: AlignmentDataQuality = {
     backtestTradeCount: backtestTrades.length,
     actualTradeCount: actualTrades.length,
+    outsideOverlapBacktestCount,
+    outsideOverlapActualCount,
     matchedTradeCount: pairs.length,
     matchRate,
     overlapMonths: monthlySeries.length,

--- a/packages/lib/calculations/trade-cost-reconciliation.ts
+++ b/packages/lib/calculations/trade-cost-reconciliation.ts
@@ -1,0 +1,247 @@
+/**
+ * Pure cost decomposition for an already-matched model/live trade pair.
+ *
+ * This module deliberately does not match trades, bind strategies, or read files.
+ * Callers must establish the pair before invoking it.
+ */
+
+import type { ReportingTrade } from "../models/reporting-trade.ts";
+import type { Trade } from "../models/trade.ts";
+
+export type TradeCostScaling = "perContract" | "toActualContracts";
+
+export interface TradeCostReconciliationOptions {
+  /** Output basis. Defaults to the live trade's total contract count. */
+  scaling?: TradeCostScaling;
+  /** Absolute arithmetic tolerance in dollars. Defaults to 1e-9. */
+  identityTolerance?: number;
+}
+
+export type TradeCostReconciliationUnavailableReason =
+  | "invalid-scaling"
+  | "missing-actual-closing-cost"
+  | "invalid-model-contract-count"
+  | "invalid-actual-contract-count"
+  | "invalid-model-net"
+  | "invalid-actual-net"
+  | "invalid-model-opening-fees"
+  | "invalid-model-closing-fees"
+  | "invalid-actual-initial-premium"
+  | "invalid-actual-closing-cost"
+  | "negative-model-fees"
+  | "negative-inferred-actual-fees"
+  | "invalid-identity-tolerance";
+
+export interface TradeCostReconciliationUnavailable {
+  available: false;
+  reason: TradeCostReconciliationUnavailableReason;
+  message: string;
+}
+
+export interface TradeCostReconciliationSide {
+  /** Gross P/L before commissions and fees, in the selected output basis. */
+  gross: number;
+  /** Positive commissions and fees deducted from gross P/L. */
+  fees: number;
+  /** Net P/L after commissions and fees. */
+  net: number;
+}
+
+export interface ActualTradeCostReconciliationSide {
+  /** Gross P/L before inferred fees, in the selected output basis. */
+  gross: number;
+  /** Fees inferred as gross P/L minus the reporting log's net P/L. */
+  inferredFees: number;
+  /** Reporting-log net P/L after applying the selected output basis. */
+  net: number;
+}
+
+export interface TradeCostReconciliationAvailable {
+  available: true;
+  scaling: {
+    basis: TradeCostScaling;
+    modelContracts: number;
+    actualContracts: number;
+    modelScaleFactor: number;
+    actualScaleFactor: number;
+  };
+  model: TradeCostReconciliationSide;
+  actual: ActualTradeCostReconciliationSide;
+  residuals: {
+    /** Actual gross P/L minus model gross P/L. */
+    grossExecution: number;
+    /** Actual inferred fees minus model commissions and fees. */
+    fees: number;
+    /** Actual net P/L minus model net P/L. */
+    net: number;
+  };
+  arithmeticIdentity: {
+    /** grossExecution - fees; this must equal the observed net residual. */
+    derivedNetDelta: number;
+    observedNetDelta: number;
+    error: number;
+    tolerance: number;
+    holds: boolean;
+  };
+}
+
+export type TradeCostReconciliation =
+  | TradeCostReconciliationAvailable
+  | TradeCostReconciliationUnavailable;
+
+function unavailable(
+  reason: TradeCostReconciliationUnavailableReason,
+  message: string,
+): TradeCostReconciliationUnavailable {
+  return { available: false, reason, message };
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+/**
+ * Decompose model-vs-live P/L for a pair that the caller has already matched.
+ *
+ * Model gross is reconstructed from its authoritative net P/L plus recorded
+ * commissions/fees. Actual gross is reconstructed from the reporting log's
+ * opening premium and average closing cost:
+ * `(initialPremium + avgClosingCost) * contracts * 100`.
+ */
+export function reconcileTradeCosts(
+  model: Trade,
+  actual: ReportingTrade,
+  options: TradeCostReconciliationOptions = {},
+): TradeCostReconciliation {
+  const basis = options.scaling ?? "toActualContracts";
+  const tolerance = options.identityTolerance ?? 1e-9;
+
+  if (basis !== "perContract" && basis !== "toActualContracts") {
+    return unavailable(
+      "invalid-scaling",
+      'scaling must be either "perContract" or "toActualContracts"',
+    );
+  }
+  if (!isFiniteNumber(tolerance) || tolerance < 0) {
+    return unavailable(
+      "invalid-identity-tolerance",
+      "identityTolerance must be a finite, non-negative number",
+    );
+  }
+  if (!isFiniteNumber(model.numContracts) || model.numContracts <= 0) {
+    return unavailable(
+      "invalid-model-contract-count",
+      "Model contract count must be finite and greater than zero",
+    );
+  }
+  if (!isFiniteNumber(actual.numContracts) || actual.numContracts <= 0) {
+    return unavailable(
+      "invalid-actual-contract-count",
+      "Actual contract count must be finite and greater than zero",
+    );
+  }
+  if (!isFiniteNumber(model.pl)) {
+    return unavailable("invalid-model-net", "Model P/L must be finite");
+  }
+  if (!isFiniteNumber(actual.pl)) {
+    return unavailable("invalid-actual-net", "Actual P/L must be finite");
+  }
+  if (!isFiniteNumber(model.openingCommissionsFees)) {
+    return unavailable(
+      "invalid-model-opening-fees",
+      "Model opening commissions and fees must be finite",
+    );
+  }
+  if (!isFiniteNumber(model.closingCommissionsFees)) {
+    return unavailable(
+      "invalid-model-closing-fees",
+      "Model closing commissions and fees must be finite",
+    );
+  }
+  if (!isFiniteNumber(actual.initialPremium)) {
+    return unavailable("invalid-actual-initial-premium", "Actual initial premium must be finite");
+  }
+  if (actual.avgClosingCost === undefined || actual.avgClosingCost === null) {
+    return unavailable(
+      "missing-actual-closing-cost",
+      "Actual average closing cost is required for cost reconciliation",
+    );
+  }
+  if (!isFiniteNumber(actual.avgClosingCost)) {
+    return unavailable("invalid-actual-closing-cost", "Actual average closing cost must be finite");
+  }
+
+  const modelFeesTotal = model.openingCommissionsFees + model.closingCommissionsFees;
+  if (!isFiniteNumber(modelFeesTotal) || modelFeesTotal < 0) {
+    return unavailable(
+      "negative-model-fees",
+      "Model commissions and fees must sum to a finite, non-negative value",
+    );
+  }
+
+  const actualGrossTotal =
+    (actual.initialPremium + actual.avgClosingCost) * actual.numContracts * 100;
+  const actualFeesTotal = actualGrossTotal - actual.pl;
+  if (!isFiniteNumber(actualGrossTotal) || !isFiniteNumber(actualFeesTotal)) {
+    return unavailable(
+      "invalid-actual-closing-cost",
+      "Actual gross P/L and inferred fees must be finite",
+    );
+  }
+  if (actualFeesTotal < 0) {
+    return unavailable(
+      "negative-inferred-actual-fees",
+      "Actual gross P/L is less than reported net P/L, producing negative inferred fees",
+    );
+  }
+
+  const modelScaleFactor =
+    basis === "perContract" ? 1 / model.numContracts : actual.numContracts / model.numContracts;
+  const actualScaleFactor = basis === "perContract" ? 1 / actual.numContracts : 1;
+
+  const modelNet = model.pl * modelScaleFactor;
+  const modelFees = modelFeesTotal * modelScaleFactor;
+  const modelGross = modelNet + modelFees;
+  const actualGross = actualGrossTotal * actualScaleFactor;
+  const actualFees = actualFeesTotal * actualScaleFactor;
+  const actualNet = actual.pl * actualScaleFactor;
+
+  const grossExecutionResidual = actualGross - modelGross;
+  const feeResidual = actualFees - modelFees;
+  const netDelta = actualNet - modelNet;
+  const derivedNetDelta = grossExecutionResidual - feeResidual;
+  const identityError = netDelta - derivedNetDelta;
+
+  return {
+    available: true,
+    scaling: {
+      basis,
+      modelContracts: model.numContracts,
+      actualContracts: actual.numContracts,
+      modelScaleFactor,
+      actualScaleFactor,
+    },
+    model: {
+      gross: modelGross,
+      fees: modelFees,
+      net: modelNet,
+    },
+    actual: {
+      gross: actualGross,
+      inferredFees: actualFees,
+      net: actualNet,
+    },
+    residuals: {
+      grossExecution: grossExecutionResidual,
+      fees: feeResidual,
+      net: netDelta,
+    },
+    arithmeticIdentity: {
+      derivedNetDelta,
+      observedNetDelta: netDelta,
+      error: identityError,
+      tolerance,
+      holds: Math.abs(identityError) <= tolerance,
+    },
+  };
+}

--- a/packages/lib/calculations/trade-cost-reconciliation.ts
+++ b/packages/lib/calculations/trade-cost-reconciliation.ts
@@ -22,7 +22,7 @@ export type TradeCostReconciliationUnavailableReason =
   | "missing-actual-closing-cost"
   | "invalid-model-contract-count"
   | "invalid-actual-contract-count"
-  | "invalid-model-net"
+  | "invalid-model-gross"
   | "invalid-actual-net"
   | "invalid-model-opening-fees"
   | "invalid-model-closing-fees"
@@ -103,9 +103,9 @@ function isFiniteNumber(value: unknown): value is number {
 /**
  * Decompose model-vs-live P/L for a pair that the caller has already matched.
  *
- * Model gross is reconstructed from its authoritative net P/L plus recorded
- * commissions/fees. Actual gross is reconstructed from the reporting log's
- * opening premium and average closing cost:
+ * Trade.pl is the model's gross P/L (the same invariant used by enrichTrades),
+ * so model net is gross minus recorded commissions/fees. Actual gross is
+ * reconstructed from the reporting log's opening premium and average closing cost:
  * `(initialPremium + avgClosingCost) * contracts * 100`.
  */
 export function reconcileTradeCosts(
@@ -141,7 +141,7 @@ export function reconcileTradeCosts(
     );
   }
   if (!isFiniteNumber(model.pl)) {
-    return unavailable("invalid-model-net", "Model P/L must be finite");
+    return unavailable("invalid-model-gross", "Model gross P/L must be finite");
   }
   if (!isFiniteNumber(actual.pl)) {
     return unavailable("invalid-actual-net", "Actual P/L must be finite");
@@ -199,9 +199,9 @@ export function reconcileTradeCosts(
     basis === "perContract" ? 1 / model.numContracts : actual.numContracts / model.numContracts;
   const actualScaleFactor = basis === "perContract" ? 1 / actual.numContracts : 1;
 
-  const modelNet = model.pl * modelScaleFactor;
+  const modelGross = model.pl * modelScaleFactor;
   const modelFees = modelFeesTotal * modelScaleFactor;
-  const modelGross = modelNet + modelFees;
+  const modelNet = modelGross - modelFees;
   const actualGross = actualGrossTotal * actualScaleFactor;
   const actualFees = actualFeesTotal * actualScaleFactor;
   const actualNet = actual.pl * actualScaleFactor;

--- a/packages/lib/calculations/trade-matching.ts
+++ b/packages/lib/calculations/trade-matching.ts
@@ -24,11 +24,19 @@ export function formatDateKey(d: Date): string {
  */
 export function truncateTimeToMinute(time: string | undefined): string {
   if (!time) return "00:00";
-  const parts = time.split(":");
-  if (parts.length >= 2) {
-    return `${parts[0].padStart(2, "0")}:${parts[1].padStart(2, "0")}`;
+  const match = time.trim().match(/^(\d{1,2}):(\d{2})(?::\d{2}(?:\.\d+)?)?\s*([AP]M)?$/i);
+  if (!match) return "00:00";
+
+  let hour = Number(match[1]);
+  const period = match[3]?.toUpperCase();
+  if (period) {
+    if (hour < 1 || hour > 12) return "00:00";
+    hour = (hour % 12) + (period === "PM" ? 12 : 0);
+  } else if (hour > 23) {
+    return "00:00";
   }
-  return "00:00";
+
+  return `${String(hour).padStart(2, "0")}:${match[2]}`;
 }
 
 /**
@@ -157,7 +165,7 @@ export function matchTrades(
   const actualByKey = new Map<string, ReportingTrade[]>();
   actualTrades.forEach((trade) => {
     const dateKey = formatDateKey(new Date(trade.dateOpened));
-    const timeKey = truncateTimeToMinute(trade.timeOpened);
+    const timeKey = truncateTimeToMinute(trade.rawTimeOpened ?? trade.timeOpened);
     const key = `${dateKey}|${trade.strategy}|${timeKey}`;
     const existing = actualByKey.get(key) || [];
     existing.push(trade);

--- a/packages/lib/models/reporting-trade.ts
+++ b/packages/lib/models/reporting-trade.ts
@@ -5,8 +5,11 @@
  */
 export interface ReportingTrade {
   strategy: string;
+  account?: string;
   dateOpened: Date;
   timeOpened?: string;
+  /** Exact source timestamp, before display formatting/truncation. */
+  rawTimeOpened?: string;
   openingPrice: number;
   legs: string;
   initialPremium: number;
@@ -15,8 +18,13 @@ export interface ReportingTrade {
   closingPrice?: number;
   dateClosed?: Date;
   timeClosed?: string;
+  /** Exact source timestamp, before display formatting/truncation. */
+  rawTimeClosed?: string;
+  daysInTrade?: number;
   avgClosingCost?: number;
   reasonForClose?: string;
+  /** Lossless source row, including columns unknown to this library version. */
+  sourceFields?: Record<string, string>;
 }
 
 /**
@@ -24,6 +32,7 @@ export interface ReportingTrade {
  */
 export interface RawReportingTradeData {
   Strategy: string;
+  Account?: string;
   "Date Opened": string;
   "Time Opened"?: string;
   "Opening Price": string;
@@ -36,6 +45,10 @@ export interface RawReportingTradeData {
   "Time Closed"?: string;
   "Avg. Closing Cost"?: string;
   "Reason For Close"?: string;
+  "Days in Trade"?: string;
+  /** Exact source row captured before alias normalization. */
+  __sourceFields?: Record<string, string>;
+  [column: string]: string | Record<string, string> | undefined;
 }
 
 /**

--- a/packages/lib/models/validators.ts
+++ b/packages/lib/models/validators.ts
@@ -75,29 +75,35 @@ export const tradeSchema = z.object({
 /**
  * Zod schema for validating raw reporting trade data from strategy logs
  */
-export const rawReportingTradeDataSchema = z.object({
-  Strategy: z.string().min(1, "Strategy is required"),
-  "Date Opened": z.string().min(1, "Date Opened is required"),
-  "Time Opened": z.string().optional(),
-  "Opening Price": z.string().min(1, "Opening Price is required"),
-  Legs: z.string().min(1, "Legs description is required"),
-  "Initial Premium": z.string().min(1, "Initial Premium is required"),
-  "No. of Contracts": z.string().min(1, "Number of Contracts is required"),
-  "P/L": z.string().min(1, "P/L is required"),
-  "Closing Price": z.string().optional(),
-  "Date Closed": z.string().optional(),
-  "Time Closed": z.string().optional(),
-  "Avg. Closing Cost": z.string().optional(),
-  "Reason For Close": z.string().optional(),
-});
+export const rawReportingTradeDataSchema = z
+  .object({
+    Strategy: z.string().min(1, "Strategy is required"),
+    Account: z.string().optional(),
+    "Date Opened": z.string().min(1, "Date Opened is required"),
+    "Time Opened": z.string().optional(),
+    "Opening Price": z.string().min(1, "Opening Price is required"),
+    Legs: z.string().min(1, "Legs description is required"),
+    "Initial Premium": z.string().min(1, "Initial Premium is required"),
+    "No. of Contracts": z.string().min(1, "Number of Contracts is required"),
+    "P/L": z.string().min(1, "P/L is required"),
+    "Closing Price": z.string().optional(),
+    "Date Closed": z.string().optional(),
+    "Time Closed": z.string().optional(),
+    "Avg. Closing Cost": z.string().optional(),
+    "Reason For Close": z.string().optional(),
+    "Days in Trade": z.string().optional(),
+  })
+  .catchall(z.string());
 
 /**
  * Zod schema for validating processed reporting trade data
  */
 export const reportingTradeSchema = z.object({
   strategy: z.string().min(1),
+  account: z.string().optional(),
   dateOpened: z.date(),
   timeOpened: z.string().optional(),
+  rawTimeOpened: z.string().optional(),
   openingPrice: z.number().finite(),
   legs: z.string().min(1),
   initialPremium: z.number().finite(),
@@ -106,8 +112,11 @@ export const reportingTradeSchema = z.object({
   closingPrice: z.number().finite().optional(),
   dateClosed: z.date().optional(),
   timeClosed: z.string().optional(),
+  rawTimeClosed: z.string().optional(),
+  daysInTrade: z.number().finite().nonnegative().optional(),
   avgClosingCost: z.number().finite().optional(),
   reasonForClose: z.string().optional(),
+  sourceFields: z.record(z.string(), z.string()).optional(),
 });
 
 /**

--- a/packages/lib/processing/csv-parser.ts
+++ b/packages/lib/processing/csv-parser.ts
@@ -158,7 +158,9 @@ export class CSVParser {
       return {
         data,
         headers: cleanHeaders,
-        totalRows: totalRows - 1, // Excluding header
+        // Count data records actually encountered. Physical line count includes
+        // trailing blank lines, which are not CSV records when skipEmptyLines is on.
+        totalRows: processedRows,
         validRows,
         errors,
         warnings,

--- a/packages/lib/processing/reporting-trade-processor.ts
+++ b/packages/lib/processing/reporting-trade-processor.ts
@@ -121,15 +121,17 @@ export class ReportingTradeProcessor {
       stage: "converting",
       progress: 0,
       rowsProcessed: 0,
-      totalRows: parseResult.data.length,
+      totalRows: parseResult.totalRows,
       errors: errors.length,
       validTrades: 0,
-      invalidTrades: 0,
+      invalidTrades: isTat ? 0 : parseResult.totalRows - parseResult.validRows,
     });
 
     const trades: ReportingTrade[] = [];
     let validTrades = 0;
-    let invalidTrades = 0;
+    // OO rows rejected by the raw schema never enter parseResult.data. Count
+    // them here so every nonblank source row is represented in the envelope.
+    let invalidTrades = isTat ? 0 : parseResult.totalRows - parseResult.validRows;
 
     for (let i = 0; i < parseResult.data.length; i++) {
       const rawTrade = parseResult.data[i];
@@ -239,27 +241,25 @@ export class ReportingTradeProcessor {
     });
   }
 
-  private validateRawRow(row: Record<string, string>): RawReportingTradeData | null {
-    try {
-      const sourceFields = { ...row };
-      const normalizedRow: Record<string, string> = { ...row };
-      Object.entries(REPORTING_TRADE_COLUMN_ALIASES).forEach(([alias, canonical]) => {
-        if (normalizedRow[alias] !== undefined) {
-          normalizedRow[canonical] = normalizedRow[alias];
-          delete normalizedRow[alias];
-        }
-      });
-
-      if (!normalizedRow["Strategy"] || normalizedRow["Strategy"].trim() === "") {
-        normalizedRow["Strategy"] = "Unknown";
+  private validateRawRow(row: Record<string, string>): RawReportingTradeData {
+    const sourceFields = { ...row };
+    const normalizedRow: Record<string, string> = { ...row };
+    Object.entries(REPORTING_TRADE_COLUMN_ALIASES).forEach(([alias, canonical]) => {
+      if (normalizedRow[alias] !== undefined) {
+        normalizedRow[canonical] = normalizedRow[alias];
+        delete normalizedRow[alias];
       }
+    });
 
-      const parsed = rawReportingTradeDataSchema.parse(normalizedRow);
-
-      return { ...parsed, __sourceFields: sourceFields };
-    } catch {
-      return null;
+    if (!normalizedRow["Strategy"] || normalizedRow["Strategy"].trim() === "") {
+      normalizedRow["Strategy"] = "Unknown";
     }
+
+    // Let schema errors reach CSVParser. It records the exact source line;
+    // returning null here would silently erase the rejected row.
+    const parsed = rawReportingTradeDataSchema.parse(normalizedRow);
+
+    return { ...parsed, __sourceFields: sourceFields };
   }
 
   /**

--- a/packages/lib/processing/reporting-trade-processor.ts
+++ b/packages/lib/processing/reporting-trade-processor.ts
@@ -55,12 +55,18 @@ export class ReportingTradeProcessor {
   }
 
   async processFile(file: File): Promise<ReportingTradeProcessingResult> {
+    const fileContent = await this.readFileContent(file);
+    return this.processText(fileContent);
+  }
+
+  /**
+   * Process reporting-log CSV text without a browser File/FileReader boundary.
+   * Server-side consumers use this path; processFile remains backward compatible.
+   */
+  async processText(fileContent: string): Promise<ReportingTradeProcessingResult> {
     const startTime = Date.now();
     const errors: ProcessingError[] = [];
     const warnings: string[] = [];
-
-    // Read file content first so we can detect format from headers
-    const fileContent = await this.readFileContent(file);
 
     // Extract headers from first line to detect format
     const firstLine = fileContent.split(/\r?\n/)[0] || "";
@@ -235,6 +241,7 @@ export class ReportingTradeProcessor {
 
   private validateRawRow(row: Record<string, string>): RawReportingTradeData | null {
     try {
+      const sourceFields = { ...row };
       const normalizedRow: Record<string, string> = { ...row };
       Object.entries(REPORTING_TRADE_COLUMN_ALIASES).forEach(([alias, canonical]) => {
         if (normalizedRow[alias] !== undefined) {
@@ -249,7 +256,7 @@ export class ReportingTradeProcessor {
 
       const parsed = rawReportingTradeDataSchema.parse(normalizedRow);
 
-      return parsed;
+      return { ...parsed, __sourceFields: sourceFields };
     } catch {
       return null;
     }
@@ -311,8 +318,10 @@ export class ReportingTradeProcessor {
 
     const reportingTrade = {
       strategy: raw["Strategy"].trim(),
+      account: raw["Account"]?.trim() || undefined,
       dateOpened,
       timeOpened: this.parseTimeToFormatted(raw["Time Opened"]),
+      rawTimeOpened: raw["Time Opened"]?.trim() || undefined,
       openingPrice: parseFloat(raw["Opening Price"]),
       legs: raw["Legs"].trim(),
       initialPremium: parseFloat(raw["Initial Premium"]),
@@ -321,8 +330,11 @@ export class ReportingTradeProcessor {
       closingPrice: raw["Closing Price"] ? parseFloat(raw["Closing Price"]) : undefined,
       dateClosed,
       timeClosed: this.parseTimeToFormatted(raw["Time Closed"]),
+      rawTimeClosed: raw["Time Closed"]?.trim() || undefined,
+      daysInTrade: raw["Days in Trade"] ? parseFloat(raw["Days in Trade"]) : undefined,
       avgClosingCost: raw["Avg. Closing Cost"] ? parseFloat(raw["Avg. Closing Cost"]) : undefined,
       reasonForClose: raw["Reason For Close"]?.trim() || undefined,
+      sourceFields: raw.__sourceFields,
     };
 
     return reportingTradeSchema.parse(reportingTrade);

--- a/releases/v3.2.0.md
+++ b/releases/v3.2.0.md
@@ -1,0 +1,36 @@
+# TradeBlocks 3.2.0 — Reporting-log evidence and cost reconciliation
+
+A minor release adding folder-independent reporting-log intake and live-cost reconciliation primitives to `@tradeblocks/lib`. Existing browser file intake remains supported; all new model fields and methods are additive.
+
+## Reporting-log intake
+
+- `ReportingTradeProcessor.processText(csv)` provides a server-safe public entrypoint without requiring `File` or `FileReader`.
+- Reporting trades preserve account, days in trade, exact source timestamps, and the complete source row, including columns unknown to this library version.
+- Raw-row validation failures retain their source line and are counted as invalid rather than disappearing from the result envelope.
+- Live/backtest matching prefers exact source timestamps and remains compatible with legacy 12-hour display timestamps.
+- Live-alignment data quality reports trades excluded outside the shared observation window.
+
+## `reconcileTradeCosts`
+
+`reconcileTradeCosts(model, actual, options?)` decomposes an already-matched model/live trade pair without performing matching, binding, or storage:
+
+- model gross P/L, commissions and fees, and net P/L;
+- actual gross P/L, inferred fees, and reported net P/L;
+- gross execution residual, fee residual, and net delta;
+- an explicit arithmetic identity check;
+- either per-contract scaling or model scaling to the actual contract count.
+
+The primitive fails closed when required cost inputs are missing or invalid. In particular, it does not infer fees without the reporting log's average closing cost.
+
+```ts
+import { reconcileTradeCosts } from "@tradeblocks/lib";
+
+const result = reconcileTradeCosts(modelTrade, reportingTrade, {
+  scaling: "toActualContracts",
+});
+
+if (result.available) {
+  // net delta = gross execution residual - fee residual
+  console.log(result.residuals, result.arithmeticIdentity);
+}
+```

--- a/tests/unit/live-alignment.test.ts
+++ b/tests/unit/live-alignment.test.ts
@@ -454,6 +454,11 @@ describe("analyzeLiveAlignment", () => {
 
       // Only the 2024-01-15 trade should match
       expect(result.dataQuality.matchedTradeCount).toBe(1);
+      expect(result.dataQuality.outsideOverlapBacktestCount).toBe(1);
+      expect(result.dataQuality.outsideOverlapActualCount).toBe(1);
+      expect(result.dataQuality.warnings).toContain(
+        "1 backtest trade(s) and 1 actual trade(s) fall outside the shared overlap window and are excluded from alignment metrics",
+      );
       expect(result.executionEfficiency.overallEfficiency).toBeCloseTo(0.8, 4);
     });
 

--- a/tests/unit/reporting-trade-processor.test.ts
+++ b/tests/unit/reporting-trade-processor.test.ts
@@ -1,0 +1,119 @@
+import {
+  analyzeLiveAlignment,
+  matchTrades,
+  ReportingTradeProcessor,
+  type Trade,
+} from "@tradeblocks/lib";
+
+describe("ReportingTradeProcessor lossless Automation-log intake", () => {
+  it("parses server-side text while preserving new and unknown source columns", async () => {
+    const csv =
+      '\ufeff"Strategy","Account","Date Opened","Time Opened","Opening Price","Legs","Initial Premium","No. of Contracts","P/L","Closing Price","Date Closed","Time Closed","Days in Trade","Avg. Closing Cost","Reason For Close","Automation Id"\n' +
+      '"Wizzy Orb EOD","Big Money","2026-07-10","15:56:07.1960624",7577.03,"1 Jul 10 7575 C STO 3.73 | 1 Jul 10 7595 C BTO 0.03",3.7,1,327.56,7575.39,"2026-07-10","16:15:01.0393019",0,-0.39,"Expired","run-42"\n';
+
+    const result = await new ReportingTradeProcessor().processText(csv);
+
+    expect(result.errors).toEqual([]);
+    expect(result.totalRows).toBe(1);
+    expect(result.validTrades).toBe(1);
+    expect(result.trades[0]).toMatchObject({
+      strategy: "Wizzy Orb EOD",
+      account: "Big Money",
+      timeOpened: "3:56 PM",
+      rawTimeOpened: "15:56:07.1960624",
+      timeClosed: "4:15 PM",
+      rawTimeClosed: "16:15:01.0393019",
+      daysInTrade: 0,
+    });
+    expect(result.trades[0].sourceFields).toMatchObject({
+      Account: "Big Money",
+      "Days in Trade": "0",
+      "Automation Id": "run-42",
+    });
+  });
+
+  it("keeps the original alias columns while exposing canonical values", async () => {
+    const csv =
+      '"Strategy","Date Opened","Time Opened","Opening Price","Legs","Initial Credit","Contracts Traded","PL","Vendor Note"\n' +
+      '"Alias Strategy","2026-07-09","09:31:02.1234567",6200,"legs",1.25,2,42.5,"preserve me"';
+
+    const result = await new ReportingTradeProcessor().processText(csv);
+
+    expect(result.errors).toEqual([]);
+    expect(result.trades[0]).toMatchObject({
+      strategy: "Alias Strategy",
+      initialPremium: 1.25,
+      numContracts: 2,
+      pl: 42.5,
+      rawTimeOpened: "09:31:02.1234567",
+    });
+    expect(result.trades[0].sourceFields).toEqual({
+      Strategy: "Alias Strategy",
+      "Date Opened": "2026-07-09",
+      "Time Opened": "09:31:02.1234567",
+      "Opening Price": "6200",
+      Legs: "legs",
+      "Initial Credit": "1.25",
+      "Contracts Traded": "2",
+      PL: "42.5",
+      "Vendor Note": "preserve me",
+    });
+  });
+
+  it("remains compatible with logs that do not have the additive fields", async () => {
+    const csv =
+      '"Strategy","Date Opened","Opening Price","Legs","Initial Premium","No. of Contracts","P/L"\n' +
+      '"Legacy Strategy","2026-07-08",6100,"legs",2.5,1,-10';
+
+    const result = await new ReportingTradeProcessor().processText(csv);
+
+    expect(result.errors).toEqual([]);
+    expect(result.trades[0]).toMatchObject({
+      strategy: "Legacy Strategy",
+      initialPremium: 2.5,
+      numContracts: 1,
+      pl: -10,
+    });
+    expect(result.trades[0].account).toBeUndefined();
+    expect(result.trades[0].daysInTrade).toBeUndefined();
+    expect(result.trades[0].rawTimeOpened).toBeUndefined();
+  });
+
+  it("matches parsed AM display times using the lossless source timestamp", async () => {
+    const csv =
+      '"Strategy","Date Opened","Time Opened","Opening Price","Legs","Initial Premium","No. of Contracts","P/L"\n' +
+      '"Morning Strategy","2026-07-07","09:32:16.1234567",6000,"legs",1,1,80';
+    const parsed = await new ReportingTradeProcessor().processText(csv);
+    const backtest: Trade[] = [
+      {
+        strategy: "Morning Strategy",
+        dateOpened: new Date(2026, 6, 7),
+        timeOpened: "09:32:00",
+        openingPrice: 6000,
+        legs: "legs",
+        premium: 1,
+        numContracts: 1,
+        pl: 100,
+        fundsAtClose: 100,
+        marginReq: 100,
+        openingCommissionsFees: 0,
+        closingCommissionsFees: 0,
+        openingShortLongRatio: 1,
+      },
+    ];
+
+    expect(parsed.trades[0]).toMatchObject({
+      timeOpened: "9:32 AM",
+      rawTimeOpened: "09:32:16.1234567",
+    });
+    const alignment = analyzeLiveAlignment(backtest, parsed.trades);
+    expect(alignment.available).toBe(true);
+    if (!alignment.available) throw new Error(alignment.reason);
+    expect(alignment.dataQuality.matchedTradeCount).toBe(1);
+    expect(matchTrades(backtest, parsed.trades, "perContract").matchedTrades).toHaveLength(1);
+    expect(
+      matchTrades(backtest, [{ ...parsed.trades[0], rawTimeOpened: undefined }], "perContract")
+        .matchedTrades,
+    ).toHaveLength(1);
+  });
+});

--- a/tests/unit/reporting-trade-processor.test.ts
+++ b/tests/unit/reporting-trade-processor.test.ts
@@ -9,7 +9,7 @@ describe("ReportingTradeProcessor lossless Automation-log intake", () => {
   it("parses server-side text while preserving new and unknown source columns", async () => {
     const csv =
       '\ufeff"Strategy","Account","Date Opened","Time Opened","Opening Price","Legs","Initial Premium","No. of Contracts","P/L","Closing Price","Date Closed","Time Closed","Days in Trade","Avg. Closing Cost","Reason For Close","Automation Id"\n' +
-      '"Wizzy Orb EOD","Big Money","2026-07-10","15:56:07.1960624",7577.03,"1 Jul 10 7575 C STO 3.73 | 1 Jul 10 7595 C BTO 0.03",3.7,1,327.56,7575.39,"2026-07-10","16:15:01.0393019",0,-0.39,"Expired","run-42"\n';
+      '"Strategy Alpha","Demo Account","2026-07-10","15:56:07.1960624",100.25,"1 XYZ Jul 10 100 C STO 1.25 | 1 XYZ Jul 10 105 C BTO 0.25",1,1,96.56,101,"2026-07-10","16:15:01.0393019",0,-0.39,"Expired","run-42"\n';
 
     const result = await new ReportingTradeProcessor().processText(csv);
 
@@ -17,8 +17,8 @@ describe("ReportingTradeProcessor lossless Automation-log intake", () => {
     expect(result.totalRows).toBe(1);
     expect(result.validTrades).toBe(1);
     expect(result.trades[0]).toMatchObject({
-      strategy: "Wizzy Orb EOD",
-      account: "Big Money",
+      strategy: "Strategy Alpha",
+      account: "Demo Account",
       timeOpened: "3:56 PM",
       rawTimeOpened: "15:56:07.1960624",
       timeClosed: "4:15 PM",
@@ -26,7 +26,7 @@ describe("ReportingTradeProcessor lossless Automation-log intake", () => {
       daysInTrade: 0,
     });
     expect(result.trades[0].sourceFields).toMatchObject({
-      Account: "Big Money",
+      Account: "Demo Account",
       "Days in Trade": "0",
       "Automation Id": "run-42",
     });

--- a/tests/unit/reporting-trade-processor.test.ts
+++ b/tests/unit/reporting-trade-processor.test.ts
@@ -79,6 +79,24 @@ describe("ReportingTradeProcessor lossless Automation-log intake", () => {
     expect(result.trades[0].rawTimeOpened).toBeUndefined();
   });
 
+  it("surfaces and counts a raw row missing a required value", async () => {
+    const csv =
+      '"Strategy","Date Opened","Opening Price","Legs","Initial Premium","No. of Contracts","P/L"\n' +
+      '"Valid Strategy","2026-07-08",6100,"legs",2.5,1,10\n' +
+      '"Broken Strategy","",6100,"legs",2.5,1,20';
+
+    const result = await new ReportingTradeProcessor().processText(csv);
+
+    expect(result.totalRows).toBe(2);
+    expect(result.validTrades).toBe(1);
+    expect(result.invalidTrades).toBe(1);
+    expect(result.validTrades + result.invalidTrades).toBe(result.totalRows);
+    expect(result.trades).toHaveLength(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatchObject({ type: "parsing", line: 3 });
+    expect(result.errors[0].message).toContain("Date Opened");
+  });
+
   it("matches parsed AM display times using the lossless source timestamp", async () => {
     const csv =
       '"Strategy","Date Opened","Time Opened","Opening Price","Legs","Initial Premium","No. of Contracts","P/L"\n' +

--- a/tests/unit/trade-cost-reconciliation.test.ts
+++ b/tests/unit/trade-cost-reconciliation.test.ts
@@ -1,0 +1,128 @@
+import { reconcileTradeCosts, type ReportingTrade, type Trade } from "@tradeblocks/lib";
+
+function modelTrade(overrides: Partial<Trade> = {}): Trade {
+  return {
+    dateOpened: new Date(2026, 6, 1),
+    timeOpened: "09:32:00",
+    openingPrice: 6000,
+    legs: "legs",
+    premium: 1,
+    pl: 1000,
+    numContracts: 10,
+    fundsAtClose: 101000,
+    marginReq: 10000,
+    strategy: "Strategy",
+    openingCommissionsFees: 20,
+    closingCommissionsFees: 10,
+    openingShortLongRatio: 1,
+    ...overrides,
+  };
+}
+
+function actualTrade(overrides: Partial<ReportingTrade> = {}): ReportingTrade {
+  return {
+    strategy: "Strategy",
+    dateOpened: new Date(2026, 6, 1),
+    timeOpened: "9:32 AM",
+    rawTimeOpened: "09:32:16.1234567",
+    openingPrice: 6000,
+    legs: "legs",
+    initialPremium: 1.5,
+    avgClosingCost: -0.5,
+    numContracts: 2,
+    pl: 190,
+    ...overrides,
+  };
+}
+
+describe("reconcileTradeCosts", () => {
+  it("decomposes a credit trade on the actual-contract basis", () => {
+    const result = reconcileTradeCosts(modelTrade(), actualTrade());
+
+    expect(result.available).toBe(true);
+    if (!result.available) throw new Error(result.message);
+
+    expect(result.scaling).toEqual({
+      basis: "toActualContracts",
+      modelContracts: 10,
+      actualContracts: 2,
+      modelScaleFactor: 0.2,
+      actualScaleFactor: 1,
+    });
+    expect(result.model).toEqual({ gross: 206, fees: 6, net: 200 });
+    expect(result.actual).toEqual({ gross: 200, inferredFees: 10, net: 190 });
+    expect(result.residuals).toEqual({ grossExecution: -6, fees: 4, net: -10 });
+    expect(result.arithmeticIdentity).toMatchObject({
+      derivedNetDelta: -10,
+      observedNetDelta: -10,
+      error: 0,
+      holds: true,
+    });
+  });
+
+  it("decomposes a debit trade on the per-contract basis", () => {
+    const result = reconcileTradeCosts(
+      modelTrade({
+        pl: 300,
+        numContracts: 4,
+        openingCommissionsFees: 8,
+        closingCommissionsFees: 8,
+      }),
+      actualTrade({
+        initialPremium: -2,
+        avgClosingCost: 4,
+        numContracts: 2,
+        pl: 390,
+      }),
+      { scaling: "perContract" },
+    );
+
+    expect(result.available).toBe(true);
+    if (!result.available) throw new Error(result.message);
+
+    expect(result.model).toEqual({ gross: 79, fees: 4, net: 75 });
+    expect(result.actual).toEqual({ gross: 200, inferredFees: 5, net: 195 });
+    expect(result.residuals).toEqual({ grossExecution: 121, fees: 1, net: 120 });
+    expect(result.arithmeticIdentity.holds).toBe(true);
+  });
+
+  it("fails closed when average closing cost is missing", () => {
+    const result = reconcileTradeCosts(modelTrade(), actualTrade({ avgClosingCost: undefined }));
+
+    expect(result).toEqual({
+      available: false,
+      reason: "missing-actual-closing-cost",
+      message: "Actual average closing cost is required for cost reconciliation",
+    });
+  });
+
+  it("fails closed for invalid contract counts and negative inferred fees", () => {
+    expect(reconcileTradeCosts(modelTrade({ numContracts: 0 }), actualTrade())).toMatchObject({
+      available: false,
+      reason: "invalid-model-contract-count",
+    });
+    expect(
+      reconcileTradeCosts(modelTrade(), actualTrade({ initialPremium: 1, pl: 300 })),
+    ).toMatchObject({
+      available: false,
+      reason: "negative-inferred-actual-fees",
+    });
+  });
+
+  it("exposes the net = gross - fees identity without rounding", () => {
+    const result = reconcileTradeCosts(
+      modelTrade({ pl: -123.45, numContracts: 3, openingCommissionsFees: 4.2 }),
+      actualTrade({ initialPremium: -1.25, avgClosingCost: 0.85, pl: -87.65 }),
+      { identityTolerance: 1e-12 },
+    );
+
+    expect(result.available).toBe(true);
+    if (!result.available) throw new Error(result.message);
+    expect(result.residuals.net).toBeCloseTo(
+      result.residuals.grossExecution - result.residuals.fees,
+      12,
+    );
+    expect(result.arithmeticIdentity.error).toBeCloseTo(0, 12);
+    expect(result.arithmeticIdentity.holds).toBe(true);
+  });
+});

--- a/tests/unit/trade-cost-reconciliation.test.ts
+++ b/tests/unit/trade-cost-reconciliation.test.ts
@@ -1,4 +1,9 @@
-import { reconcileTradeCosts, type ReportingTrade, type Trade } from "@tradeblocks/lib";
+import {
+  enrichTrades,
+  reconcileTradeCosts,
+  type ReportingTrade,
+  type Trade,
+} from "@tradeblocks/lib";
 
 function modelTrade(overrides: Partial<Trade> = {}): Trade {
   return {
@@ -49,12 +54,12 @@ describe("reconcileTradeCosts", () => {
       modelScaleFactor: 0.2,
       actualScaleFactor: 1,
     });
-    expect(result.model).toEqual({ gross: 206, fees: 6, net: 200 });
+    expect(result.model).toEqual({ gross: 200, fees: 6, net: 194 });
     expect(result.actual).toEqual({ gross: 200, inferredFees: 10, net: 190 });
-    expect(result.residuals).toEqual({ grossExecution: -6, fees: 4, net: -10 });
+    expect(result.residuals).toEqual({ grossExecution: 0, fees: 4, net: -4 });
     expect(result.arithmeticIdentity).toMatchObject({
-      derivedNetDelta: -10,
-      observedNetDelta: -10,
+      derivedNetDelta: -4,
+      observedNetDelta: -4,
       error: 0,
       holds: true,
     });
@@ -80,10 +85,25 @@ describe("reconcileTradeCosts", () => {
     expect(result.available).toBe(true);
     if (!result.available) throw new Error(result.message);
 
-    expect(result.model).toEqual({ gross: 79, fees: 4, net: 75 });
+    expect(result.model).toEqual({ gross: 75, fees: 4, net: 71 });
     expect(result.actual).toEqual({ gross: 200, inferredFees: 5, net: 195 });
-    expect(result.residuals).toEqual({ grossExecution: 121, fees: 1, net: 120 });
+    expect(result.residuals).toEqual({ grossExecution: 125, fees: 1, net: 124 });
     expect(result.arithmeticIdentity.holds).toBe(true);
+  });
+
+  it("uses the same gross-P/L invariant as enrichTrades", () => {
+    const model = modelTrade();
+    const enriched = enrichTrades([model])[0];
+    const result = reconcileTradeCosts(model, actualTrade());
+
+    expect(enriched.netPl).toBe(
+      model.pl - model.openingCommissionsFees - model.closingCommissionsFees,
+    );
+    expect(result.available).toBe(true);
+    if (!result.available) throw new Error(result.message);
+    expect(result.model.gross).toBe(model.pl * result.scaling.modelScaleFactor);
+    expect(enriched.netPl).toBeDefined();
+    expect(result.model.net).toBe(enriched.netPl! * result.scaling.modelScaleFactor);
   });
 
   it("fails closed when average closing cost is missing", () => {


### PR DESCRIPTION
Tier: 3 — public parser evidence and cost-reconciliation exports.

Worktree: /home/romeo/code/tradeblocks-org/tradeblocks-romeo-917-reporting-log

## What it does

- releases TradeBlocks v3.2.0 with a matching lockfile and release note
- preserves exact OO Automation timestamps, Account, Days in Trade, and unknown source columns
- exposes server-safe reporting-log text processing
- reports malformed source rows instead of silently dropping them
- fixes exact-time matching and surfaces rows outside model coverage
- adds pure, fail-closed live/model cost decomposition with an enforced accounting identity

## Verification

- 1,283 tests pass across 76 suites
- direct public-entry coverage for every new/changed export
- typecheck, ESLint, Prettier, and diff checks clean
- real 162-row fixture parses 162/162 with all 15 columns retained (local smoke only; no private data committed)
- Worf CLEAR at current head after adversarial gross/net and malformed-row probes

## Tracking

Supports tradeblocks-org/enterprise#917. No enterprise vocabulary or storage authority is introduced into the public API.