### PR TITLE
feat(db): optional DuckDB resource bounds (memory_limit/threads) for the parquet market connection

### DIFF
--- a/packages/mcp-server/src/db/connection.ts
+++ b/packages/mcp-server/src/db/connection.ts
@@ -845,11 +845,12 @@ export interface MarketConnectionOptions {
    */
   memoryLimit?: string;
   /**
-   * DuckDB `threads` for the connection, a positive integer. The parquet-read
-   * hot path is I/O-bound, and higher thread counts trigger intermittent
-   * prepared-statement failures on long reads — the library-wide default thread
-   * count is 2 for this reason (see defaultThreads() above). Non-integer or
-   * non-positive values throw before any connection is opened.
+   * DuckDB `threads` for the connection, a positive integer. The analytics
+   * connection defaults to 2 threads (see defaultThreads() above) because higher
+   * thread counts trigger intermittent prepared-statement failures on long
+   * reads. NOTE: this parquet path's UNSET default is DuckDB native (all
+   * cores), not 2 — set this option (or the env var) to bound it. Non-integer
+   * or non-positive values throw before any connection is opened.
    */
   threads?: number;
 }

--- a/packages/mcp-server/src/db/connection.ts
+++ b/packages/mcp-server/src/db/connection.ts
@@ -28,6 +28,10 @@
  *   DUCKDB_LOCK_RECOVERY   - Force-kill ANY lock-holding tradeblocks-mcp (default: false)
  *   DUCKDB_LOCK_RECOVERY_TIMEOUT_MS - Wait time for SIGTERM (default: 1500)
  *   MARKET_DB_PATH         - Path to market.duckdb (overrides default, overridden by --market-db)
+ *   TRADEBLOCKS_DUCKDB_MEMORY_LIMIT - Resource cap for the parquet market connection
+ *                            (openMarketParquetConnection); unset = DuckDB native default
+ *   TRADEBLOCKS_DUCKDB_THREADS      - Thread cap for the parquet market connection
+ *                            (openMarketParquetConnection); unset = DuckDB native default
  *
  * Security:
  *   - enable_external_access: "true" at DuckDBInstance creation allows local ATTACH
@@ -815,6 +819,125 @@ export async function openMarketOnlyConnection(baseDir: string): Promise<MarketO
  *   fallback for `getDataRoot()` when neither `--data-root` nor the data-root
  *   env var is set.
  */
+/**
+ * Optional DuckDB resource bounds for a parquet market connection.
+ *
+ * Both fields are additive and OFF by default. When a field is omitted AND its
+ * environment override is unset, that resource is left at DuckDB's native
+ * default — i.e. today's behavior, unchanged. This is the backwards-compatible
+ * contract: an existing caller that passes no options and sets no env var gets a
+ * connection that is byte- and perf-identical to before this option existed.
+ *
+ * Per-field precedence: explicit option > environment variable > native default.
+ *   - memoryLimit ← TRADEBLOCKS_DUCKDB_MEMORY_LIMIT
+ *   - threads     ← TRADEBLOCKS_DUCKDB_THREADS
+ *
+ * When set, the bounds are applied via `SET memory_limit=...` / `SET threads=...`
+ * immediately after the connection opens, before any consumer statement (schema
+ * creation, view registration, or caller query) runs.
+ */
+export interface MarketConnectionOptions {
+  /**
+   * DuckDB `memory_limit` for the connection, e.g. "4GB", "512MB", "8GiB".
+   * Accepts a number followed by a DuckDB memory unit (KB/MB/GB/TB decimal or
+   * KiB/MiB/GiB/TiB binary). Malformed values throw before any connection is
+   * opened — they never reach DuckDB as SQL.
+   */
+  memoryLimit?: string;
+  /**
+   * DuckDB `threads` for the connection, a positive integer. The parquet-read
+   * hot path is I/O-bound, and higher thread counts trigger intermittent
+   * prepared-statement failures on long reads — the library-wide default thread
+   * count is 2 for this reason (see defaultThreads() above). Non-integer or
+   * non-positive values throw before any connection is opened.
+   */
+  threads?: number;
+}
+
+// DuckDB `SET memory_limit` accepts a number + a memory unit only: KB/MB/GB/TB
+// (decimal, 1000^i) or KiB/MiB/GiB/TiB (binary, 1024^i). Note it rejects the
+// `%` form here even though instance-creation config accepts it — so this
+// pattern deliberately excludes `%`. Validating against this closed grammar is
+// what makes the value safe to interpolate into the SET statement: a passing
+// value cannot contain a quote or any other SQL metacharacter.
+const DUCKDB_MEMORY_LIMIT_PATTERN = /^\d+(\.\d+)?(KB|MB|GB|TB|KiB|MiB|GiB|TiB)$/i;
+
+function validateMemoryLimit(value: string): string {
+  const trimmed = value.trim();
+  if (!DUCKDB_MEMORY_LIMIT_PATTERN.test(trimmed)) {
+    throw new Error(
+      `Invalid DuckDB memory_limit ${JSON.stringify(value)}. ` +
+        `Expected a number followed by a unit, e.g. "4GB", "512MB", or "8GiB" ` +
+        `(units: KB, MB, GB, TB, KiB, MiB, GiB, TiB).`,
+    );
+  }
+  return trimmed;
+}
+
+function validateThreads(value: number): number {
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(
+      `Invalid DuckDB threads ${JSON.stringify(value)}. Expected a positive integer.`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Resolve the effective resource bounds from an options object and the
+ * environment, applying the explicit-option > env > native-default precedence
+ * and validating both fields. Returns only the fields that are set; an unset
+ * field means "leave DuckDB at its native default" (issue no SET for it).
+ *
+ * Validation happens here — before any DuckDBInstance is created — so malformed
+ * input throws cleanly without leaking a native handle.
+ */
+function resolveResourceBounds(options?: MarketConnectionOptions): {
+  memoryLimit?: string;
+  threads?: number;
+} {
+  const resolved: { memoryLimit?: string; threads?: number } = {};
+
+  const memoryLimitRaw = options?.memoryLimit ?? envValue("TRADEBLOCKS_DUCKDB_MEMORY_LIMIT");
+  if (memoryLimitRaw !== undefined) {
+    resolved.memoryLimit = validateMemoryLimit(memoryLimitRaw);
+  }
+
+  const threadsEnv = envValue("TRADEBLOCKS_DUCKDB_THREADS");
+  const threadsRaw =
+    options?.threads ?? (threadsEnv !== undefined ? Number(threadsEnv) : undefined);
+  if (threadsRaw !== undefined) {
+    resolved.threads = validateThreads(threadsRaw);
+  }
+
+  return resolved;
+}
+
+/** Read an env var, treating unset or all-whitespace as absent (matches the `|| default` idiom elsewhere in this module). */
+function envValue(name: string): string | undefined {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") return undefined;
+  return raw;
+}
+
+/**
+ * Apply already-resolved resource bounds to an open connection via runtime SET
+ * statements. Interpolation is safe: memoryLimit has passed the closed-grammar
+ * validator (no quote/metacharacter can survive) and threads is a validated
+ * integer.
+ */
+async function applyResourceBounds(
+  conn: DuckDBConnection,
+  bounds: { memoryLimit?: string; threads?: number },
+): Promise<void> {
+  if (bounds.memoryLimit !== undefined) {
+    await conn.run(`SET memory_limit='${bounds.memoryLimit}'`);
+  }
+  if (bounds.threads !== undefined) {
+    await conn.run(`SET threads=${bounds.threads}`);
+  }
+}
+
 export interface MarketParquetConnection {
   /** The active DuckDB connection. Backed by a `:memory:` host with `market.*` parquet views. */
   conn: DuckDBConnection;
@@ -831,7 +954,14 @@ export interface MarketParquetConnection {
 
 export async function openMarketParquetConnection(
   baseDir: string,
+  options?: MarketConnectionOptions,
 ): Promise<MarketParquetConnection> {
+  // Resolve + validate resource bounds BEFORE allocating any native handle, so
+  // malformed input (e.g. a bad memory_limit string) throws cleanly without
+  // leaking a DuckDBInstance. Unset option + unset env = empty bounds = no SET
+  // issued = DuckDB native defaults (the backwards-compatible path).
+  const bounds = resolveResourceBounds(options);
+
   // `:memory:` host means the connection does not open any on-disk database as
   // the catalog root — neither the analytics database nor the shared market
   // database file is touched by this code path. `enable_external_access:
@@ -842,6 +972,10 @@ export async function openMarketParquetConnection(
     enable_external_access: "true",
   });
   const conn = await memoryInstance.connect();
+
+  // Apply resource bounds first — before schema creation, view registration, or
+  // any caller query — so every statement on this connection runs under the cap.
+  await applyResourceBounds(conn, bounds);
 
   // The `market.*` views target the `market` schema. On the attach-based
   // paths the ATTACH creates that schema; here there is no attach, so we must
@@ -880,12 +1014,16 @@ export async function openMarketParquetConnection(
  * Read-side name for {@link openMarketParquetConnection}. Retained as the
  * canonical handle for read-only parquet consumers; the underlying connection
  * is identical (parquet has no read/write distinction once the shared market
- * database file is out of the picture).
+ * database file is out of the picture). Accepts the same optional resource
+ * bounds ({@link MarketConnectionOptions}), forwarded verbatim.
  */
 export type MarketReadOnlyConnection = MarketParquetConnection;
 
-export function openMarketReadOnlyConnection(baseDir: string): Promise<MarketReadOnlyConnection> {
-  return openMarketParquetConnection(baseDir);
+export function openMarketReadOnlyConnection(
+  baseDir: string,
+  options?: MarketConnectionOptions,
+): Promise<MarketReadOnlyConnection> {
+  return openMarketParquetConnection(baseDir, options);
 }
 
 /**

--- a/packages/mcp-server/src/db/index.ts
+++ b/packages/mcp-server/src/db/index.ts
@@ -21,6 +21,7 @@ export type {
   MarketOnlyConnection,
   MarketParquetConnection,
   MarketReadOnlyConnection,
+  MarketConnectionOptions,
 } from "./connection.ts";
 export {
   ensureSyncTables,

--- a/packages/mcp-server/src/test-exports.ts
+++ b/packages/mcp-server/src/test-exports.ts
@@ -64,6 +64,7 @@ export type {
   MarketOnlyConnection,
   MarketParquetConnection,
   MarketReadOnlyConnection,
+  MarketConnectionOptions,
 } from "./db/connection.ts";
 export { setDataRoot, getDataRoot, resetDataRoot } from "./db/data-root.ts";
 export { yesterdayET } from "./utils/trading-dates.ts";

--- a/packages/mcp-server/tests/unit/market-parquet-connection.test.ts
+++ b/packages/mcp-server/tests/unit/market-parquet-connection.test.ts
@@ -171,7 +171,7 @@ describe("openMarketParquetConnection (write-side)", () => {
 
 /**
  * Tests for the optional resource-bounds parameter on the parquet market
- * connection (issue #669). Proves: options are applied to the live connection,
+ * connection. Proves: options are applied to the live connection,
  * env overrides work with the documented precedence, the UNSET path issues no
  * SET (native defaults untouched — the backwards-compatibility guarantee), and
  * malformed input is rejected before any connection opens.
@@ -245,7 +245,7 @@ describe("openMarketParquetConnection (resource bounds)", () => {
   });
 
   it("issues NO SET when unset — native defaults untouched (compat guarantee)", async () => {
-    // Native baseline: a raw :memory: instance is exactly what the pre-#669 code
+    // Native baseline: a raw :memory: instance is exactly what the previous code
     // produced (create + connect, no SETs).
     const raw = await DuckDBInstance.create(":memory:", { enable_external_access: "true" });
     const rawConn = await raw.connect();

--- a/packages/mcp-server/tests/unit/market-parquet-connection.test.ts
+++ b/packages/mcp-server/tests/unit/market-parquet-connection.test.ts
@@ -168,3 +168,158 @@ describe("openMarketParquetConnection (write-side)", () => {
     }
   });
 });
+
+/**
+ * Tests for the optional resource-bounds parameter on the parquet market
+ * connection (issue #669). Proves: options are applied to the live connection,
+ * env overrides work with the documented precedence, the UNSET path issues no
+ * SET (native defaults untouched — the backwards-compatibility guarantee), and
+ * malformed input is rejected before any connection opens.
+ */
+describe("openMarketParquetConnection (resource bounds)", () => {
+  let baseDir: string;
+  let savedMemoryLimitEnv: string | undefined;
+  let savedThreadsEnv: string | undefined;
+
+  const MEM_ENV = "TRADEBLOCKS_DUCKDB_MEMORY_LIMIT";
+  const THREADS_ENV = "TRADEBLOCKS_DUCKDB_THREADS";
+
+  async function currentSetting(
+    conn: MarketParquetConnection["conn"],
+    key: string,
+  ): Promise<unknown> {
+    const r = await conn.runAndReadAll(`SELECT current_setting('${key}') AS v`);
+    return (r.getRows() as Array<Array<unknown>>)[0][0];
+  }
+
+  // Parse DuckDB's normalized memory display ("96.9 GiB", "244.1 MiB") to bytes.
+  function parseMemBytes(s: string): number {
+    const m = /^([\d.]+)\s*(KB|MB|GB|TB|KiB|MiB|GiB|TiB)$/.exec(s.trim());
+    if (!m) throw new Error(`unparseable memory setting: ${s}`);
+    const factors: Record<string, number> = {
+      KB: 1e3,
+      MB: 1e6,
+      GB: 1e9,
+      TB: 1e12,
+      KiB: 2 ** 10,
+      MiB: 2 ** 20,
+      GiB: 2 ** 30,
+      TiB: 2 ** 40,
+    };
+    return parseFloat(m[1]) * factors[m[2]];
+  }
+
+  beforeEach(() => {
+    baseDir = join(tmpdir(), `market-bounds-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(baseDir, { recursive: true });
+    // Isolate from any ambient env so "unset" tests are meaningful and env-override
+    // tests are deterministic.
+    savedMemoryLimitEnv = process.env[MEM_ENV];
+    savedThreadsEnv = process.env[THREADS_ENV];
+    delete process.env[MEM_ENV];
+    delete process.env[THREADS_ENV];
+  });
+
+  afterEach(() => {
+    if (savedMemoryLimitEnv === undefined) delete process.env[MEM_ENV];
+    else process.env[MEM_ENV] = savedMemoryLimitEnv;
+    if (savedThreadsEnv === undefined) delete process.env[THREADS_ENV];
+    else process.env[THREADS_ENV] = savedThreadsEnv;
+    try {
+      rmSync(baseDir, { recursive: true, force: true });
+    } catch {
+      /* non-fatal */
+    }
+  });
+
+  it("applies explicit memoryLimit + threads options to the live connection", async () => {
+    const mp = await openMarketParquetConnection(baseDir, { memoryLimit: "256MB", threads: 1 });
+    try {
+      expect(Number(await currentSetting(mp.conn, "threads"))).toBe(1);
+      const mem = String(await currentSetting(mp.conn, "memory_limit"));
+      // 256MB (decimal) == 244.14 MiB — well under the multi-GiB native default.
+      expect(parseMemBytes(mem)).toBeLessThan(512 * 1e6);
+    } finally {
+      await mp.close();
+    }
+  });
+
+  it("issues NO SET when unset — native defaults untouched (compat guarantee)", async () => {
+    // Native baseline: a raw :memory: instance is exactly what the pre-#669 code
+    // produced (create + connect, no SETs).
+    const raw = await DuckDBInstance.create(":memory:", { enable_external_access: "true" });
+    const rawConn = await raw.connect();
+    const nativeThreads = Number(await currentSetting(rawConn, "threads"));
+    const nativeMem = String(await currentSetting(rawConn, "memory_limit"));
+    rawConn.closeSync();
+    raw.closeSync();
+
+    const mp = await openMarketParquetConnection(baseDir); // no options, env cleared
+    try {
+      expect(Number(await currentSetting(mp.conn, "threads"))).toBe(nativeThreads);
+      expect(String(await currentSetting(mp.conn, "memory_limit"))).toBe(nativeMem);
+    } finally {
+      await mp.close();
+    }
+  });
+
+  it("applies bounds from environment variables when no option is passed", async () => {
+    process.env[MEM_ENV] = "256MB";
+    process.env[THREADS_ENV] = "1";
+    const mp = await openMarketParquetConnection(baseDir);
+    try {
+      expect(Number(await currentSetting(mp.conn, "threads"))).toBe(1);
+      expect(parseMemBytes(String(await currentSetting(mp.conn, "memory_limit")))).toBeLessThan(
+        512 * 1e6,
+      );
+    } finally {
+      await mp.close();
+    }
+  });
+
+  it("explicit option takes precedence over the environment variable", async () => {
+    process.env[THREADS_ENV] = "1";
+    const mp = await openMarketParquetConnection(baseDir, { threads: 3 });
+    try {
+      expect(Number(await currentSetting(mp.conn, "threads"))).toBe(3);
+    } finally {
+      await mp.close();
+    }
+  });
+
+  it("read-only alias forwards the options", async () => {
+    const ro = await openMarketReadOnlyConnection(baseDir, { threads: 1 });
+    try {
+      expect(Number(await currentSetting(ro.conn, "threads"))).toBe(1);
+    } finally {
+      await ro.close();
+    }
+  });
+
+  it("rejects a malformed memoryLimit before opening a connection", async () => {
+    await expect(openMarketParquetConnection(baseDir, { memoryLimit: "lots" })).rejects.toThrow(
+      /memory_limit/,
+    );
+    // A percentage is valid at instance-creation but NOT via SET — reject it here.
+    await expect(openMarketParquetConnection(baseDir, { memoryLimit: "80%" })).rejects.toThrow(
+      /memory_limit/,
+    );
+  });
+
+  it("rejects a SQL-injection attempt in memoryLimit (never reaches DuckDB as SQL)", async () => {
+    await expect(
+      openMarketParquetConnection(baseDir, { memoryLimit: "4GB'; DROP TABLE market.spot;--" }),
+    ).rejects.toThrow(/memory_limit/);
+  });
+
+  it("rejects non-integer / non-positive threads", async () => {
+    await expect(openMarketParquetConnection(baseDir, { threads: 2.5 })).rejects.toThrow(/threads/);
+    await expect(openMarketParquetConnection(baseDir, { threads: 0 })).rejects.toThrow(/threads/);
+    await expect(openMarketParquetConnection(baseDir, { threads: -4 })).rejects.toThrow(/threads/);
+  });
+
+  it("rejects a malformed threads environment variable", async () => {
+    process.env[THREADS_ENV] = "notanumber";
+    await expect(openMarketParquetConnection(baseDir)).rejects.toThrow(/threads/);
+  });
+});


### PR DESCRIPTION
Tier: 2 — public-interface change under the ADR-0004 coverage-bar election (pre-merge gate PASS; suite green; each new export behavior-tested; no breaking delta).

**Optional DuckDB resource bounds for the parquet market connection**

`openMarketParquetConnection` (and its `openMarketReadOnlyConnection` alias) creates DuckDB connections with no `memory_limit`/`threads` set, so every consumer runs at DuckDB's native defaults (~80% of system RAM, all cores). This adds an **optional** resource-bounds parameter so callers can cap a connection's footprint.

**New surface (all additive):**
- `options?: { memoryLimit?: string; threads?: number }` on both helpers. When provided, applied via `SET memory_limit` / `SET threads` right after the connection opens, before any consumer statement.
- Env overrides `TRADEBLOCKS_DUCKDB_MEMORY_LIMIT` / `TRADEBLOCKS_DUCKDB_THREADS` (distinct from the existing `DUCKDB_*` vars, which affect only the analytics connection — reusing those names would silently re-scope them onto this path).
- Precedence per field: explicit option → env var → native default.
- `MarketConnectionOptions` exported for typing.

**Backwards compatibility:** the default is unchanged. With no option and no env var, no `SET` is issued and the connection is identical to before. A test asserts the unset path produces byte-identical `threads`/`memory_limit` versus a native connection.

**Input safety:** `memoryLimit` is validated against a closed unit grammar (`KB/MB/GB/TB`, `KiB/MiB/GiB/TiB`) and `threads` against positive integers, before any connection opens — malformed input throws a clear error and never reaches DuckDB as SQL.

**Deliberately out of scope:** flipping the default to bounded values. The parquet scan path is the hot path and a thread cap could regress the end-to-end wall; that is a separate, measured decision.

Tests: options applied (asserted via `current_setting`), env precedence, explicit-over-env, alias forwarding, the unset compat guarantee, and rejection of malformed/injection-shaped input. Full test suites green (1642 + 1314).

Review: pre-merge gate PASS; Tier 2 elected under the public-interface coverage bar (suite green, each new export behavior-tested, no breaking delta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hz5buzAgqQDHMrTKzBeNGU
