### PR TITLE
feat(quote-store): opt-in neededGreeks projection on readWindow (inert until a consumer opts in)

### DIFF
--- a/packages/mcp-server/src/market/stores/duckdb-quote-store.ts
+++ b/packages/mcp-server/src/market/stores/duckdb-quote-store.ts
@@ -16,6 +16,7 @@ import { extractRoot } from "../tickers/resolver.ts";
 import {
   describeQueryColumns,
   quoteParquetCanonicalProjection,
+  readWindowGreekProjection,
   type ParquetColumnSet,
 } from "../../utils/quote-parquet-projection.ts";
 
@@ -275,7 +276,7 @@ export class DuckdbQuoteStore extends QuoteStore {
    * No SQL ranking; ranking + top-N selection happen in JS at the call site.
    */
   async readWindow(params: ReadWindowParams): Promise<WindowQuoteRow[]> {
-    const { underlying, date, timeStart, timeEnd, legEnvelopes } = params;
+    const { underlying, date, timeStart, timeEnd, legEnvelopes, neededGreeks } = params;
     if (legEnvelopes.length === 0) return [];
 
     // Inline every value as a SQL literal and call the unbound
@@ -309,6 +310,12 @@ export class DuckdbQuoteStore extends QuoteStore {
     // and `date` are filter-pinned by the WHERE clause, and `mid` is derived
     // as `(bid + ask) / 2` in `toMinuteQuoteRow` — fetching + decoding those
     // three columns for ~100K rows per call was wasted work.
+    // Opt-in greek trim: when `neededGreeks` is present the projection emits
+    // NULL::DOUBLE for the unrequested greeks so they are neither read nor
+    // marshaled to JS; row positions are unchanged. Absent ⇒
+    // `q.delta, q.gamma, q.theta, q.vega, q.iv`, identical to the historic read.
+    const greekProjection = readWindowGreekProjection("q", neededGreeks);
+
     const sql = `
       WITH band AS (
         SELECT DISTINCT ticker, contract_type, strike, expiration, dte
@@ -319,7 +326,7 @@ export class DuckdbQuoteStore extends QuoteStore {
       SELECT q.ticker, q.time,
              b.contract_type, b.strike, b.expiration, b.dte,
              q.bid, q.ask,
-             q.delta, q.gamma, q.theta, q.vega, q.iv, q.greeks_source
+             ${greekProjection}, q.greeks_source
         FROM market.option_quote_minutes q
         JOIN band b ON q.ticker = b.ticker
        WHERE q.underlying = ${pUnderlying}
@@ -328,22 +335,26 @@ export class DuckdbQuoteStore extends QuoteStore {
     `;
 
     const reader = await this.ctx.conn.runAndReadAll(sql);
-    return reader.getRows().map((r) => ({
-      ticker: String(r[0]),
-      time: String(r[1]),
-      contract_type: String(r[2]) as "call" | "put",
-      strike: Number(r[3]),
-      expiration: String(r[4]),
-      dte: Number(r[5]),
-      bid: Number(r[6]),
-      ask: Number(r[7]),
-      delta: r[8] == null ? null : Number(r[8]),
-      gamma: r[9] == null ? null : Number(r[9]),
-      theta: r[10] == null ? null : Number(r[10]),
-      vega: r[11] == null ? null : Number(r[11]),
-      iv: r[12] == null ? null : Number(r[12]),
-      greeks_source: r[13] == null ? null : (String(r[13]) as WindowQuoteRow["greeks_source"]),
-    }));
+    return reader.getRows().map((r) => {
+      const row: WindowQuoteRow = {
+        ticker: String(r[0]),
+        time: String(r[1]),
+        contract_type: String(r[2]) as "call" | "put",
+        strike: Number(r[3]),
+        expiration: String(r[4]),
+        dte: Number(r[5]),
+        bid: Number(r[6]),
+        ask: Number(r[7]),
+        delta: r[8] == null ? null : Number(r[8]),
+        gamma: r[9] == null ? null : Number(r[9]),
+        theta: r[10] == null ? null : Number(r[10]),
+        vega: r[11] == null ? null : Number(r[11]),
+        iv: r[12] == null ? null : Number(r[12]),
+        greeks_source: r[13] == null ? null : (String(r[13]) as WindowQuoteRow["greeks_source"]),
+      };
+      if (neededGreeks !== undefined) row.projectedGreeks = neededGreeks;
+      return row;
+    });
   }
 
   async getCoverage(underlying: string, from: string, to: string): Promise<CoverageReport> {

--- a/packages/mcp-server/src/market/stores/index.ts
+++ b/packages/mcp-server/src/market/stores/index.ts
@@ -74,4 +74,13 @@ export function createMarketStores(ctx: StoreContext): MarketStores {
 export { SpotStore, EnrichedStore, ChainStore, QuoteStore };
 export type { StoreContext };
 export type { EnrichedReadOpts } from "./enriched-store.ts";
-export type { BarRow, ContractRow, QuoteRow, CoverageReport } from "./types.ts";
+export type {
+  BarRow,
+  ContractRow,
+  QuoteRow,
+  CoverageReport,
+  LegEnvelope,
+  ReadWindowParams,
+  WindowQuoteRow,
+  GreekColumn,
+} from "./types.ts";

--- a/packages/mcp-server/src/market/stores/parquet-quote-store.ts
+++ b/packages/mcp-server/src/market/stores/parquet-quote-store.ts
@@ -28,6 +28,7 @@ import {
   quoteParquetCanonicalProjection,
   quoteParquetCanonicalWriteProjection,
   readParquetFilesSql,
+  readWindowGreekProjection,
 } from "../../utils/quote-parquet-projection.ts";
 
 function parseQuoteRow(row: unknown[]): QuoteRow {
@@ -307,7 +308,7 @@ export class ParquetQuoteStore extends QuoteStore {
    * pipeline assumes chain coverage.
    */
   async readWindow(params: ReadWindowParams): Promise<WindowQuoteRow[]> {
-    const { underlying, date, timeStart, timeEnd, legEnvelopes } = params;
+    const { underlying, date, timeStart, timeEnd, legEnvelopes, neededGreeks } = params;
     if (legEnvelopes.length === 0) return [];
 
     const marketDir = resolveMarketDir(this.ctx.dataDir);
@@ -361,6 +362,13 @@ export class ParquetQuoteStore extends QuoteStore {
       return clause;
     });
 
+    // Opt-in greek trim: when `neededGreeks` is present the projection emits
+    // NULL::DOUBLE for the unrequested greeks so DuckDB neither scans them from
+    // Parquet nor marshals real values across to JS; row positions are
+    // unchanged. Absent ⇒ `q.delta, q.gamma, q.theta, q.vega, q.iv`, identical
+    // to the historic full read.
+    const greekProjection = readWindowGreekProjection("q", neededGreeks);
+
     const sql = `
       WITH band AS (
         SELECT DISTINCT ticker, contract_type, strike, expiration, dte
@@ -370,29 +378,33 @@ export class ParquetQuoteStore extends QuoteStore {
       SELECT q.ticker, q.time,
              b.contract_type, b.strike, b.expiration, b.dte,
              q.bid, q.ask,
-             q.delta, q.gamma, q.theta, q.vega, q.iv, q.greeks_source
+             ${greekProjection}, q.greeks_source
         FROM ${quoteSrc} AS q
         JOIN band b ON q.ticker = b.ticker
        WHERE q.time BETWEEN ${safeTimeStart} AND ${safeTimeEnd}
     `;
 
     const reader = await this.ctx.conn.runAndReadAll(sql);
-    return reader.getRows().map((r) => ({
-      ticker: String(r[0]),
-      time: String(r[1]),
-      contract_type: String(r[2]) as "call" | "put",
-      strike: Number(r[3]),
-      expiration: String(r[4]),
-      dte: Number(r[5]),
-      bid: Number(r[6]),
-      ask: Number(r[7]),
-      delta: r[8] == null ? null : Number(r[8]),
-      gamma: r[9] == null ? null : Number(r[9]),
-      theta: r[10] == null ? null : Number(r[10]),
-      vega: r[11] == null ? null : Number(r[11]),
-      iv: r[12] == null ? null : Number(r[12]),
-      greeks_source: r[13] == null ? null : (String(r[13]) as WindowQuoteRow["greeks_source"]),
-    }));
+    return reader.getRows().map((r) => {
+      const row: WindowQuoteRow = {
+        ticker: String(r[0]),
+        time: String(r[1]),
+        contract_type: String(r[2]) as "call" | "put",
+        strike: Number(r[3]),
+        expiration: String(r[4]),
+        dte: Number(r[5]),
+        bid: Number(r[6]),
+        ask: Number(r[7]),
+        delta: r[8] == null ? null : Number(r[8]),
+        gamma: r[9] == null ? null : Number(r[9]),
+        theta: r[10] == null ? null : Number(r[10]),
+        vega: r[11] == null ? null : Number(r[11]),
+        iv: r[12] == null ? null : Number(r[12]),
+        greeks_source: r[13] == null ? null : (String(r[13]) as WindowQuoteRow["greeks_source"]),
+      };
+      if (neededGreeks !== undefined) row.projectedGreeks = neededGreeks;
+      return row;
+    });
   }
 
   async getCoverage(underlying: string, from: string, to: string): Promise<CoverageReport> {

--- a/packages/mcp-server/src/market/stores/quote-store.ts
+++ b/packages/mcp-server/src/market/stores/quote-store.ts
@@ -156,6 +156,11 @@ export abstract class QuoteStore {
    * dte) so the caller doesn't OCC-parse. Greeks columns project as-is from the
    * quote table.
    *
+   * `params.neededGreeks` is an optional projection: absent ⇒ all five greeks
+   * are read (historic behavior); present ⇒ only the listed greeks are read and
+   * the rest come back NULL, with the projection echoed on each row's
+   * `projectedGreeks` so the collapse contract (`hasQuoteGreeks`) can honor it.
+   *
    * Per P1: this is the single read primitive. Ranking + top-N selection happen
    * in JS at the call site. No SQL ranking CTE.
    */

--- a/packages/mcp-server/src/market/stores/types.ts
+++ b/packages/mcp-server/src/market/stores/types.ts
@@ -93,6 +93,9 @@ export interface CoverageReport {
 // stores) have a single import path: `./types.js`.
 export type { BarRow } from "../../utils/market-provider.ts";
 export type { ContractRow } from "../../utils/chain-loader.ts";
+export type { GreekColumn } from "../../utils/quote-parquet-projection.ts";
+
+import type { GreekColumn } from "../../utils/quote-parquet-projection.ts";
 
 /**
  * Per-leg envelope for QuoteStore.readWindow. Compiled from the strategy's
@@ -113,6 +116,20 @@ export interface ReadWindowParams {
   timeStart: string;
   timeEnd: string;
   legEnvelopes: LegEnvelope[];
+  /**
+   * Opt-in greek projection. Absent ⇒ the full five-greek projection is read
+   * (delta/gamma/theta/vega/iv), byte-identical to the historic behavior.
+   * Present ⇒ the SQL projects only the listed greeks from the partition and
+   * emits NULL for the rest; every returned row is stamped with
+   * `WindowQuoteRow.projectedGreeks` so a null greek that was never requested
+   * is distinguishable from a null greek whose data is genuinely missing.
+   *
+   * Non-greek columns (bid/ask/chain metadata/greeks_source) are always
+   * projected in full regardless of this setting. An unknown greek name throws.
+   * Selection typically needs only `["delta", "iv"]`; gamma/theta/vega feed
+   * downstream reporting snapshots.
+   */
+  neededGreeks?: ReadonlyArray<GreekColumn>;
 }
 
 /**
@@ -139,4 +156,14 @@ export interface WindowQuoteRow {
   vega: number | null;
   iv: number | null;
   greeks_source: "massive" | "thetadata" | "computed" | null;
+  /**
+   * The greek subset deliberately projected by this read, echoed back from
+   * `ReadWindowParams.neededGreeks`. Absent when the read used the full
+   * projection (every greek is meaningful). Present ⇒ only the listed greeks
+   * carry meaningful values; the others are NULL because they were not
+   * requested, NOT because their data is missing. Pass this straight to
+   * `hasQuoteGreeks(row, projectedGreeks)` so a trimmed read is never mistaken
+   * for a data-missing read and collapsed to zero candidates.
+   */
+  projectedGreeks?: ReadonlyArray<GreekColumn>;
 }

--- a/packages/mcp-server/src/test-exports.ts
+++ b/packages/mcp-server/src/test-exports.ts
@@ -315,8 +315,13 @@ export {
 export {
   describeReadParquetColumns,
   quoteParquetCanonicalProjection,
+  quoteParquetGreekProjection,
+  readWindowGreekProjection,
+  assertKnownGreeks,
+  ALL_GREEKS,
   readParquetFilesSql,
 } from "./utils/quote-parquet-projection.ts";
+export type { GreekColumn } from "./utils/quote-parquet-projection.ts";
 
 // Export parquet-writer utility functions for unit testing
 export {

--- a/packages/mcp-server/src/utils/option-quote-greeks.ts
+++ b/packages/mcp-server/src/utils/option-quote-greeks.ts
@@ -3,6 +3,7 @@ import type { ContractRow } from "./chain-loader.ts";
 import { computeLegGreeks } from "./black-scholes.ts";
 import { computeFractionalDte } from "./option-time.ts";
 import { getSharedIvSolverPool, type IvSolveColumns, type IvSolverPool } from "./iv-solver-pool.ts";
+import { ALL_GREEKS, type GreekColumn } from "./quote-parquet-projection.ts";
 
 export type QuoteGreeksSource = "massive" | "thetadata" | "computed";
 export type QuoteGreeksMode = "auto" | "provider" | "compute";
@@ -74,14 +75,25 @@ function memoizedSofrRate(dateKey: string): number {
   return rate;
 }
 
-export function hasQuoteGreeks(row: QuoteGreekFields): boolean {
-  return (
-    isFiniteNumber(row.delta ?? null) &&
-    isFiniteNumber(row.gamma ?? null) &&
-    isFiniteNumber(row.theta ?? null) &&
-    isFiniteNumber(row.vega ?? null) &&
-    isFiniteNumber(row.iv ?? null)
-  );
+/**
+ * True when every greek in `needed` is a finite number on `row`.
+ *
+ * `needed` defaults to all five greeks, so `hasQuoteGreeks(row)` is exactly the
+ * historic all-or-nothing collapse contract. When a read was deliberately
+ * projected to a greek subset (`ReadWindowParams.neededGreeks`), pass that same
+ * subset — echoed back on `WindowQuoteRow.projectedGreeks` — so a greek that is
+ * NULL because it was never requested does not fail validation and silently
+ * collapse the whole greeks object to zero candidates. A greek that IS in
+ * `needed` but came back non-finite is genuinely missing data and still fails.
+ */
+export function hasQuoteGreeks(
+  row: QuoteGreekFields,
+  needed: readonly GreekColumn[] = ALL_GREEKS,
+): boolean {
+  for (const greek of needed) {
+    if (!isFiniteNumber(row[greek] ?? null)) return false;
+  }
+  return true;
 }
 
 function hasProviderFirstOrderGreeks(row: QuoteGreekFields): boolean {

--- a/packages/mcp-server/src/utils/quote-parquet-projection.ts
+++ b/packages/mcp-server/src/utils/quote-parquet-projection.ts
@@ -64,7 +64,56 @@ export function quoteParquetMidExpr(columns: ParquetColumnSet, alias: string): s
 
 export type GreekColumn = "delta" | "gamma" | "theta" | "vega" | "iv";
 
-const ALL_GREEKS: readonly GreekColumn[] = ["delta", "gamma", "theta", "vega", "iv"] as const;
+export const ALL_GREEKS: readonly GreekColumn[] = [
+  "delta",
+  "gamma",
+  "theta",
+  "vega",
+  "iv",
+] as const;
+
+const ALL_GREEK_SET: ReadonlySet<string> = new Set(ALL_GREEKS);
+
+/**
+ * Single validation gate for caller-supplied greek names. TypeScript pins the
+ * `GreekColumn` union at compile time, but a name arriving from JSON / config
+ * (e.g. a strategy definition) bypasses that check — so anything selecting a
+ * projected subset routes through here first and throws a clear error naming
+ * both the offending value and the valid set.
+ */
+export function assertKnownGreeks(
+  needed: readonly string[],
+): asserts needed is readonly GreekColumn[] {
+  for (const name of needed) {
+    if (!ALL_GREEK_SET.has(name)) {
+      throw new Error(`Unknown greek "${name}" — valid greeks are: ${ALL_GREEKS.join(", ")}.`);
+    }
+  }
+}
+
+/**
+ * Greek SELECT list for `QuoteStore.readWindow`. readWindow targets a single
+ * known (underlying, date) partition, so it references the greek columns
+ * directly (`q.delta`) rather than guarding on column existence the way the
+ * canonical projection does.
+ *
+ * `needed` omitted ⇒ every greek projects as-is, byte-identical to the historic
+ * full projection. `needed` supplied ⇒ only those greeks project from the
+ * partition; the rest emit `NULL::DOUBLE` so the row stays position-stable. The
+ * NULL emitted for a trimmed greek is indistinguishable at the SQL level from a
+ * stored NULL — the "not requested" vs "genuinely missing" distinction is
+ * carried out-of-band by `WindowQuoteRow.projectedGreeks`, never by the value.
+ */
+export function readWindowGreekProjection(alias: string, needed?: readonly GreekColumn[]): string {
+  if (needed === undefined) {
+    return ALL_GREEKS.map((name) => `${alias}.${name}`).join(", ");
+  }
+  assertKnownGreeks(needed);
+  const want = new Set<GreekColumn>(needed);
+  return ALL_GREEKS.map((name) =>
+    want.has(name) ? `${alias}.${name}` : `NULL::DOUBLE AS ${name}`,
+  ).join(", ");
+}
 
 export function quoteParquetGreekProjection(
   columns: ParquetColumnSet,

--- a/packages/mcp-server/tests/unit/market/stores/duckdb-quote-store.test.ts
+++ b/packages/mcp-server/tests/unit/market/stores/duckdb-quote-store.test.ts
@@ -225,4 +225,79 @@ describe("DuckdbQuoteStore.readWindow", () => {
     // entry/data.test.ts MinuteQuoteRow assertions.
     await conn.close();
   });
+
+  it("honors neededGreeks: only requested greeks populate, rest are null, stamped", async () => {
+    const { store, conn } = await setUpDuckdbStoreWithFixtures();
+    const rows = await store.readWindow({
+      underlying: "SPX",
+      date: "2024-01-15",
+      timeStart: "09:35",
+      timeEnd: "09:35",
+      legEnvelopes: [
+        { contractType: "put", dteMin: 7, dteMax: 11, strikeMin: 4700, strikeMax: 4700 },
+      ],
+      neededGreeks: ["delta", "iv"],
+    });
+    expect(rows.length).toBeGreaterThan(0);
+    const row = rows[0];
+    expect(row.delta).toBeCloseTo(0.5, 5);
+    expect(row.iv).toBeCloseTo(0.2, 5);
+    expect(row.gamma).toBeNull();
+    expect(row.theta).toBeNull();
+    expect(row.vega).toBeNull();
+    expect(row.projectedGreeks).toEqual(["delta", "iv"]);
+    await conn.close();
+  });
+
+  it("default read carries no projectedGreeks stamp (byte-identity)", async () => {
+    const { store, conn } = await setUpDuckdbStoreWithFixtures();
+    const rows = await store.readWindow({
+      underlying: "SPX",
+      date: "2024-01-15",
+      timeStart: "09:35",
+      timeEnd: "09:35",
+      legEnvelopes: [
+        { contractType: "put", dteMin: 7, dteMax: 11, strikeMin: 4700, strikeMax: 4700 },
+      ],
+    });
+    // Byte-identity: the exact historic key set (symmetric with the parquet-side
+    // assertion), no projectedGreeks key present.
+    expect(Object.keys(rows[0]).sort()).toEqual(
+      [
+        "ticker",
+        "time",
+        "contract_type",
+        "strike",
+        "expiration",
+        "dte",
+        "bid",
+        "ask",
+        "delta",
+        "gamma",
+        "theta",
+        "vega",
+        "iv",
+        "greeks_source",
+      ].sort(),
+    );
+    expect("projectedGreeks" in rows[0]).toBe(false);
+    await conn.close();
+  });
+
+  it("rejects an unknown greek name with a clear error", async () => {
+    const { store, conn } = await setUpDuckdbStoreWithFixtures();
+    await expect(
+      store.readWindow({
+        underlying: "SPX",
+        date: "2024-01-15",
+        timeStart: "09:35",
+        timeEnd: "09:35",
+        legEnvelopes: [
+          { contractType: "put", dteMin: 7, dteMax: 11, strikeMin: 4700, strikeMax: 4700 },
+        ],
+        neededGreeks: ["rho"] as never,
+      }),
+    ).rejects.toThrow(/Unknown greek "rho"/);
+    await conn.close();
+  });
 });

--- a/packages/mcp-server/tests/unit/market/stores/parquet-quote-store.test.ts
+++ b/packages/mcp-server/tests/unit/market/stores/parquet-quote-store.test.ts
@@ -16,6 +16,7 @@ import {
   ParquetChainStore,
   DuckdbQuoteStore,
   DuckdbChainStore,
+  hasQuoteGreeks,
 } from "../../../../src/test-exports.ts";
 import {
   buildStoreFixture,
@@ -281,6 +282,109 @@ describe("ParquetQuoteStore.readWindow", () => {
     expect(row.ask).toBeCloseTo(1.2, 5);
     // `mid` is no longer projected on WindowQuoteRow — it's derived as
     // (bid + ask) / 2 in `toMinuteQuoteRow`.
+    await conn.close();
+  });
+
+  it("default read (no neededGreeks) carries every greek and no projectedGreeks stamp", async () => {
+    const { store, conn } = await setUpParquetStoreWithFixtures();
+    const rows = await store.readWindow({
+      underlying: "SPX",
+      date: DATE,
+      timeStart: "09:35",
+      timeEnd: "09:35",
+      legEnvelopes: [
+        { contractType: "put", dteMin: 7, dteMax: 11, strikeMin: 4700, strikeMax: 4700 },
+      ],
+    });
+    expect(rows.length).toBeGreaterThan(0);
+    const row = rows[0];
+    // Byte-identity: the exact historic key set, no projectedGreeks key present.
+    expect(Object.keys(row).sort()).toEqual(
+      [
+        "ticker",
+        "time",
+        "contract_type",
+        "strike",
+        "expiration",
+        "dte",
+        "bid",
+        "ask",
+        "delta",
+        "gamma",
+        "theta",
+        "vega",
+        "iv",
+        "greeks_source",
+      ].sort(),
+    );
+    expect("projectedGreeks" in row).toBe(false);
+    for (const g of ["delta", "gamma", "theta", "vega", "iv"] as const) {
+      expect(typeof row[g]).toBe("number");
+    }
+    await conn.close();
+  });
+
+  it("projected read returns only requested greeks, NULLs the rest, and stamps projectedGreeks", async () => {
+    const { store, conn } = await setUpParquetStoreWithFixtures();
+    const rows = await store.readWindow({
+      underlying: "SPX",
+      date: DATE,
+      timeStart: "09:35",
+      timeEnd: "09:35",
+      legEnvelopes: [
+        { contractType: "put", dteMin: 7, dteMax: 11, strikeMin: 4700, strikeMax: 4700 },
+      ],
+      neededGreeks: ["delta", "iv"],
+    });
+    expect(rows.length).toBeGreaterThan(0);
+    const row = rows[0];
+    expect(row.delta).toBeCloseTo(0.5, 5);
+    expect(row.iv).toBeCloseTo(0.2, 5);
+    expect(row.gamma).toBeNull();
+    expect(row.theta).toBeNull();
+    expect(row.vega).toBeNull();
+    // Non-greek metadata is always projected in full.
+    expect(row.bid).toBeCloseTo(1.0, 5);
+    expect(row.ask).toBeCloseTo(1.2, 5);
+    expect(row.projectedGreeks).toEqual(["delta", "iv"]);
+    await conn.close();
+  });
+
+  it("a projected row survives the collapse contract when the projection is honored", async () => {
+    const { store, conn } = await setUpParquetStoreWithFixtures();
+    const rows = await store.readWindow({
+      underlying: "SPX",
+      date: DATE,
+      timeStart: "09:35",
+      timeEnd: "09:35",
+      legEnvelopes: [
+        { contractType: "put", dteMin: 7, dteMax: 11, strikeMin: 4700, strikeMax: 4700 },
+      ],
+      neededGreeks: ["delta", "iv"],
+    });
+    const row = rows[0];
+    // The failure mode the projection prevents: the default full contract sees
+    // NULL gamma/theta/vega and would collapse the row.
+    expect(hasQuoteGreeks(row)).toBe(false);
+    // Honoring the projection carried on the row keeps it valid.
+    expect(hasQuoteGreeks(row, row.projectedGreeks)).toBe(true);
+    await conn.close();
+  });
+
+  it("rejects an unknown greek name with a clear error", async () => {
+    const { store, conn } = await setUpParquetStoreWithFixtures();
+    await expect(
+      store.readWindow({
+        underlying: "SPX",
+        date: DATE,
+        timeStart: "09:35",
+        timeEnd: "09:35",
+        legEnvelopes: [
+          { contractType: "put", dteMin: 7, dteMax: 11, strikeMin: 4700, strikeMax: 4700 },
+        ],
+        neededGreeks: ["rho"] as never,
+      }),
+    ).rejects.toThrow(/Unknown greek "rho"/);
     await conn.close();
   });
 

--- a/packages/mcp-server/tests/unit/utils/option-quote-greeks.test.ts
+++ b/packages/mcp-server/tests/unit/utils/option-quote-greeks.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Collapse-contract tests for `hasQuoteGreeks`.
+ *
+ * The historic contract collapses the whole greeks object when ANY of the five
+ * greeks is non-finite. When a read is deliberately projected to a greek subset
+ * (`ReadWindowParams.neededGreeks`), the unrequested greeks come back NULL by
+ * design — passing the projection to `hasQuoteGreeks` must keep the row valid so
+ * a trimmed read is never mistaken for a data-missing read and collapsed to zero
+ * candidates.
+ */
+import { describe, it, expect } from "@jest/globals";
+import { hasQuoteGreeks } from "../../../src/utils/option-quote-greeks.ts";
+
+describe("hasQuoteGreeks — full contract (default)", () => {
+  it("is true when all five greeks are finite", () => {
+    expect(hasQuoteGreeks({ delta: 0.5, gamma: 0.01, theta: -0.02, vega: 0.1, iv: 0.2 })).toBe(
+      true,
+    );
+  });
+
+  it("collapses when any single greek is null (historic all-or-nothing)", () => {
+    expect(hasQuoteGreeks({ delta: 0.5, gamma: null, theta: -0.02, vega: 0.1, iv: 0.2 })).toBe(
+      false,
+    );
+  });
+
+  it("collapses when a greek is non-finite (NaN)", () => {
+    expect(hasQuoteGreeks({ delta: 0.5, gamma: 0.01, theta: -0.02, vega: 0.1, iv: NaN })).toBe(
+      false,
+    );
+  });
+});
+
+describe("hasQuoteGreeks — projected subset", () => {
+  // A read projected to delta+iv: gamma/theta/vega are NULL because they were
+  // never requested, NOT because they are missing.
+  const projectedRow = { delta: 0.5, gamma: null, theta: null, vega: null, iv: 0.2 };
+
+  it("the default full contract WOULD collapse this projected row (the failure mode)", () => {
+    expect(hasQuoteGreeks(projectedRow)).toBe(false);
+  });
+
+  it("honors the projection and validates only the requested greeks", () => {
+    expect(hasQuoteGreeks(projectedRow, ["delta", "iv"])).toBe(true);
+  });
+
+  it("still collapses when a REQUESTED greek is genuinely missing", () => {
+    expect(
+      hasQuoteGreeks({ delta: null, gamma: null, theta: null, vega: null, iv: 0.2 }, [
+        "delta",
+        "iv",
+      ]),
+    ).toBe(false);
+  });
+
+  it("is trivially true for an empty projection (no greeks required)", () => {
+    expect(
+      hasQuoteGreeks({ delta: null, gamma: null, theta: null, vega: null, iv: null }, []),
+    ).toBe(true);
+  });
+});

--- a/packages/mcp-server/tests/unit/utils/quote-parquet-projection.test.ts
+++ b/packages/mcp-server/tests/unit/utils/quote-parquet-projection.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "@jest/globals";
-import { quoteParquetGreekProjection } from "../../../src/utils/quote-parquet-projection.ts";
+import {
+  quoteParquetGreekProjection,
+  readWindowGreekProjection,
+  assertKnownGreeks,
+} from "../../../src/utils/quote-parquet-projection.ts";
 
 describe("quoteParquetGreekProjection", () => {
   const allColumns = new Set([
@@ -41,5 +45,41 @@ describe("quoteParquetGreekProjection", () => {
     expect(sql).toContain("NULL::DOUBLE AS theta");
     expect(sql).toContain("NULL::DOUBLE AS vega");
     expect(sql).toContain("NULL::DOUBLE AS iv");
+  });
+});
+
+describe("readWindowGreekProjection", () => {
+  it("projects every greek as-is when `needed` is omitted (byte-identical default)", () => {
+    expect(readWindowGreekProjection("q")).toBe("q.delta, q.gamma, q.theta, q.vega, q.iv");
+  });
+
+  it("references only the requested greeks and NULLs the rest, position-stable", () => {
+    expect(readWindowGreekProjection("q", ["delta", "iv"])).toBe(
+      "q.delta, NULL::DOUBLE AS gamma, NULL::DOUBLE AS theta, NULL::DOUBLE AS vega, q.iv",
+    );
+  });
+
+  it("NULLs every greek when `needed` is empty", () => {
+    expect(readWindowGreekProjection("q", [])).toBe(
+      "NULL::DOUBLE AS delta, NULL::DOUBLE AS gamma, NULL::DOUBLE AS theta, NULL::DOUBLE AS vega, NULL::DOUBLE AS iv",
+    );
+  });
+
+  it("throws a clear error on an unknown greek name", () => {
+    expect(() => readWindowGreekProjection("q", ["banana"] as never)).toThrow(
+      /Unknown greek "banana"/,
+    );
+  });
+});
+
+describe("assertKnownGreeks", () => {
+  it("passes for the valid greek names", () => {
+    expect(() => assertKnownGreeks(["delta", "gamma", "theta", "vega", "iv"])).not.toThrow();
+  });
+
+  it("throws naming the offending value and the valid set", () => {
+    expect(() => assertKnownGreeks(["delta", "rho"])).toThrow(
+      /Unknown greek "rho" — valid greeks are: delta, gamma, theta, vega, iv\./,
+    );
   });
 });


### PR DESCRIPTION
Tier: 2 — public-interface change under the ADR-0004 coverage-bar election (pre-merge gate PASS; suite green; each new export behavior-tested; no breaking delta).

**feat(quote-store): opt-in greek projection on `readWindow`**

Adds a strictly opt-in `neededGreeks` projection to `QuoteStore.readWindow` on both the Parquet and DuckDB backends. It lets a caller read only the greeks it actually needs (selection typically needs just `delta` + `iv`) instead of marshaling all five plus metadata for every row on the entry hot path.

**Backwards compatible by construction.** With `neededGreeks` absent, the read is byte-identical to today: all five greeks, the same result-row shape (asserted key-for-key on both backends), the same SQL. Present ⇒ the SQL projects only the requested greek columns and emits `NULL` for the rest; every non-greek column is always projected in full.

**Trimmed ≠ missing.** A projected read stamps each row with `projectedGreeks`, and the greeks-validity contract `hasQuoteGreeks(row, needed)` now accepts that subset — so a greek that is null *because it wasn't requested* is never mistaken for missing data, while a **requested** greek that is genuinely missing still fails validation. Called without the subset, `hasQuoteGreeks` is exactly the previous all-or-nothing check.

**Guardrails.** One place maps greek names to columns; an unknown greek name throws a clear error listing the valid set.

**Inert until a consumer opts in.** No default behavior, result shape, or performance characteristic changes for existing callers — no production caller passes the parameter in this PR. This is the enabling surface only; consumer wiring and the end-to-end measurement are tracked separately, and no performance claim is made here.

**Tests.** Default-path byte-identity (exact historic key set, both backends), requested-only projection with the rest null, the collapse contract honoring a projected read (reproduced from real store output, not a stub), still-fails-when-a-requested-greek-is-missing, unknown-name rejection, and projection SQL-shape assertions. Full public suites green (1653 + 1314).

Review: pre-merge gate PASS; Tier 2 elected under the public-interface coverage bar (suite green, each new/changed export behavior-tested, no breaking delta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hz5buzAgqQDHMrTKzBeNGU
