### PR TITLE
feat(lib): add paired-path block bootstrap for reconciliation

### DIFF
--- a/packages/lib/calculations/paired-block-bootstrap.ts
+++ b/packages/lib/calculations/paired-block-bootstrap.ts
@@ -38,6 +38,11 @@
  * holds the arm's contribution on each day. `observedMask` marks whether the
  * arm was observed that day -- `true` means observed (traded, or a genuine flat
  * zero), `false` means dormant / not-observed and is excluded entirely.
+ *
+ * Block contiguity is positional on the caller's session grid; this primitive
+ * does not contain an exchange calendar. A caller with sparse event dates must
+ * first expand them onto its contiguous session grid (marking unobserved
+ * sessions false), or those event dates will be treated as adjacent positions.
  */
 export interface DaySeries {
   index: string[];
@@ -145,6 +150,100 @@ export interface PairedBlockBootstrapResult {
   seed: number;
 }
 
+/** Direction of a caller-specified one-sided bootstrap test. */
+export type OneSidedAlternative = "greater" | "less";
+
+/**
+ * Input for a paired path-functional day-block bootstrap.
+ *
+ * Unlike {@link PairedBlockBootstrapInput}, this API keeps both aligned arms
+ * intact and passes both complete paths to `statistic`. This is required for
+ * nonlinear path functionals that cannot be reconstructed from an elementwise
+ * difference series. Every resample uses the same drawn day indices for both
+ * arms.
+ */
+export interface PairedPathBlockBootstrapInput {
+  armA: DaySeries;
+  armB: DaySeries;
+  /**
+   * Pure deterministic functional recomputed on both complete (possibly
+   * resampled) paths. Every invocation must return a finite number.
+   */
+  statistic: (armA: number[], armB: number[]) => number;
+  holdingRule: HoldingPeriodRule;
+  /** Confidence level in (0, 1), e.g. 0.95. */
+  ciLevel: number;
+  /** Number of bootstrap resamples. Required -- no baked-in default. */
+  resamples: number;
+  /** Seed for the internal PRNG. Identical input + seed -> identical result. */
+  seed: number;
+  /** Null value for the centered one-sided bootstrap test. */
+  nullValue: number;
+  /** Direction of the caller's one-sided alternative. */
+  alternative: OneSidedAlternative;
+  /**
+   * Caller-calibrated minimum effective-N (in blocks). When effectiveN falls
+   * below it the result is `notComparable` with null interval and p-value.
+   */
+  effectiveNFloorBlocks?: number;
+}
+
+/** Raw one-sided inference suitable for caller-owned family adjustment. */
+export interface OneSidedBootstrapInference {
+  nullValue: number;
+  alternative: OneSidedAlternative;
+  /** Unadjusted finite-resample p-value; null when the run cannot resolve. */
+  pValue: number | null;
+  /** Smallest attainable plus-one-corrected p-value for this resample count. */
+  pValueResolution: number;
+  /** Decision bound coherent with the centered p-value at `ci.level`. */
+  bound: {
+    level: number;
+    side: "lower" | "upper";
+    value: number | null;
+    method: "centered-basic-paired-day-block-bound";
+  };
+  method: "centered-paired-day-block-p-value";
+}
+
+/** Basic interval for a paired nonlinear path-functional bootstrap. */
+export interface PairedPathConfidenceInterval {
+  level: number;
+  low: number | null;
+  high: number | null;
+  /** Marginal two-sided interval; family adjustment remains caller-owned. */
+  method: "basic-paired-day-block";
+}
+
+/**
+ * One supplementary paired-path run at a unique multiplied block length.
+ * Multipliers that round to the base or an already-emitted length are deduped.
+ */
+export interface PairedPathSensitivityEntry {
+  /** First requested multiplier that produced this unique block length. */
+  multiplier: number;
+  blockDays: number;
+  point: number | null;
+  ci: PairedPathConfidenceInterval;
+  inference: OneSidedBootstrapInference;
+  effectiveN: number;
+  status: PairedBlockBootstrapStatus;
+}
+
+export interface PairedPathBlockBootstrapResult {
+  point: number | null;
+  ci: PairedPathConfidenceInterval;
+  inference: OneSidedBootstrapInference;
+  /** Jointly observed days divided by the block length. */
+  effectiveN: number;
+  overlapWindow: { start: string; end: string } | null;
+  blockDays: number;
+  sensitivity: PairedPathSensitivityEntry[];
+  status: PairedBlockBootstrapStatus;
+  seed: number;
+  resamples: number;
+}
+
 // ---------------------------------------------------------------------------
 // Internal types
 // ---------------------------------------------------------------------------
@@ -161,6 +260,14 @@ interface ObservedRun {
 interface Overlap {
   days: string[];
   delta: number[];
+  runs: ObservedRun[];
+}
+
+/** Two arms aligned to their jointly observed day axis. */
+interface PairedPathOverlap {
+  days: string[];
+  armA: number[];
+  armB: number[];
   runs: ObservedRun[];
 }
 
@@ -207,6 +314,106 @@ function percentileOf(sorted: number[], p: number): number {
   if (lo === hi) return sorted[lo];
   const weight = rank - lo;
   return sorted[lo] * (1 - weight) + sorted[hi] * weight;
+}
+
+function assertFiniteNumber(value: unknown, label: string): asserts value is number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new TypeError(`${label} must be a finite number`);
+  }
+}
+
+function assertIsoDay(day: unknown, label: string): asserts day is string {
+  if (typeof day !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(day)) {
+    throw new TypeError(`${label} must be an ISO day (YYYY-MM-DD)`);
+  }
+
+  const parsed = new Date(`${day}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== day) {
+    throw new TypeError(`${label} must be a valid ISO day (YYYY-MM-DD)`);
+  }
+}
+
+function assertValidDaySeries(arm: DaySeries, name: string): void {
+  if (
+    !arm ||
+    !Array.isArray(arm.index) ||
+    !Array.isArray(arm.values) ||
+    !Array.isArray(arm.observedMask)
+  ) {
+    throw new TypeError(`${name} must contain index, values, and observedMask arrays`);
+  }
+  if (arm.index.length !== arm.values.length || arm.index.length !== arm.observedMask.length) {
+    throw new RangeError(`${name} index, values, and observedMask must have equal lengths`);
+  }
+
+  for (let i = 0; i < arm.index.length; i++) {
+    assertIsoDay(arm.index[i], `${name}.index[${i}]`);
+    if (i > 0 && arm.index[i] <= arm.index[i - 1]) {
+      throw new RangeError(`${name}.index must be strictly ascending with no duplicate days`);
+    }
+    assertFiniteNumber(arm.values[i], `${name}.values[${i}]`);
+    if (typeof arm.observedMask[i] !== "boolean") {
+      throw new TypeError(`${name}.observedMask[${i}] must be boolean`);
+    }
+  }
+}
+
+/** Strict validation used by the paired-path API without changing legacy behavior. */
+function assertValidPairedPathInput(input: PairedPathBlockBootstrapInput): void {
+  assertValidDaySeries(input.armA, "armA");
+  assertValidDaySeries(input.armB, "armB");
+
+  if (typeof input.statistic !== "function") {
+    throw new TypeError("statistic must be a function");
+  }
+  assertFiniteNumber(input.holdingRule?.blockDays, "holdingRule.blockDays");
+  if (input.holdingRule.blockDays <= 0) {
+    throw new RangeError("holdingRule.blockDays must be greater than zero");
+  }
+  if (
+    input.holdingRule.sensitivity !== undefined &&
+    !Array.isArray(input.holdingRule.sensitivity)
+  ) {
+    throw new TypeError("holdingRule.sensitivity must be an array");
+  }
+  for (let i = 0; i < (input.holdingRule.sensitivity ?? []).length; i++) {
+    const multiplier = input.holdingRule.sensitivity![i];
+    assertFiniteNumber(multiplier, `holdingRule.sensitivity[${i}]`);
+    if (multiplier <= 0) {
+      throw new RangeError(`holdingRule.sensitivity[${i}] must be greater than zero`);
+    }
+  }
+  assertFiniteNumber(input.ciLevel, "ciLevel");
+  if (input.ciLevel <= 0 || input.ciLevel >= 1) {
+    throw new RangeError("ciLevel must be between zero and one");
+  }
+  if (!Number.isSafeInteger(input.resamples) || input.resamples < 1) {
+    throw new RangeError("resamples must be a positive safe integer");
+  }
+  if (!Number.isSafeInteger(input.seed)) {
+    throw new RangeError("seed must be a safe integer");
+  }
+  assertFiniteNumber(input.nullValue, "nullValue");
+  if (input.alternative !== "greater" && input.alternative !== "less") {
+    throw new TypeError('alternative must be either "greater" or "less"');
+  }
+  if (input.effectiveNFloorBlocks !== undefined) {
+    assertFiniteNumber(input.effectiveNFloorBlocks, "effectiveNFloorBlocks");
+    if (input.effectiveNFloorBlocks <= 0) {
+      throw new RangeError("effectiveNFloorBlocks must be greater than zero");
+    }
+  }
+}
+
+function evaluatePairedPathStatistic(
+  statistic: (armA: number[], armB: number[]) => number,
+  armA: number[],
+  armB: number[],
+  label: string,
+): number {
+  const value = statistic(armA, armB);
+  assertFiniteNumber(value, label);
+  return value;
 }
 
 // ---------------------------------------------------------------------------
@@ -299,6 +506,24 @@ function buildComparisonOverlap(armA: DaySeries, armB?: DaySeries | ConstantArm)
   );
 }
 
+/** Build two intact paths over the arms' jointly observed days. */
+function buildPairedPathOverlap(armA: DaySeries, armB: DaySeries): PairedPathOverlap {
+  const mapA = observedValueMap(armA);
+  const mapB = observedValueMap(armB);
+  const overlap = buildOverlap(
+    unionDays(armA.index, armB.index),
+    (day) => mapA.has(day) && mapB.has(day),
+    () => 0,
+  );
+
+  return {
+    days: overlap.days,
+    armA: overlap.days.map((day) => mapA.get(day)!),
+    armB: overlap.days.map((day) => mapB.get(day)!),
+    runs: overlap.runs,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Block enumeration
 // ---------------------------------------------------------------------------
@@ -351,6 +576,11 @@ interface CoreResult {
   high: number | null;
   effectiveN: number;
   status: PairedBlockBootstrapStatus;
+}
+
+interface PairedPathCoreResult extends CoreResult {
+  pValue: number | null;
+  oneSidedBound: number | null;
 }
 
 /**
@@ -437,6 +667,131 @@ function computeCore(params: {
   return { point, low, high, effectiveN, status: "resolved" };
 }
 
+/**
+ * Compute one paired-path basic interval and centered one-sided bootstrap
+ * p-value.
+ *
+ * The centered tail compares `T* - T(observed)` with the observed displacement
+ * from the caller's null. A plus-one correction keeps the finite-resample
+ * p-value non-zero, which makes it suitable as raw input to a caller-owned
+ * multiplicity adjustment. The one-sided bound uses a discrete order statistic
+ * chosen so its strict comparison with the null is coherent with the corrected
+ * p-value (including ties).
+ */
+function computePairedPathCore(params: {
+  overlapDays: string[];
+  runs: ObservedRun[];
+  armA: number[];
+  armB: number[];
+  blockDays: number;
+  resamples: number;
+  seed: number;
+  ciLevel: number;
+  statistic: (armA: number[], armB: number[]) => number;
+  nullValue: number;
+  alternative: OneSidedAlternative;
+  effectiveNFloorBlocks?: number;
+}): PairedPathCoreResult {
+  const {
+    overlapDays,
+    runs,
+    armA,
+    armB,
+    blockDays,
+    resamples,
+    seed,
+    ciLevel,
+    statistic,
+    nullValue,
+    alternative,
+    effectiveNFloorBlocks,
+  } = params;
+
+  const n = overlapDays.length;
+  const effectiveN = n / blockDays;
+  const point =
+    n === 0
+      ? null
+      : evaluatePairedPathStatistic(
+          statistic,
+          [...armA],
+          [...armB],
+          "statistic result on observed paths",
+        );
+  const blockStarts = enumerateBlockStarts(runs, blockDays);
+
+  if (effectiveNFloorBlocks !== undefined && effectiveN < effectiveNFloorBlocks) {
+    return {
+      point,
+      low: null,
+      high: null,
+      pValue: null,
+      oneSidedBound: null,
+      effectiveN,
+      status: "notComparable",
+    };
+  }
+
+  if (blockStarts.length < 2 || point === null) {
+    return {
+      point,
+      low: null,
+      high: null,
+      pValue: null,
+      oneSidedBound: null,
+      effectiveN,
+      status: "underpowered",
+    };
+  }
+
+  const rng = mulberry32(deriveSeed(seed, blockDays));
+  const centeredErrors: number[] = new Array(resamples);
+  let tailCount = 0;
+  const observedDisplacement = point - nullValue;
+
+  for (let r = 0; r < resamples; r++) {
+    const idx = drawResampleIndices(rng, blockStarts, blockDays, n);
+    const draw = evaluatePairedPathStatistic(
+      statistic,
+      idx.map((i) => armA[i]),
+      idx.map((i) => armB[i]),
+      `statistic result for resample ${r}`,
+    );
+    const centeredDraw = draw - point;
+    centeredErrors[r] = centeredDraw;
+    if (
+      (alternative === "greater" && centeredDraw >= observedDisplacement) ||
+      (alternative === "less" && centeredDraw <= observedDisplacement)
+    ) {
+      tailCount++;
+    }
+  }
+
+  centeredErrors.sort((a, b) => a - b);
+  const alpha = 1 - ciLevel;
+  const lower = point - percentileOf(centeredErrors, 1 - alpha / 2);
+  const upper = point - percentileOf(centeredErrors, alpha / 2);
+
+  let oneSidedBound: number | null;
+  if (alternative === "greater") {
+    const oneBasedIndex = Math.ceil((1 - alpha) * (resamples + 1));
+    oneSidedBound = oneBasedIndex > resamples ? null : point - centeredErrors[oneBasedIndex - 1];
+  } else {
+    const oneBasedIndex = Math.floor(alpha * (resamples + 1));
+    oneSidedBound = oneBasedIndex < 1 ? null : point - centeredErrors[oneBasedIndex - 1];
+  }
+
+  return {
+    point,
+    low: lower,
+    high: upper,
+    pValue: (tailCount + 1) / (resamples + 1),
+    oneSidedBound,
+    effectiveN,
+    status: "resolved",
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Selection overlap
 // ---------------------------------------------------------------------------
@@ -497,6 +852,29 @@ export function pairedBlockDays(input: PairedBlockBootstrapInput, blockDays: num
   const overlap = buildComparisonOverlap(input.armA, input.armB);
   const starts = enumerateBlockStarts(overlap.runs, blockDays);
   return starts.map((start) => overlap.days.slice(start, start + blockDays));
+}
+
+/**
+ * The ISO days of every valid moving block for a paired-path comparison.
+ *
+ * This is the exact candidate set used by {@link pairedPathBlockBootstrap}; it
+ * is exposed so callers can audit overlap and gap handling without inspecting
+ * bootstrap draws.
+ */
+export function pairedPathBlockDays(
+  input: Pick<PairedPathBlockBootstrapInput, "armA" | "armB">,
+  blockDays: number,
+): string[][] {
+  assertValidDaySeries(input.armA, "armA");
+  assertValidDaySeries(input.armB, "armB");
+  assertFiniteNumber(blockDays, "blockDays");
+  if (blockDays <= 0) {
+    throw new RangeError("blockDays must be greater than zero");
+  }
+  const overlap = buildPairedPathOverlap(input.armA, input.armB);
+  const normalizedBlockDays = Math.max(1, Math.round(blockDays));
+  const starts = enumerateBlockStarts(overlap.runs, normalizedBlockDays);
+  return starts.map((start) => overlap.days.slice(start, start + normalizedBlockDays));
 }
 
 // ---------------------------------------------------------------------------
@@ -631,5 +1009,103 @@ export function pairedBlockBootstrap(input: PairedBlockBootstrapInput): PairedBl
     selection,
     status: primary.status,
     seed,
+  };
+}
+
+/**
+ * Run a paired day-block bootstrap for a nonlinear two-path functional.
+ *
+ * Both arms are first aligned to jointly observed days. Every bootstrap draw
+ * then applies one shared sequence of moving-block indices to both paths before
+ * recomputing `statistic`. The returned p-value is raw and intentionally
+ * unadjusted so the caller can apply its own family-level procedure.
+ *
+ * @param input - See {@link PairedPathBlockBootstrapInput}
+ * @returns Point statistic, marginal basic interval, raw centered one-sided
+ *   p-value, overlap/power diagnostics and block-length sensitivity runs
+ */
+export function pairedPathBlockBootstrap(
+  input: PairedPathBlockBootstrapInput,
+): PairedPathBlockBootstrapResult {
+  assertValidPairedPathInput(input);
+  const blockDays = Math.max(1, Math.round(input.holdingRule.blockDays));
+  const { ciLevel, resamples, seed, statistic, nullValue, alternative, effectiveNFloorBlocks } =
+    input;
+  const overlap = buildPairedPathOverlap(input.armA, input.armB);
+  const overlapWindow =
+    overlap.days.length > 0
+      ? { start: overlap.days[0], end: overlap.days[overlap.days.length - 1] }
+      : null;
+
+  const run = (runBlockDays: number): PairedPathCoreResult =>
+    computePairedPathCore({
+      overlapDays: overlap.days,
+      runs: overlap.runs,
+      armA: overlap.armA,
+      armB: overlap.armB,
+      blockDays: runBlockDays,
+      resamples,
+      seed,
+      ciLevel,
+      statistic,
+      nullValue,
+      alternative,
+      effectiveNFloorBlocks,
+    });
+
+  const inferenceOf = (result: PairedPathCoreResult): OneSidedBootstrapInference => ({
+    nullValue,
+    alternative,
+    pValue: result.pValue,
+    pValueResolution: 1 / (resamples + 1),
+    bound: {
+      level: ciLevel,
+      side: alternative === "greater" ? "lower" : "upper",
+      value: result.oneSidedBound,
+      method: "centered-basic-paired-day-block-bound",
+    },
+    method: "centered-paired-day-block-p-value",
+  });
+
+  const primary = run(blockDays);
+  const sensitivity: PairedPathSensitivityEntry[] = [];
+  const emittedBlockDays = new Set<number>([blockDays]);
+  for (const multiplier of input.holdingRule.sensitivity ?? []) {
+    const sensitivityBlockDays = Math.max(1, Math.round(multiplier * blockDays));
+    if (emittedBlockDays.has(sensitivityBlockDays)) continue;
+    emittedBlockDays.add(sensitivityBlockDays);
+    const result = run(sensitivityBlockDays);
+    sensitivity.push({
+      multiplier,
+      blockDays: sensitivityBlockDays,
+      point: result.point,
+      ci: {
+        level: ciLevel,
+        low: result.low,
+        high: result.high,
+        method: "basic-paired-day-block" as const,
+      },
+      inference: inferenceOf(result),
+      effectiveN: result.effectiveN,
+      status: result.status,
+    });
+  }
+
+  return {
+    point: primary.point,
+    ci: {
+      level: ciLevel,
+      low: primary.low,
+      high: primary.high,
+      method: "basic-paired-day-block",
+    },
+    inference: inferenceOf(primary),
+    effectiveN: primary.effectiveN,
+    overlapWindow,
+    blockDays,
+    sensitivity,
+    status: primary.status,
+    seed,
+    resamples,
   };
 }

--- a/tests/lib/calculations/paired-block-bootstrap.test.ts
+++ b/tests/lib/calculations/paired-block-bootstrap.test.ts
@@ -1,9 +1,12 @@
 import {
   pairedBlockBootstrap,
   pairedBlockDays,
+  pairedPathBlockBootstrap,
+  pairedPathBlockDays,
   holdingPeriodBlockDays,
   type DaySeries,
   type PairedBlockBootstrapInput,
+  type PairedPathBlockBootstrapInput,
 } from "@tradeblocks/lib";
 import { describe, expect, it } from "@jest/globals";
 
@@ -42,6 +45,30 @@ function seededSeq(seed: number, n: number): number[] {
 }
 
 const mean = (d: number[]): number => d.reduce((a, b) => a + b, 0) / d.length;
+
+function maxDrawdown(dailyPnl: number[]): number {
+  let equity = 0;
+  let peak = 0;
+  let drawdown = 0;
+  for (const pnl of dailyPnl) {
+    equity += pnl;
+    peak = Math.max(peak, equity);
+    drawdown = Math.max(drawdown, peak - equity);
+  }
+  return drawdown;
+}
+
+function maxDrawdownFromFirstValue(dailyPnl: number[]): number {
+  let equity = 0;
+  let peak = Number.NEGATIVE_INFINITY;
+  let drawdown = 0;
+  for (const pnl of dailyPnl) {
+    equity += pnl;
+    peak = Math.max(peak, equity);
+    drawdown = Math.max(drawdown, peak - equity);
+  }
+  return drawdown;
+}
 
 // ---------------------------------------------------------------------------
 // 1. Intersection masking -- never zero-fill
@@ -447,5 +474,283 @@ describe("holdingPeriodBlockDays", () => {
     expect(holdingPeriodBlockDays([0.2, 0.3, 0.4])).toBe(1);
     expect(holdingPeriodBlockDays([])).toBe(1);
     expect(holdingPeriodBlockDays([10, 10, 10], 0.95)).toBe(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Paired nonlinear path functionals
+// ---------------------------------------------------------------------------
+
+describe("pairedPathBlockBootstrap", () => {
+  const build = (
+    overrides: Partial<PairedPathBlockBootstrapInput> = {},
+  ): PairedPathBlockBootstrapInput => {
+    const armBValues = seededSeq(71, 48);
+    const armAValues = armBValues.map((value, i) => value + (i % 6 < 3 ? -0.4 : 0.6));
+    return {
+      armA: mkSeries(armAValues),
+      armB: mkSeries(armBValues),
+      statistic: (armA, armB) => maxDrawdown(armA) - maxDrawdown(armB),
+      holdingRule: { blockDays: 4, sensitivity: [0.5, 2] },
+      ciLevel: 0.95,
+      resamples: 400,
+      seed: 27,
+      nullValue: 0,
+      alternative: "greater",
+      ...overrides,
+    };
+  };
+
+  it("recomputes a nonlinear functional on both complete paths", () => {
+    const input = build();
+    const result = pairedPathBlockBootstrap(input);
+
+    expect(result.point).toBe(input.statistic(input.armA.values, input.armB.values));
+    expect(result.status).toBe("resolved");
+    expect(result.inference).toEqual({
+      nullValue: 0,
+      alternative: "greater",
+      pValue: expect.any(Number),
+      pValueResolution: 1 / 401,
+      bound: {
+        level: 0.95,
+        side: "lower",
+        value: expect.any(Number),
+        method: "centered-basic-paired-day-block-bound",
+      },
+      method: "centered-paired-day-block-p-value",
+    });
+    expect(result.ci.method).toBe("basic-paired-day-block");
+    expect(result.inference.pValue).toBeGreaterThan(0);
+    expect(result.inference.pValue).toBeLessThanOrEqual(1);
+    expect(result.resamples).toBe(400);
+    expect(result.sensitivity.map((entry) => entry.blockDays)).toEqual([2, 8]);
+    expect(result.sensitivity.map((entry) => entry.multiplier)).toEqual([0.5, 2]);
+    expect(result.sensitivity.every((entry) => entry.point === result.point)).toBe(true);
+    expect(result.sensitivity.every((entry) => entry.ci.method === "basic-paired-day-block")).toBe(
+      true,
+    );
+    expect(result.sensitivity.map((entry) => entry.effectiveN)).toEqual([24, 6]);
+  });
+
+  it("uses shared resample indices for the two paths", () => {
+    const armBValues = seededSeq(72, 40);
+    const input = build({
+      armA: mkSeries(armBValues.map((value) => 2 * value)),
+      armB: mkSeries(armBValues),
+      statistic: (armA, armB) => Math.max(...armA.map((value, i) => Math.abs(value - 2 * armB[i]))),
+      holdingRule: { blockDays: 5 },
+      resamples: 300,
+      nullValue: 0,
+    });
+
+    const result = pairedPathBlockBootstrap(input);
+
+    expect(result.point).toBe(0);
+    expect(result.ci.low).toBe(0);
+    expect(result.ci.high).toBe(0);
+    expect(result.inference.pValue).toBe(1);
+  });
+
+  it("does not collapse a nonlinear two-path functional to an elementwise delta", () => {
+    const armAValues = [10, -10];
+    const armBValues = [-10, 10];
+    const statistic = (armA: number[], armB: number[]): number =>
+      maxDrawdownFromFirstValue(armA) - maxDrawdownFromFirstValue(armB);
+
+    const result = pairedPathBlockBootstrap(
+      build({
+        armA: mkSeries(armAValues),
+        armB: mkSeries(armBValues),
+        statistic,
+        holdingRule: { blockDays: 1 },
+        resamples: 200,
+      }),
+    );
+    const collapsedDelta = armAValues.map((value, i) => value - armBValues[i]);
+
+    expect(result.point).toBe(10);
+    expect(maxDrawdownFromFirstValue(collapsedDelta)).toBe(20);
+    expect(result.point).not.toBe(maxDrawdownFromFirstValue(collapsedDelta));
+  });
+
+  it("returns a raw finite-resample one-sided p-value for caller-owned adjustment", () => {
+    const base = seededSeq(73, 40);
+    const resamples = 399;
+    const result = pairedPathBlockBootstrap(
+      build({
+        armA: mkSeries(base.map((value) => value + 5)),
+        armB: mkSeries(base),
+        statistic: (armA, armB) => mean(armA) - mean(armB),
+        holdingRule: { blockDays: 4 },
+        resamples,
+        nullValue: 0,
+        alternative: "greater",
+      }),
+    );
+
+    expect(result.point).toBeCloseTo(5, 12);
+    expect(result.ci.low).toBeCloseTo(5, 12);
+    expect(result.ci.high).toBeCloseTo(5, 12);
+    expect(result.inference.pValue).toBe(1 / (resamples + 1));
+    expect(result.inference.pValueResolution).toBe(1 / (resamples + 1));
+    expect(result.inference.bound.value).toBeCloseTo(5, 12);
+  });
+
+  it("keeps the greater-side bound decision coherent with the corrected p-value", () => {
+    const base = seededSeq(78, 40);
+    const common = {
+      armA: mkSeries(base.map((value) => value + 5)),
+      armB: mkSeries(base),
+      statistic: (armA: number[], armB: number[]) => mean(armA) - mean(armB),
+      holdingRule: { blockDays: 4 },
+      resamples: 399,
+      ciLevel: 0.95,
+      alternative: "greater" as const,
+    };
+    const initial = pairedPathBlockBootstrap(build(common));
+    const bound = initial.inference.bound.value!;
+
+    for (const nullValue of [bound - 1e-9, bound, bound + 1e-9]) {
+      const result = pairedPathBlockBootstrap(build({ ...common, nullValue }));
+      expect(result.inference.pValue! <= 0.05).toBe(result.inference.bound.value! > nullValue);
+    }
+  });
+
+  it("keeps the less-side bound decision coherent with the corrected p-value", () => {
+    const base = seededSeq(79, 40);
+    const common = {
+      armA: mkSeries(base.map((value) => value - 5)),
+      armB: mkSeries(base),
+      statistic: (armA: number[], armB: number[]) => mean(armA) - mean(armB),
+      holdingRule: { blockDays: 4 },
+      resamples: 399,
+      ciLevel: 0.95,
+      alternative: "less" as const,
+    };
+    const initial = pairedPathBlockBootstrap(build(common));
+    const bound = initial.inference.bound.value!;
+
+    for (const nullValue of [bound + 1e-9, bound, bound - 1e-9]) {
+      const result = pairedPathBlockBootstrap(build({ ...common, nullValue }));
+      expect(result.inference.pValue! <= 0.05).toBe(result.inference.bound.value! < nullValue);
+    }
+  });
+
+  it("reports a null decision bound when resample resolution is insufficient", () => {
+    const result = pairedPathBlockBootstrap(
+      build({
+        ciLevel: 0.99,
+        resamples: 10,
+      }),
+    );
+
+    expect(result.status).toBe("resolved");
+    expect(result.inference.pValueResolution).toBe(1 / 11);
+    expect(result.inference.bound.value).toBeNull();
+  });
+
+  it("is deterministic across the primary and sensitivity runs", () => {
+    const input = build();
+    expect(pairedPathBlockBootstrap(input)).toEqual(pairedPathBlockBootstrap(input));
+  });
+
+  it("dedupes sensitivity multipliers that round to an existing block length", () => {
+    const result = pairedPathBlockBootstrap(
+      build({
+        holdingRule: { blockDays: 1, sensitivity: [0.5, 1, 1.4, 2] },
+      }),
+    );
+
+    expect(result.blockDays).toBe(1);
+    expect(result.sensitivity.map((entry) => entry.blockDays)).toEqual([2]);
+    expect(result.sensitivity.map((entry) => entry.multiplier)).toEqual([2]);
+  });
+
+  it("never offers a candidate block that crosses a joint-observation gap", () => {
+    const armA = mkSeries(seededSeq(74, 20));
+    const observed = armA.values.map((_, i) => i !== 10);
+    const armB = mkSeries(seededSeq(75, 20), observed);
+    const gapDate = armA.index[10];
+
+    const blocks = pairedPathBlockDays({ armA, armB }, 4);
+
+    expect(blocks.length).toBeGreaterThan(0);
+    for (const block of blocks) {
+      expect(block).toHaveLength(4);
+      expect(block.some((day) => day < gapDate) && block.some((day) => day > gapDate)).toBe(false);
+    }
+  });
+
+  it("reports null inference for a caller-calibrated effective-N refusal", () => {
+    const result = pairedPathBlockBootstrap(
+      build({
+        armA: mkSeries(seededSeq(76, 12)),
+        armB: mkSeries(seededSeq(77, 12)),
+        holdingRule: { blockDays: 4, sensitivity: [2] },
+        effectiveNFloorBlocks: 4,
+      }),
+    );
+
+    expect(result.status).toBe("notComparable");
+    expect(result.effectiveN).toBe(3);
+    expect(result.ci.low).toBeNull();
+    expect(result.inference.pValue).toBeNull();
+    expect(result.sensitivity[0].status).toBe("notComparable");
+    expect(result.sensitivity[0].inference.pValue).toBeNull();
+  });
+
+  it("rejects malformed series shapes and day ordering", () => {
+    const unequalLengths = build({
+      armA: {
+        index: ["2020-01-01"],
+        values: [1, 2],
+        observedMask: [true],
+      },
+    });
+    expect(() => pairedPathBlockBootstrap(unequalLengths)).toThrow(
+      "armA index, values, and observedMask must have equal lengths",
+    );
+
+    const duplicateDay = build({
+      armA: {
+        index: ["2020-01-01", "2020-01-01"],
+        values: [1, 2],
+        observedMask: [true, true],
+      },
+    });
+    expect(() => pairedPathBlockBootstrap(duplicateDay)).toThrow(
+      "armA.index must be strictly ascending with no duplicate days",
+    );
+
+    const invalidDay = build({
+      armA: {
+        index: ["2020-02-30"],
+        values: [1],
+        observedMask: [true],
+      },
+    });
+    expect(() => pairedPathBlockBootstrap(invalidDay)).toThrow(
+      "armA.index[0] must be a valid ISO day",
+    );
+  });
+
+  it("rejects non-finite inputs and statistic outputs", () => {
+    expect(() =>
+      pairedPathBlockBootstrap(
+        build({
+          armA: mkSeries([Number.NaN, 1, 2, 3, 4, 5]),
+          armB: mkSeries([0, 1, 2, 3, 4, 5]),
+        }),
+      ),
+    ).toThrow("armA.values[0] must be a finite number");
+
+    expect(() =>
+      pairedPathBlockBootstrap(
+        build({
+          statistic: () => Number.NaN,
+        }),
+      ),
+    ).toThrow("statistic result on observed paths must be a finite number");
   });
 });


### PR DESCRIPTION
Tier: 3 — public statistical surface

Worktree: /home/romeo/code/tradeblocks-org/tradeblocks-romeo-1253-drawdown-inference

Part of tradeblocks-org/enterprise#1253.

Adds an additive paired-path moving-block bootstrap primitive with deterministic seeds, complete nonlinear path recomputation, centered one-sided inference, confidence intervals, and the shared type-7 holding-period block selector.

Verification:
- 29 focused bootstrap tests
- full TypeScript typecheck
- Worf: PASS