### PR TITLE
feat(lib): add trade-set alignment primitive

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "private": true,
   "workspaces": [

--- a/packages/lib/calculations/index.ts
+++ b/packages/lib/calculations/index.ts
@@ -26,6 +26,7 @@ export * from "./rolling-metrics.ts";
 export * from "./mc-regime-comparison.ts";
 export * from "./walk-forward-degradation.ts";
 export * from "./trade-matching.ts";
+export * from "./trade-set-alignment.ts";
 export * from "./trade-cost-reconciliation.ts";
 export * from "./live-alignment.ts";
 export * from "./edge-decay-synthesis.ts";

--- a/packages/lib/calculations/live-alignment.ts
+++ b/packages/lib/calculations/live-alignment.ts
@@ -13,12 +13,8 @@
 
 import type { Trade } from "../models/trade.ts";
 import type { ReportingTrade } from "../models/reporting-trade.ts";
-import {
-  formatDateKey,
-  truncateTimeToMinute,
-  calculateScaledPl,
-  getMonthKey,
-} from "./trade-matching.ts";
+import { formatDateKey, calculateScaledPl, getMonthKey } from "./trade-matching.ts";
+import { matchTradeSets } from "./trade-set-alignment.ts";
 import { computeTrends, type TrendResult } from "./trend-detection.ts";
 
 // ---------------------------------------------------------------------------
@@ -150,8 +146,8 @@ interface MatchedPair {
 
 /**
  * Match backtest to actual trades and return per-pair scaled P/L values.
- * Uses the same key-generation logic as matchTrades from trade-matching.ts
- * but tracks individual scaled P/L per pair for efficiency computation.
+ * Delegates matching to the single-authority matcher (matchTradeSets) and
+ * layers scaled P/L per pair for efficiency computation.
  */
 function matchTradesWithScaledPl(
   backtestTrades: Trade[],
@@ -162,70 +158,55 @@ function matchTradesWithScaledPl(
   unmatchedBacktestByStrategy: Map<string, number>;
   unmatchedActualByStrategy: Map<string, number>;
 } {
-  // Build lookup for actual trades
-  const actualByKey = new Map<string, ReportingTrade[]>();
-  for (const trade of actualTrades) {
-    const dateKey = formatDateKey(new Date(trade.dateOpened));
-    const timeKey = truncateTimeToMinute(trade.rawTimeOpened ?? trade.timeOpened);
-    const key = `${dateKey}\t${trade.strategy}\t${timeKey}`;
-    const existing = actualByKey.get(key) || [];
-    existing.push(trade);
-    actualByKey.set(key, existing);
+  const {
+    matched,
+    unmatchedBacktestIndices,
+    unmatchedActualIndices,
+    unusableBacktest,
+    unusableActual,
+  } = matchTradeSets(backtestTrades, actualTrades);
+
+  const pairs: MatchedPair[] = matched.map(({ backtestIndex, actualIndex }) => {
+    const btTrade = backtestTrades[backtestIndex];
+    const actualTrade = actualTrades[actualIndex];
+    const { scaledBtPl, scaledActualPl } = calculateScaledPl(
+      btTrade.pl,
+      actualTrade.pl,
+      btTrade.numContracts,
+      actualTrade.numContracts,
+      scaling,
+    );
+    return {
+      date: formatDateKey(new Date(btTrade.dateOpened)),
+      strategy: btTrade.strategy,
+      scaledBtPl,
+      scaledActualPl,
+      slippage: scaledActualPl - scaledBtPl,
+      btContracts: btTrade.numContracts,
+      actualContracts: actualTrade.numContracts,
+    };
+  });
+
+  // Malformed rows never match; fold them into the per-strategy unmatched
+  // tallies so counts still span every input row on each side.
+  const unmatchedBacktestByStrategy = new Map<string, number>();
+  for (const index of unmatchedBacktestIndices) {
+    const strat = backtestTrades[index].strategy;
+    unmatchedBacktestByStrategy.set(strat, (unmatchedBacktestByStrategy.get(strat) || 0) + 1);
+  }
+  for (const { index } of unusableBacktest) {
+    const strat = backtestTrades[index].strategy;
+    unmatchedBacktestByStrategy.set(strat, (unmatchedBacktestByStrategy.get(strat) || 0) + 1);
   }
 
-  const pairs: MatchedPair[] = [];
-  const unmatchedBacktestByStrategy = new Map<string, number>();
   const unmatchedActualByStrategy = new Map<string, number>();
-
-  // Count actual trades per strategy for unmatched tracking
-  for (const trade of actualTrades) {
-    const strat = trade.strategy;
+  for (const index of unmatchedActualIndices) {
+    const strat = actualTrades[index].strategy;
     unmatchedActualByStrategy.set(strat, (unmatchedActualByStrategy.get(strat) || 0) + 1);
   }
-
-  // Match backtest trades to actual trades
-  for (const btTrade of backtestTrades) {
-    const dateKey = formatDateKey(new Date(btTrade.dateOpened));
-    const timeKey = truncateTimeToMinute(btTrade.timeOpened);
-    const key = `${dateKey}\t${btTrade.strategy}\t${timeKey}`;
-
-    const actualMatches = actualByKey.get(key);
-    const actualTrade = actualMatches?.[0];
-
-    if (actualTrade) {
-      // Decrement unmatched actual count
-      const strat = actualTrade.strategy;
-      const remaining = (unmatchedActualByStrategy.get(strat) || 1) - 1;
-      unmatchedActualByStrategy.set(strat, remaining);
-
-      // Remove matched trade
-      if (actualMatches && actualMatches.length > 1) {
-        actualByKey.set(key, actualMatches.slice(1));
-      } else {
-        actualByKey.delete(key);
-      }
-
-      const { scaledBtPl, scaledActualPl } = calculateScaledPl(
-        btTrade.pl,
-        actualTrade.pl,
-        btTrade.numContracts,
-        actualTrade.numContracts,
-        scaling,
-      );
-
-      pairs.push({
-        date: dateKey,
-        strategy: btTrade.strategy,
-        scaledBtPl,
-        scaledActualPl,
-        slippage: scaledActualPl - scaledBtPl,
-        btContracts: btTrade.numContracts,
-        actualContracts: actualTrade.numContracts,
-      });
-    } else {
-      const strat = btTrade.strategy;
-      unmatchedBacktestByStrategy.set(strat, (unmatchedBacktestByStrategy.get(strat) || 0) + 1);
-    }
+  for (const { index } of unusableActual) {
+    const strat = actualTrades[index].strategy;
+    unmatchedActualByStrategy.set(strat, (unmatchedActualByStrategy.get(strat) || 0) + 1);
   }
 
   return { pairs, unmatchedBacktestByStrategy, unmatchedActualByStrategy };

--- a/packages/lib/calculations/trade-matching.ts
+++ b/packages/lib/calculations/trade-matching.ts
@@ -8,6 +8,7 @@
 
 import type { Trade } from "../models/trade.ts";
 import type { ReportingTrade } from "../models/reporting-trade.ts";
+import { matchTradeSets } from "./trade-set-alignment.ts";
 
 /**
  * Helper to format date key for trade matching
@@ -161,67 +162,44 @@ export function matchTrades(
   unmatchedBacktestCount: number;
   unmatchedActualCount: number;
 } {
-  // Build lookup for actual trades
-  const actualByKey = new Map<string, ReportingTrade[]>();
-  actualTrades.forEach((trade) => {
-    const dateKey = formatDateKey(new Date(trade.dateOpened));
-    const timeKey = truncateTimeToMinute(trade.rawTimeOpened ?? trade.timeOpened);
-    const key = `${dateKey}|${trade.strategy}|${timeKey}`;
-    const existing = actualByKey.get(key) || [];
-    existing.push(trade);
-    actualByKey.set(key, existing);
+  const {
+    matched,
+    unmatchedBacktestIndices,
+    unmatchedActualIndices,
+    unusableBacktest,
+    unusableActual,
+  } = matchTradeSets(backtestTrades, actualTrades);
+
+  const matchedTrades: MatchedTradeData[] = matched.map(({ backtestIndex, actualIndex }) => {
+    const btTrade = backtestTrades[backtestIndex];
+    const actualTrade = actualTrades[actualIndex];
+    const { scaledBtPl, scaledActualPl } = calculateScaledPl(
+      btTrade.pl,
+      actualTrade.pl,
+      btTrade.numContracts,
+      actualTrade.numContracts,
+      scaling,
+    );
+
+    return {
+      date: formatDateKey(new Date(btTrade.dateOpened)),
+      strategy: btTrade.strategy,
+      timeOpened: truncateTimeToMinute(btTrade.timeOpened),
+      // Total slippage = actual P/L - backtest P/L (after scaling)
+      totalSlippage: scaledActualPl - scaledBtPl,
+      openingVix: btTrade.openingVix,
+      closingVix: btTrade.closingVix,
+      gap: btTrade.gap,
+      movement: btTrade.movement,
+      hourOfDay: parseHourFromTime(btTrade.timeOpened),
+      contracts: actualTrade.numContracts,
+    };
   });
 
-  const matchedTrades: MatchedTradeData[] = [];
-  let unmatchedBacktestCount = 0;
-  let unmatchedActualCount = actualTrades.length;
-
-  // Match backtest trades to actual trades by date+strategy+time
-  for (const btTrade of backtestTrades) {
-    const dateKey = formatDateKey(new Date(btTrade.dateOpened));
-    const timeKey = truncateTimeToMinute(btTrade.timeOpened);
-    const key = `${dateKey}|${btTrade.strategy}|${timeKey}`;
-
-    const actualMatches = actualByKey.get(key);
-    const actualTrade = actualMatches?.[0];
-
-    if (actualTrade) {
-      unmatchedActualCount--;
-      // Remove the matched trade from the list
-      if (actualMatches && actualMatches.length > 1) {
-        actualByKey.set(key, actualMatches.slice(1));
-      } else {
-        actualByKey.delete(key);
-      }
-
-      // Calculate scaled P/L values
-      const { scaledBtPl, scaledActualPl } = calculateScaledPl(
-        btTrade.pl,
-        actualTrade.pl,
-        btTrade.numContracts,
-        actualTrade.numContracts,
-        scaling,
-      );
-
-      // Total slippage = actual P/L - backtest P/L (after scaling)
-      const totalSlippage = scaledActualPl - scaledBtPl;
-
-      matchedTrades.push({
-        date: dateKey,
-        strategy: btTrade.strategy,
-        timeOpened: timeKey,
-        totalSlippage,
-        openingVix: btTrade.openingVix,
-        closingVix: btTrade.closingVix,
-        gap: btTrade.gap,
-        movement: btTrade.movement,
-        hourOfDay: parseHourFromTime(btTrade.timeOpened),
-        contracts: actualTrade.numContracts,
-      });
-    } else {
-      unmatchedBacktestCount++;
-    }
-  }
+  // Malformed rows never match; count them with the unmatched totals so the
+  // matched + unmatched accounting still spans every input row.
+  const unmatchedBacktestCount = unmatchedBacktestIndices.length + unusableBacktest.length;
+  const unmatchedActualCount = unmatchedActualIndices.length + unusableActual.length;
 
   return { matchedTrades, unmatchedBacktestCount, unmatchedActualCount };
 }

--- a/packages/lib/calculations/trade-set-alignment.ts
+++ b/packages/lib/calculations/trade-set-alignment.ts
@@ -1,0 +1,488 @@
+/**
+ * Trade-Set Alignment
+ *
+ * Single-authority matching of a backtest trade set against an actual
+ * (reporting-log) trade set, plus a factual public alignment surface.
+ *
+ * Matching authority: `matchTradeSets` is the one implementation of the
+ * date+strategy+minute matching loop. Both `matchTrades` and the live-alignment
+ * engine consume it, so matching logic lives in exactly one place.
+ *
+ * `analyzeTradeSetAlignment` reports factual measurements only -- counts, rates,
+ * and Wilson score confidence intervals. It draws no conclusions: a matched pair
+ * asserts identity of opening date/strategy/minute, nothing about P/L, execution,
+ * or equivalence.
+ */
+
+import type { Trade } from "../models/trade.ts";
+import type { ReportingTrade } from "../models/reporting-trade.ts";
+import { formatDateKey, truncateTimeToMinute } from "./trade-matching.ts";
+
+// ---------------------------------------------------------------------------
+// Matcher types
+// ---------------------------------------------------------------------------
+
+/** Identity of one matched pair by position in the original input arrays. */
+export interface TradeSetMatchPair {
+  /** Index into the backtest input array. */
+  backtestIndex: number;
+  /** Index into the actual (reporting-log) input array. */
+  actualIndex: number;
+}
+
+/** A row that cannot be matched because its match key is malformed. */
+export interface UnusableRow {
+  /** Index into the original input array for its side. */
+  index: number;
+  /** Human-readable reason the key is unusable. */
+  reason: string;
+}
+
+/**
+ * Result of matching two trade sets. All index fields refer to positions in the
+ * ORIGINAL input arrays. Ordering is deterministic:
+ * - `matched` and `unmatchedBacktestIndices` follow backtest source order;
+ * - `unmatchedActualIndices` is ascending by actual index;
+ * - `unusable*` follow source order.
+ */
+export interface TradeSetMatchResult {
+  matched: TradeSetMatchPair[];
+  unmatchedBacktestIndices: number[];
+  unmatchedActualIndices: number[];
+  unusableBacktest: UnusableRow[];
+  unusableActual: UnusableRow[];
+}
+
+const KEY_SEPARATOR = "\t";
+const REASON_EMPTY_STRATEGY = "empty or non-string strategy";
+const REASON_INVALID_DATE = "invalid dateOpened";
+
+/**
+ * Compute the match key for a row, or the reason it is unusable.
+ *
+ * Fail-closed: a row with an empty/non-string strategy or an Invalid Date
+ * `dateOpened` (which `formatDateKey` would render as "NaN-NaN-NaN") yields no
+ * key and is never matched.
+ */
+function computeMatchKey(
+  strategy: unknown,
+  dateOpened: Date,
+  time: string | undefined,
+): { key: string; reason: null } | { key: null; reason: string } {
+  if (typeof strategy !== "string" || strategy.length === 0) {
+    return { key: null, reason: REASON_EMPTY_STRATEGY };
+  }
+  const dateKey = formatDateKey(new Date(dateOpened));
+  if (dateKey.includes("NaN")) {
+    return { key: null, reason: REASON_INVALID_DATE };
+  }
+  const timeKey = truncateTimeToMinute(time);
+  return { key: `${dateKey}${KEY_SEPARATOR}${strategy}${KEY_SEPARATOR}${timeKey}`, reason: null };
+}
+
+/**
+ * Match backtest trades to actual (reporting-log) trades on exact strategy +
+ * opening date + opening minute.
+ *
+ * - Duplicate-safe: rows sharing a key match FIFO in source (input) order.
+ * - Returns input-index identity for every matched pair.
+ * - Fails closed on malformed keys (surfaced in `unusable*`), never mutates
+ *   inputs, and produces deterministic ordering.
+ */
+export function matchTradeSets(
+  backtestTrades: Trade[],
+  actualTrades: ReportingTrade[],
+): TradeSetMatchResult {
+  const actualByKey = new Map<string, number[]>();
+  const unusableActual: UnusableRow[] = [];
+
+  actualTrades.forEach((trade, index) => {
+    const { key, reason } = computeMatchKey(
+      trade.strategy,
+      trade.dateOpened,
+      trade.rawTimeOpened ?? trade.timeOpened,
+    );
+    if (key === null) {
+      unusableActual.push({ index, reason });
+      return;
+    }
+    const queue = actualByKey.get(key);
+    if (queue) queue.push(index);
+    else actualByKey.set(key, [index]);
+  });
+
+  const matched: TradeSetMatchPair[] = [];
+  const unmatchedBacktestIndices: number[] = [];
+  const unusableBacktest: UnusableRow[] = [];
+
+  backtestTrades.forEach((trade, index) => {
+    const { key, reason } = computeMatchKey(trade.strategy, trade.dateOpened, trade.timeOpened);
+    if (key === null) {
+      unusableBacktest.push({ index, reason });
+      return;
+    }
+    const queue = actualByKey.get(key);
+    if (queue && queue.length > 0) {
+      const actualIndex = queue.shift() as number;
+      matched.push({ backtestIndex: index, actualIndex });
+    } else {
+      unmatchedBacktestIndices.push(index);
+    }
+  });
+
+  const unmatchedActualIndices: number[] = [];
+  for (const queue of actualByKey.values()) {
+    for (const idx of queue) unmatchedActualIndices.push(idx);
+  }
+  unmatchedActualIndices.sort((a, b) => a - b);
+
+  return {
+    matched,
+    unmatchedBacktestIndices,
+    unmatchedActualIndices,
+    unusableBacktest,
+    unusableActual,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Alignment surface types
+// ---------------------------------------------------------------------------
+
+/** Inclusive date range, `YYYY-MM-DD` string bounds. */
+export interface DateRange {
+  from: string;
+  to: string;
+}
+
+/** Wilson score confidence-interval bounds (proportion scale). */
+export interface WilsonInterval {
+  lower: number;
+  upper: number;
+}
+
+/** Which sides of the comparison a strategy appears on. */
+export type StrategyPresence = "both" | "backtestOnly" | "actualOnly";
+
+/** Per-strategy factual alignment measurements. */
+export interface StrategyTradeSetAlignment {
+  strategy: string;
+  presence: StrategyPresence;
+  /** Date range of this strategy's own usable backtest rows, or null. */
+  backtestDateRange: DateRange | null;
+  /** Date range of this strategy's own usable actual rows, or null. */
+  actualDateRange: DateRange | null;
+  /**
+   * Comparable coverage: intersection of this strategy's own backtest and
+   * actual date ranges. Never a portfolio-global window. Null when the strategy
+   * lacks usable rows on either side or the ranges do not intersect.
+   */
+  coverage: DateRange | null;
+  matchedPairs: TradeSetMatchPair[];
+  matchedCount: number;
+  /** Backtest input indices with no live counterpart, within coverage. */
+  missingFromLive: number[];
+  missingCount: number;
+  /** missingCount / (matchedCount + missingCount); null when denominator is 0. */
+  missingRate: number | null;
+  missingRateInterval: WilsonInterval | null;
+  /** Actual input indices with no backtest counterpart, within coverage. */
+  extraInLive: number[];
+  extraCount: number;
+  /** extraCount / (matchedCount + extraCount); null when denominator is 0. */
+  extraRate: number | null;
+  extraRateInterval: WilsonInterval | null;
+  /** Backtest input indices outside comparable coverage. */
+  outsideCoverageBacktest: number[];
+  /** Actual input indices outside comparable coverage. */
+  outsideCoverageActual: number[];
+  /** Backtest rows of this strategy with malformed keys. */
+  unusableBacktest: UnusableRow[];
+  /** Actual rows of this strategy with malformed keys. */
+  unusableActual: UnusableRow[];
+}
+
+/** Aggregate + per-strategy factual alignment surface. */
+export interface TradeSetAlignmentResult {
+  backtestTradeCount: number;
+  actualTradeCount: number;
+  matchedPairs: TradeSetMatchPair[];
+  matchedCount: number;
+  missingCount: number;
+  /** Aggregate missingCount / (matchedCount + missingCount); null if 0. */
+  missingRate: number | null;
+  missingRateInterval: WilsonInterval | null;
+  extraCount: number;
+  /** Aggregate extraCount / (matchedCount + extraCount); null if 0. */
+  extraRate: number | null;
+  extraRateInterval: WilsonInterval | null;
+  outsideCoverageBacktestCount: number;
+  outsideCoverageActualCount: number;
+  /** All backtest rows with malformed keys (includes rows with no strategy). */
+  unusableBacktest: UnusableRow[];
+  /** All actual rows with malformed keys (includes rows with no strategy). */
+  unusableActual: UnusableRow[];
+  /** Per-strategy breakdown, sorted lexicographically by strategy. */
+  byStrategy: StrategyTradeSetAlignment[];
+}
+
+// ---------------------------------------------------------------------------
+// Wilson interval
+// ---------------------------------------------------------------------------
+
+const WILSON_Z = 1.96;
+
+/**
+ * Wilson score confidence interval (95%, z = 1.96) for a binomial proportion.
+ * Returns null when `trials` is not positive.
+ */
+export function wilsonInterval(successes: number, trials: number): WilsonInterval | null {
+  if (trials <= 0) return null;
+  const z = WILSON_Z;
+  const z2 = z * z;
+  const p = successes / trials;
+  const denominator = 1 + z2 / trials;
+  const center = (p + z2 / (2 * trials)) / denominator;
+  const margin = (z * Math.sqrt((p * (1 - p) + z2 / (4 * trials)) / trials)) / denominator;
+  return { lower: center - margin, upper: center + margin };
+}
+
+// ---------------------------------------------------------------------------
+// Alignment surface
+// ---------------------------------------------------------------------------
+
+function rangeFromDateKeys(dateKeys: string[]): DateRange | null {
+  if (dateKeys.length === 0) return null;
+  let from = dateKeys[0];
+  let to = dateKeys[0];
+  for (let i = 1; i < dateKeys.length; i++) {
+    if (dateKeys[i] < from) from = dateKeys[i];
+    if (dateKeys[i] > to) to = dateKeys[i];
+  }
+  return { from, to };
+}
+
+function intersectRanges(a: DateRange, b: DateRange): DateRange | null {
+  const from = a.from > b.from ? a.from : b.from;
+  const to = a.to < b.to ? a.to : b.to;
+  return from <= to ? { from, to } : null;
+}
+
+function withinCoverage(dateKey: string, coverage: DateRange | null): boolean {
+  if (!coverage) return false;
+  return dateKey >= coverage.from && dateKey <= coverage.to;
+}
+
+interface StrategyBucket {
+  backtestUsable: number[];
+  actualUsable: number[];
+  hasBacktest: boolean;
+  hasActual: boolean;
+  unusableBacktest: UnusableRow[];
+  unusableActual: UnusableRow[];
+}
+
+function emptyBucket(): StrategyBucket {
+  return {
+    backtestUsable: [],
+    actualUsable: [],
+    hasBacktest: false,
+    hasActual: false,
+    unusableBacktest: [],
+    unusableActual: [],
+  };
+}
+
+/**
+ * Analyze alignment between a backtest trade set and an actual (reporting-log)
+ * trade set. Factual measurements only -- counts, rates, and Wilson intervals.
+ *
+ * Coverage is computed INDEPENDENTLY per strategy (intersection of that
+ * strategy's own backtest and actual date ranges), never a portfolio-global
+ * window. All row lists carry input-index identity and are deterministically
+ * ordered. Inputs are never mutated.
+ */
+export function analyzeTradeSetAlignment(
+  backtestTrades: Trade[],
+  actualTrades: ReportingTrade[],
+): TradeSetAlignmentResult {
+  const match = matchTradeSets(backtestTrades, actualTrades);
+
+  const backtestDateKey = backtestTrades.map((t) => formatDateKey(new Date(t.dateOpened)));
+  const actualDateKey = actualTrades.map((t) => formatDateKey(new Date(t.dateOpened)));
+
+  const buckets = new Map<string, StrategyBucket>();
+  const getBucket = (strategy: string): StrategyBucket => {
+    let bucket = buckets.get(strategy);
+    if (!bucket) {
+      bucket = emptyBucket();
+      buckets.set(strategy, bucket);
+    }
+    return bucket;
+  };
+
+  // Usable rows (valid strategy + valid date) seed the per-strategy ranges.
+  const unusableBacktestIndices = new Set(match.unusableBacktest.map((u) => u.index));
+  const unusableActualIndices = new Set(match.unusableActual.map((u) => u.index));
+
+  backtestTrades.forEach((trade, index) => {
+    if (unusableBacktestIndices.has(index)) return;
+    const bucket = getBucket(trade.strategy);
+    bucket.hasBacktest = true;
+    bucket.backtestUsable.push(index);
+  });
+  actualTrades.forEach((trade, index) => {
+    if (unusableActualIndices.has(index)) return;
+    const bucket = getBucket(trade.strategy);
+    bucket.hasActual = true;
+    bucket.actualUsable.push(index);
+  });
+
+  // Attribute unusable rows to a named strategy when the strategy string is
+  // usable (e.g. an invalid-date row). Rows with no usable strategy remain
+  // orphaned in the aggregate unusable lists only.
+  for (const u of match.unusableBacktest) {
+    const strategy = backtestTrades[u.index].strategy;
+    if (typeof strategy === "string" && strategy.length > 0) {
+      const bucket = getBucket(strategy);
+      bucket.hasBacktest = true;
+      bucket.unusableBacktest.push(u);
+    }
+  }
+  for (const u of match.unusableActual) {
+    const strategy = actualTrades[u.index].strategy;
+    if (typeof strategy === "string" && strategy.length > 0) {
+      const bucket = getBucket(strategy);
+      bucket.hasActual = true;
+      bucket.unusableActual.push(u);
+    }
+  }
+
+  // Group matched / unmatched indices by strategy.
+  const matchedByStrategy = new Map<string, TradeSetMatchPair[]>();
+  for (const pair of match.matched) {
+    const strategy = backtestTrades[pair.backtestIndex].strategy;
+    const list = matchedByStrategy.get(strategy);
+    if (list) list.push(pair);
+    else matchedByStrategy.set(strategy, [pair]);
+  }
+  const unmatchedBacktestByStrategy = new Map<string, number[]>();
+  for (const index of match.unmatchedBacktestIndices) {
+    const strategy = backtestTrades[index].strategy;
+    const list = unmatchedBacktestByStrategy.get(strategy);
+    if (list) list.push(index);
+    else unmatchedBacktestByStrategy.set(strategy, [index]);
+  }
+  const unmatchedActualByStrategy = new Map<string, number[]>();
+  for (const index of match.unmatchedActualIndices) {
+    const strategy = actualTrades[index].strategy;
+    const list = unmatchedActualByStrategy.get(strategy);
+    if (list) list.push(index);
+    else unmatchedActualByStrategy.set(strategy, [index]);
+  }
+
+  const strategies = Array.from(buckets.keys()).sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+
+  const byStrategy: StrategyTradeSetAlignment[] = [];
+  let aggMatched = 0;
+  let aggMissing = 0;
+  let aggExtra = 0;
+  let aggOutsideBacktest = 0;
+  let aggOutsideActual = 0;
+
+  for (const strategy of strategies) {
+    const bucket = buckets.get(strategy) as StrategyBucket;
+
+    const backtestRange = rangeFromDateKeys(bucket.backtestUsable.map((i) => backtestDateKey[i]));
+    const actualRange = rangeFromDateKeys(bucket.actualUsable.map((i) => actualDateKey[i]));
+    const coverage =
+      backtestRange && actualRange ? intersectRanges(backtestRange, actualRange) : null;
+
+    const matchedPairs = (matchedByStrategy.get(strategy) ?? [])
+      .slice()
+      .sort((a, b) => a.backtestIndex - b.backtestIndex);
+
+    const missingFromLive: number[] = [];
+    const outsideCoverageBacktest: number[] = [];
+    for (const index of unmatchedBacktestByStrategy.get(strategy) ?? []) {
+      if (withinCoverage(backtestDateKey[index], coverage)) missingFromLive.push(index);
+      else outsideCoverageBacktest.push(index);
+    }
+    missingFromLive.sort((a, b) => a - b);
+    outsideCoverageBacktest.sort((a, b) => a - b);
+
+    const extraInLive: number[] = [];
+    const outsideCoverageActual: number[] = [];
+    for (const index of unmatchedActualByStrategy.get(strategy) ?? []) {
+      if (withinCoverage(actualDateKey[index], coverage)) extraInLive.push(index);
+      else outsideCoverageActual.push(index);
+    }
+    extraInLive.sort((a, b) => a - b);
+    outsideCoverageActual.sort((a, b) => a - b);
+
+    const matchedCount = matchedPairs.length;
+    const missingCount = missingFromLive.length;
+    const extraCount = extraInLive.length;
+
+    const missingDenominator = matchedCount + missingCount;
+    const extraDenominator = matchedCount + extraCount;
+    const missingRate = missingDenominator > 0 ? missingCount / missingDenominator : null;
+    const extraRate = extraDenominator > 0 ? extraCount / extraDenominator : null;
+
+    const presence: StrategyPresence =
+      bucket.hasBacktest && bucket.hasActual
+        ? "both"
+        : bucket.hasBacktest
+          ? "backtestOnly"
+          : "actualOnly";
+
+    byStrategy.push({
+      strategy,
+      presence,
+      backtestDateRange: backtestRange,
+      actualDateRange: actualRange,
+      coverage,
+      matchedPairs,
+      matchedCount,
+      missingFromLive,
+      missingCount,
+      missingRate,
+      missingRateInterval: wilsonInterval(missingCount, missingDenominator),
+      extraInLive,
+      extraCount,
+      extraRate,
+      extraRateInterval: wilsonInterval(extraCount, extraDenominator),
+      outsideCoverageBacktest,
+      outsideCoverageActual,
+      unusableBacktest: bucket.unusableBacktest.slice().sort((a, b) => a.index - b.index),
+      unusableActual: bucket.unusableActual.slice().sort((a, b) => a.index - b.index),
+    });
+
+    aggMatched += matchedCount;
+    aggMissing += missingCount;
+    aggExtra += extraCount;
+    aggOutsideBacktest += outsideCoverageBacktest.length;
+    aggOutsideActual += outsideCoverageActual.length;
+  }
+
+  const aggMissingDenominator = aggMatched + aggMissing;
+  const aggExtraDenominator = aggMatched + aggExtra;
+
+  return {
+    backtestTradeCount: backtestTrades.length,
+    actualTradeCount: actualTrades.length,
+    matchedPairs: match.matched.slice().sort((a, b) => a.backtestIndex - b.backtestIndex),
+    matchedCount: aggMatched,
+    missingCount: aggMissing,
+    missingRate: aggMissingDenominator > 0 ? aggMissing / aggMissingDenominator : null,
+    missingRateInterval: wilsonInterval(aggMissing, aggMissingDenominator),
+    extraCount: aggExtra,
+    extraRate: aggExtraDenominator > 0 ? aggExtra / aggExtraDenominator : null,
+    extraRateInterval: wilsonInterval(aggExtra, aggExtraDenominator),
+    outsideCoverageBacktestCount: aggOutsideBacktest,
+    outsideCoverageActualCount: aggOutsideActual,
+    unusableBacktest: match.unusableBacktest,
+    unusableActual: match.unusableActual,
+    byStrategy,
+  };
+}

--- a/releases/v3.3.0.md
+++ b/releases/v3.3.0.md
@@ -2,8 +2,9 @@
 
 A minor release adding a public trade-set alignment API to `@tradeblocks/lib`,
 consolidating trade matching behind a single authority, and correcting
-per-strategy coverage measurement. All additions are additive; existing intake
-and alignment behavior is unchanged for well-formed inputs.
+per-strategy coverage measurement. Existing intake and alignment behavior is
+unchanged for well-formed inputs. Malformed match keys now deliberately fail
+closed instead of being able to match one another.
 
 ## Single-authority matcher
 

--- a/releases/v3.3.0.md
+++ b/releases/v3.3.0.md
@@ -1,0 +1,76 @@
+# TradeBlocks 3.3.0 — Trade-set alignment primitive
+
+A minor release adding a public trade-set alignment API to `@tradeblocks/lib`,
+consolidating trade matching behind a single authority, and correcting
+per-strategy coverage measurement. All additions are additive; existing intake
+and alignment behavior is unchanged for well-formed inputs.
+
+## Single-authority matcher
+
+`matchTradeSets(backtestTrades, actualTrades)` is now the one implementation of
+the date + strategy + minute matching loop:
+
+- Match key is exact strategy string + opening date + opening minute.
+- Duplicate-safe: rows sharing a key match FIFO in source (input) order.
+- Every matched pair carries input-index identity (`backtestIndex`,
+  `actualIndex`) into the original arrays.
+- Malformed keys fail closed: a row with an Invalid Date `dateOpened` or an
+  empty/non-string strategy is never matched and is returned explicitly in an
+  `unusable*` list with its input index and a reason string, rather than
+  silently dropping from counts.
+- Inputs are never mutated; ordering is deterministic.
+
+`matchTrades` and the live-alignment engine's internal matcher now both consume
+`matchTradeSets`, so matching logic lives in exactly one place. `matchTrades`
+folds malformed rows into its unmatched counts, preserving its
+matched + unmatched accounting.
+
+## Factual alignment surface
+
+`analyzeTradeSetAlignment(backtestTrades, actualTrades)` reports factual
+measurements only — counts, rates, and Wilson score confidence intervals. It
+draws no conclusions: a matched pair asserts identity of opening
+date/strategy/minute, nothing about P/L, execution, or equivalence.
+
+- Per-strategy comparable coverage, computed independently per strategy as the
+  intersection of that strategy's own backtest and actual date ranges.
+- Matched pairs, missing-from-live and extra-in-live rows within coverage, and
+  rows outside coverage on each side — all with input indices.
+- One-sided strategies flagged via `presence`
+  (`"both" | "backtestOnly" | "actualOnly"`) with all rows reported outside
+  coverage.
+- Malformed rows surfaced per side with indices and reasons.
+- Aggregate and per-strategy counts and rates. `missingRate = missing /
+(matched + missing)` and `extraRate = extra / (matched + extra)`, both within
+  coverage; zero denominators yield `null`, never `NaN`.
+- `wilsonInterval(successes, trials)` (95%, z = 1.96) as its own exported
+  function; `null` when `trials` is 0.
+- Honest empty results: empty inputs, no overlap, and disjoint strategy sets all
+  produce well-formed results with zero counts, null rates/intervals, and empty
+  arrays — never a thrown error and never fabricated coverage.
+
+```ts
+import { analyzeTradeSetAlignment } from "@tradeblocks/lib";
+
+const alignment = analyzeTradeSetAlignment(backtestTrades, actualTrades);
+for (const strategy of alignment.byStrategy) {
+  console.log(strategy.strategy, strategy.coverage, strategy.missingRate);
+}
+```
+
+## Per-strategy coverage-window correction
+
+Live-alignment coverage was previously computed as one portfolio-global overlap
+window (the min/max of all trades on each side). A strategy with a long live
+history extended that window for every other strategy, so a strategy's backtest
+rows on dates where it had no live coverage were still counted "within overlap"
+and inflated its unmatched counts.
+
+- Before: coverage = intersection of the global backtest date range and the
+  global actual date range, applied to every strategy.
+- After: `analyzeTradeSetAlignment` computes coverage independently per
+  strategy, so a strategy's out-of-coverage rows are reported as outside
+  coverage rather than missing-from-live.
+
+`analyzeLiveAlignment`'s existing outputs are unchanged; the corrected
+per-strategy coverage is provided by the new `analyzeTradeSetAlignment` surface.

--- a/tests/unit/trade-set-alignment.test.ts
+++ b/tests/unit/trade-set-alignment.test.ts
@@ -1,0 +1,477 @@
+import { analyzeTradeSetAlignment, matchTradeSets, wilsonInterval } from "@tradeblocks/lib";
+import type {
+  Trade,
+  ReportingTrade,
+  TradeSetAlignmentResult,
+  StrategyTradeSetAlignment,
+} from "@tradeblocks/lib";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeTrade(overrides: Partial<Trade> = {}): Trade {
+  return {
+    dateOpened: new Date(2024, 0, 15),
+    timeOpened: "09:30:00",
+    openingPrice: 100,
+    legs: "Sample Legs",
+    premium: 1.5,
+    pl: 100,
+    numContracts: 10,
+    fundsAtClose: 100100,
+    marginReq: 5000,
+    strategy: "Iron Condor",
+    openingCommissionsFees: 1.5,
+    closingCommissionsFees: 1.5,
+    openingShortLongRatio: 1.0,
+    ...overrides,
+  };
+}
+
+function makeReportingTrade(overrides: Partial<ReportingTrade> = {}): ReportingTrade {
+  return {
+    strategy: "Iron Condor",
+    dateOpened: new Date(2024, 0, 15),
+    timeOpened: "09:30:00",
+    openingPrice: 100,
+    legs: "Sample Legs",
+    initialPremium: 1.5,
+    numContracts: 1,
+    pl: 80,
+    ...overrides,
+  };
+}
+
+function findStrategy(result: TradeSetAlignmentResult, name: string): StrategyTradeSetAlignment {
+  const s = result.byStrategy.find((x) => x.strategy === name);
+  if (!s) throw new Error(`strategy ${name} not found`);
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Global-window regression: one strategy's span must not extend another's
+//    comparable coverage.
+// ---------------------------------------------------------------------------
+
+describe("analyzeTradeSetAlignment — per-strategy coverage (global-window regression)", () => {
+  test("strategy B's long span does not make strategy A's out-of-coverage rows missing-from-live", () => {
+    const backtest: Trade[] = [
+      makeTrade({ strategy: "Alpha", dateOpened: new Date(2024, 0, 1) }), // 0 matched
+      makeTrade({ strategy: "Alpha", dateOpened: new Date(2024, 0, 2) }), // 1 matched
+      makeTrade({ strategy: "Alpha", dateOpened: new Date(2024, 0, 3) }), // 2 outside coverage
+      makeTrade({ strategy: "Alpha", dateOpened: new Date(2024, 0, 4) }), // 3 outside coverage
+      makeTrade({ strategy: "Alpha", dateOpened: new Date(2024, 0, 5) }), // 4 outside coverage
+      makeTrade({ strategy: "Beta", dateOpened: new Date(2024, 0, 1) }), // 5 matched
+      makeTrade({ strategy: "Beta", dateOpened: new Date(2024, 5, 30) }), // 6 matched
+    ];
+    const actual: ReportingTrade[] = [
+      makeReportingTrade({ strategy: "Alpha", dateOpened: new Date(2024, 0, 1) }), // 0
+      makeReportingTrade({ strategy: "Alpha", dateOpened: new Date(2024, 0, 2) }), // 1
+      makeReportingTrade({ strategy: "Beta", dateOpened: new Date(2024, 0, 1) }), // 2
+      makeReportingTrade({ strategy: "Beta", dateOpened: new Date(2024, 5, 30) }), // 3
+    ];
+
+    const result = analyzeTradeSetAlignment(backtest, actual);
+    const alpha = findStrategy(result, "Alpha");
+
+    // Alpha's own coverage is Jan 1..Jan 2, NOT the portfolio-global Jan 1..Jun 30.
+    expect(alpha.coverage).toEqual({ from: "2024-01-01", to: "2024-01-02" });
+    // The Jan 3/4/5 backtest rows are outside Alpha's coverage, not missing-from-live.
+    expect(alpha.missingFromLive).toEqual([]);
+    expect(alpha.missingCount).toBe(0);
+    expect(alpha.outsideCoverageBacktest).toEqual([2, 3, 4]);
+    expect(alpha.matchedPairs).toEqual([
+      { backtestIndex: 0, actualIndex: 0 },
+      { backtestIndex: 1, actualIndex: 1 },
+    ]);
+
+    const beta = findStrategy(result, "Beta");
+    expect(beta.coverage).toEqual({ from: "2024-01-01", to: "2024-06-30" });
+    expect(beta.matchedPairs).toEqual([
+      { backtestIndex: 5, actualIndex: 2 },
+      { backtestIndex: 6, actualIndex: 3 },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Duplicate trades sharing the same key match deterministically by source
+//    order (FIFO).
+// ---------------------------------------------------------------------------
+
+describe("matchTradeSets — duplicate keys are FIFO by source order", () => {
+  test("duplicates match in source order and report exact index pairs", () => {
+    const backtest: Trade[] = [
+      makeTrade({ strategy: "Dup", dateOpened: new Date(2024, 0, 1), pl: 10 }), // 0
+      makeTrade({ strategy: "Dup", dateOpened: new Date(2024, 0, 1), pl: 20 }), // 1
+      makeTrade({ strategy: "Dup", dateOpened: new Date(2024, 0, 1), pl: 30 }), // 2
+    ];
+    const actual: ReportingTrade[] = [
+      makeReportingTrade({ strategy: "Dup", dateOpened: new Date(2024, 0, 1), pl: 1 }), // 0
+      makeReportingTrade({ strategy: "Dup", dateOpened: new Date(2024, 0, 1), pl: 2 }), // 1
+    ];
+
+    const match = matchTradeSets(backtest, actual);
+    expect(match.matched).toEqual([
+      { backtestIndex: 0, actualIndex: 0 },
+      { backtestIndex: 1, actualIndex: 1 },
+    ]);
+    expect(match.unmatchedBacktestIndices).toEqual([2]);
+    expect(match.unmatchedActualIndices).toEqual([]);
+    expect(match.unusableBacktest).toEqual([]);
+    expect(match.unusableActual).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3 & 4. One-sided strategies.
+// ---------------------------------------------------------------------------
+
+describe("analyzeTradeSetAlignment — one-sided strategies", () => {
+  test("backtest-only strategy: no coverage, all rows outside coverage", () => {
+    const backtest: Trade[] = [
+      makeTrade({ strategy: "OnlyBacktest", dateOpened: new Date(2024, 0, 1) }), // 0
+      makeTrade({ strategy: "OnlyBacktest", dateOpened: new Date(2024, 0, 2) }), // 1
+    ];
+    const actual: ReportingTrade[] = [
+      makeReportingTrade({ strategy: "Shared", dateOpened: new Date(2024, 0, 1) }),
+    ];
+
+    const result = analyzeTradeSetAlignment(backtest, actual);
+    const only = findStrategy(result, "OnlyBacktest");
+    expect(only.presence).toBe("backtestOnly");
+    expect(only.coverage).toBeNull();
+    expect(only.missingFromLive).toEqual([]);
+    expect(only.missingCount).toBe(0);
+    expect(only.missingRate).toBeNull();
+    expect(only.missingRateInterval).toBeNull();
+    expect(only.outsideCoverageBacktest).toEqual([0, 1]);
+  });
+
+  test("live-only strategy: no coverage, all rows outside coverage", () => {
+    const backtest: Trade[] = [makeTrade({ strategy: "Shared", dateOpened: new Date(2024, 0, 1) })];
+    const actual: ReportingTrade[] = [
+      makeReportingTrade({ strategy: "OnlyLive", dateOpened: new Date(2024, 0, 1) }), // 0
+      makeReportingTrade({ strategy: "OnlyLive", dateOpened: new Date(2024, 0, 2) }), // 1
+    ];
+
+    const result = analyzeTradeSetAlignment(backtest, actual);
+    const only = findStrategy(result, "OnlyLive");
+    expect(only.presence).toBe("actualOnly");
+    expect(only.coverage).toBeNull();
+    expect(only.extraInLive).toEqual([]);
+    expect(only.extraCount).toBe(0);
+    expect(only.extraRate).toBeNull();
+    expect(only.outsideCoverageActual).toEqual([0, 1]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Partial overlap and inclusive boundary dates.
+// ---------------------------------------------------------------------------
+
+describe("analyzeTradeSetAlignment — coverage boundaries are inclusive", () => {
+  test("a trade exactly on a coverage boundary date is inside coverage", () => {
+    // Backtest Jan1..Jan4, actual Jan2..Jan5 -> coverage Jan2..Jan4.
+    const backtest: Trade[] = [
+      makeTrade({ strategy: "Edge", dateOpened: new Date(2024, 0, 1), timeOpened: "10:00:00" }), // 0 before coverage
+      makeTrade({ strategy: "Edge", dateOpened: new Date(2024, 0, 2), timeOpened: "10:00:00" }), // 1 boundary, unmatched
+      makeTrade({ strategy: "Edge", dateOpened: new Date(2024, 0, 4), timeOpened: "10:00:00" }), // 2 boundary, unmatched
+    ];
+    const actual: ReportingTrade[] = [
+      makeReportingTrade({
+        strategy: "Edge",
+        dateOpened: new Date(2024, 0, 2),
+        timeOpened: "11:00:00",
+      }), // 0 boundary
+      makeReportingTrade({
+        strategy: "Edge",
+        dateOpened: new Date(2024, 0, 5),
+        timeOpened: "11:00:00",
+      }), // 1 after coverage
+    ];
+
+    const result = analyzeTradeSetAlignment(backtest, actual);
+    const edge = findStrategy(result, "Edge");
+    expect(edge.coverage).toEqual({ from: "2024-01-02", to: "2024-01-04" });
+    // Jan1 backtest is before coverage; Jan2 and Jan4 backtest are inside (both boundaries inclusive).
+    expect(edge.outsideCoverageBacktest).toEqual([0]);
+    expect(edge.missingFromLive).toEqual([1, 2]);
+    // Jan2 actual is inside coverage (extra); Jan5 actual is after coverage.
+    expect(edge.extraInLive).toEqual([0]);
+    expect(edge.outsideCoverageActual).toEqual([1]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Empty inputs and no overlap.
+// ---------------------------------------------------------------------------
+
+describe("analyzeTradeSetAlignment — honest empty results", () => {
+  test("both empty", () => {
+    const result = analyzeTradeSetAlignment([], []);
+    expect(result.backtestTradeCount).toBe(0);
+    expect(result.actualTradeCount).toBe(0);
+    expect(result.matchedCount).toBe(0);
+    expect(result.missingRate).toBeNull();
+    expect(result.extraRate).toBeNull();
+    expect(result.missingRateInterval).toBeNull();
+    expect(result.extraRateInterval).toBeNull();
+    expect(result.byStrategy).toEqual([]);
+    expect(result.matchedPairs).toEqual([]);
+  });
+
+  test("backtest only (empty actual)", () => {
+    const result = analyzeTradeSetAlignment([makeTrade({ strategy: "Solo" })], []);
+    expect(result.matchedCount).toBe(0);
+    const solo = findStrategy(result, "Solo");
+    expect(solo.presence).toBe("backtestOnly");
+    expect(solo.coverage).toBeNull();
+    expect(solo.outsideCoverageBacktest).toEqual([0]);
+  });
+
+  test("actual only (empty backtest)", () => {
+    const result = analyzeTradeSetAlignment([], [makeReportingTrade({ strategy: "Solo" })]);
+    expect(result.matchedCount).toBe(0);
+    const solo = findStrategy(result, "Solo");
+    expect(solo.presence).toBe("actualOnly");
+    expect(solo.coverage).toBeNull();
+    expect(solo.outsideCoverageActual).toEqual([0]);
+  });
+
+  test("disjoint date ranges, same strategy -> no coverage", () => {
+    const backtest = [makeTrade({ strategy: "S", dateOpened: new Date(2022, 0, 1) })];
+    const actual = [makeReportingTrade({ strategy: "S", dateOpened: new Date(2025, 0, 1) })];
+    const result = analyzeTradeSetAlignment(backtest, actual);
+    const s = findStrategy(result, "S");
+    expect(s.presence).toBe("both");
+    expect(s.coverage).toBeNull();
+    expect(s.missingFromLive).toEqual([]);
+    expect(s.extraInLive).toEqual([]);
+    expect(s.outsideCoverageBacktest).toEqual([0]);
+    expect(s.outsideCoverageActual).toEqual([0]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Wilson intervals.
+// ---------------------------------------------------------------------------
+
+describe("wilsonInterval", () => {
+  test("successes=3, trials=10 matches hand-computed 95% score interval", () => {
+    const ci = wilsonInterval(3, 10);
+    expect(ci).not.toBeNull();
+    expect(ci!.lower).toBeCloseTo(0.1078, 3);
+    expect(ci!.upper).toBeCloseTo(0.6032, 3);
+  });
+
+  test("successes=0, trials=0 -> null", () => {
+    expect(wilsonInterval(0, 0)).toBeNull();
+  });
+
+  test("successes=1, trials=1 -> upper bound is 1.0", () => {
+    const ci = wilsonInterval(1, 1);
+    expect(ci).not.toBeNull();
+    expect(ci!.upper).toBeCloseTo(1.0, 5);
+  });
+
+  test("intervals surface on the alignment result for missing and extra rates", () => {
+    // Strategy with 7 matched, 3 missing (backtest-only within coverage) -> missing 3/10.
+    const backtest: Trade[] = [];
+    const actual: ReportingTrade[] = [];
+    for (let i = 0; i < 7; i++) {
+      const d = new Date(2024, 0, i + 1);
+      backtest.push(makeTrade({ strategy: "W", dateOpened: d, timeOpened: "09:30:00" }));
+      actual.push(makeReportingTrade({ strategy: "W", dateOpened: d, timeOpened: "09:30:00" }));
+    }
+    // 3 backtest-only rows inside coverage (distinct times so they do not match).
+    for (let i = 0; i < 3; i++) {
+      backtest.push(
+        makeTrade({ strategy: "W", dateOpened: new Date(2024, 0, i + 1), timeOpened: "13:00:00" }),
+      );
+    }
+    const result = analyzeTradeSetAlignment(backtest, actual);
+    const w = findStrategy(result, "W");
+    expect(w.matchedCount).toBe(7);
+    expect(w.missingCount).toBe(3);
+    expect(w.missingRate).toBeCloseTo(0.3, 6);
+    expect(w.missingRateInterval).not.toBeNull();
+    expect(w.missingRateInterval!.lower).toBeCloseTo(0.1078, 3);
+    expect(w.missingRateInterval!.upper).toBeCloseTo(0.6032, 3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Malformed match keys fail closed.
+// ---------------------------------------------------------------------------
+
+describe("analyzeTradeSetAlignment — malformed keys fail closed", () => {
+  test("invalid date and empty strategy are reported unusable and excluded", () => {
+    const backtest: Trade[] = [
+      makeTrade({ strategy: "Real", dateOpened: new Date(2024, 0, 1) }), // 0 matched
+      makeTrade({ strategy: "Real", dateOpened: new Date("not-a-date") }), // 1 invalid date
+      makeTrade({ strategy: "", dateOpened: new Date(2024, 0, 1) }), // 2 empty strategy
+    ];
+    const actual: ReportingTrade[] = [
+      makeReportingTrade({ strategy: "Real", dateOpened: new Date(2024, 0, 1) }), // 0 matched
+      makeReportingTrade({ strategy: "Real", dateOpened: new Date("also-bad") }), // 1 invalid date
+    ];
+
+    const result = analyzeTradeSetAlignment(backtest, actual);
+
+    expect(result.unusableBacktest.map((u) => u.index).sort((a, b) => a - b)).toEqual([1, 2]);
+    expect(result.unusableActual.map((u) => u.index)).toEqual([1]);
+    // Reasons are non-empty strings.
+    for (const u of [...result.unusableBacktest, ...result.unusableActual]) {
+      expect(typeof u.reason).toBe("string");
+      expect(u.reason.length).toBeGreaterThan(0);
+    }
+
+    // The invalid-date "Real" backtest row is attributed to the Real strategy's unusable list.
+    const real = findStrategy(result, "Real");
+    expect(real.matchedCount).toBe(1);
+    expect(real.unusableBacktest.map((u) => u.index)).toEqual([1]);
+    expect(real.unusableActual.map((u) => u.index)).toEqual([1]);
+
+    // Per-side accounting adds up at the aggregate level.
+    const btAccounted =
+      result.matchedCount +
+      result.byStrategy.reduce(
+        (n, s) => n + s.missingFromLive.length + s.outsideCoverageBacktest.length,
+        0,
+      ) +
+      result.unusableBacktest.length;
+    expect(btAccounted).toBe(backtest.length);
+
+    const actualAccounted =
+      result.matchedCount +
+      result.byStrategy.reduce(
+        (n, s) => n + s.extraInLive.length + s.outsideCoverageActual.length,
+        0,
+      ) +
+      result.unusableActual.length;
+    expect(actualAccounted).toBe(actual.length);
+  });
+
+  test("per-strategy accounting adds up for a well-formed strategy", () => {
+    const backtest: Trade[] = [
+      makeTrade({ strategy: "Acct", dateOpened: new Date(2024, 0, 1), timeOpened: "09:30:00" }), // matched
+      makeTrade({ strategy: "Acct", dateOpened: new Date(2024, 0, 2), timeOpened: "09:30:00" }), // missing (no actual)
+      makeTrade({ strategy: "Acct", dateOpened: new Date(2024, 0, 9), timeOpened: "09:30:00" }), // outside coverage
+    ];
+    const actual: ReportingTrade[] = [
+      makeReportingTrade({
+        strategy: "Acct",
+        dateOpened: new Date(2024, 0, 1),
+        timeOpened: "09:30:00",
+      }), // matched
+      makeReportingTrade({
+        strategy: "Acct",
+        dateOpened: new Date(2024, 0, 2),
+        timeOpened: "14:00:00",
+      }), // extra (diff time)
+    ];
+    const result = analyzeTradeSetAlignment(backtest, actual);
+    const s = findStrategy(result, "Acct");
+    const btTotal =
+      s.matchedCount +
+      s.missingFromLive.length +
+      s.outsideCoverageBacktest.length +
+      s.unusableBacktest.length;
+    expect(btTotal).toBe(3);
+    const actualTotal =
+      s.matchedCount +
+      s.extraInLive.length +
+      s.outsideCoverageActual.length +
+      s.unusableActual.length;
+    expect(actualTotal).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Determinism, ordering, no mutation.
+// ---------------------------------------------------------------------------
+
+describe("analyzeTradeSetAlignment — ordering and no mutation", () => {
+  test("strategies sorted lexicographically; row lists sorted by input index", () => {
+    const backtest: Trade[] = [
+      makeTrade({ strategy: "Zebra", dateOpened: new Date(2024, 0, 1) }),
+      makeTrade({ strategy: "Apple", dateOpened: new Date(2024, 0, 1) }),
+      makeTrade({ strategy: "Mango", dateOpened: new Date(2024, 0, 1) }),
+    ];
+    const actual: ReportingTrade[] = [
+      makeReportingTrade({ strategy: "Mango", dateOpened: new Date(2024, 0, 1) }),
+      makeReportingTrade({ strategy: "Apple", dateOpened: new Date(2024, 0, 1) }),
+      makeReportingTrade({ strategy: "Zebra", dateOpened: new Date(2024, 0, 1) }),
+    ];
+    const result = analyzeTradeSetAlignment(backtest, actual);
+    expect(result.byStrategy.map((s) => s.strategy)).toEqual(["Apple", "Mango", "Zebra"]);
+  });
+
+  test("inputs are not mutated (deep-frozen inputs do not throw)", () => {
+    const backtest: Trade[] = [
+      Object.freeze(makeTrade({ strategy: "F", dateOpened: new Date(2024, 0, 1) })) as Trade,
+    ];
+    const actual: ReportingTrade[] = [
+      Object.freeze(
+        makeReportingTrade({ strategy: "F", dateOpened: new Date(2024, 0, 1) }),
+      ) as ReportingTrade,
+    ];
+    Object.freeze(backtest);
+    Object.freeze(actual);
+    expect(() => analyzeTradeSetAlignment(backtest, actual)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Aggregate rates and denominators.
+// ---------------------------------------------------------------------------
+
+describe("analyzeTradeSetAlignment — aggregate rates", () => {
+  test("aggregate missing/extra rates use in-coverage denominators", () => {
+    // Alpha: 2 matched, 1 missing. Beta: 2 matched, 1 extra.
+    const backtest: Trade[] = [
+      makeTrade({ strategy: "Alpha", dateOpened: new Date(2024, 0, 1), timeOpened: "09:30:00" }),
+      makeTrade({ strategy: "Alpha", dateOpened: new Date(2024, 0, 2), timeOpened: "09:30:00" }),
+      makeTrade({ strategy: "Alpha", dateOpened: new Date(2024, 0, 2), timeOpened: "12:00:00" }), // missing
+      makeTrade({ strategy: "Beta", dateOpened: new Date(2024, 0, 1), timeOpened: "09:30:00" }),
+      makeTrade({ strategy: "Beta", dateOpened: new Date(2024, 0, 2), timeOpened: "09:30:00" }),
+    ];
+    const actual: ReportingTrade[] = [
+      makeReportingTrade({
+        strategy: "Alpha",
+        dateOpened: new Date(2024, 0, 1),
+        timeOpened: "09:30:00",
+      }),
+      makeReportingTrade({
+        strategy: "Alpha",
+        dateOpened: new Date(2024, 0, 2),
+        timeOpened: "09:30:00",
+      }),
+      makeReportingTrade({
+        strategy: "Beta",
+        dateOpened: new Date(2024, 0, 1),
+        timeOpened: "09:30:00",
+      }),
+      makeReportingTrade({
+        strategy: "Beta",
+        dateOpened: new Date(2024, 0, 2),
+        timeOpened: "09:30:00",
+      }),
+      makeReportingTrade({
+        strategy: "Beta",
+        dateOpened: new Date(2024, 0, 2),
+        timeOpened: "12:00:00",
+      }), // extra
+    ];
+    const result = analyzeTradeSetAlignment(backtest, actual);
+    expect(result.matchedCount).toBe(4);
+    expect(result.missingCount).toBe(1);
+    expect(result.extraCount).toBe(1);
+    // missingRate = 1 / (4 + 1) = 0.2
+    expect(result.missingRate).toBeCloseTo(0.2, 6);
+    // extraRate = 1 / (4 + 1) = 0.2
+    expect(result.extraRate).toBeCloseTo(0.2, 6);
+  });
+});


### PR DESCRIPTION
Tier: 3 — additive public-library API and shared matcher authority.

Worktree: /home/romeo/code/tradeblocks-org/tradeblocks-romeo-917-alignment-primitive

## What it does

- adds `matchTradeSets` as the single fail-closed trade matching authority
- adds `analyzeTradeSetAlignment` with per-strategy inclusive coverage, original-input indices, factual missing/extra rates, and Wilson intervals
- keeps `analyzeLiveAlignment` behavior identical for well-formed inputs while malformed match keys now deliberately fail closed
- exports the new public API and releases `@tradeblocks/lib` v3.3.0

## Correctness contract

- strategies are analyzed against their own coverage windows, never a portfolio-global window
- malformed strategy/date keys are unusable and never matched
- duplicate keys match deterministically FIFO at this public primitive layer
- one-sided strategies have null coverage and explicit presence
- zero-trial rates and intervals are null
- all returned indices refer to the original input arrays

This layer reports measurements and confidence intervals only. Consumers may apply stricter evidence rules above it; such policy stays out of the library.

## Verification

- 1301/1301 library tests across 77 suites (+18)
- 1633/1633 MCP tests
- typecheck, lint, format, build, and all import-boundary gates clean
- boundary review found no interpretive verdicts, thresholds, or product-specific workflow vocabulary

## Before / after

Before: Strategy A live Jan 1–2 plus Strategy B live Jan 1–Jun 30 created a global Jan 1–Jun 30 comparison window, incorrectly counting A’s Jan 3–5 model rows as missing.

After: A’s comparison coverage is Jan 1–2; Jan 3–5 are outside coverage and A’s missing count remains zero.
