### PR TITLE
feat(provenance): add closure-scoped historical adoption

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tradeblocks",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tradeblocks",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "workspaces": [
         "packages/*"
       ],
@@ -22409,7 +22409,7 @@
     },
     "packages/mcp-server": {
       "name": "tradeblocks-mcp",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "MIT",
       "dependencies": {
         "@duckdb/node-api": "^1.4.4-r.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "private": true,
   "workspaces": [

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks-mcp",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "MCP server for options trade analysis",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "type": "module",

--- a/packages/mcp-server/scripts/verify-packed-provenance-runtime.mjs
+++ b/packages/mcp-server/scripts/verify-packed-provenance-runtime.mjs
@@ -58,6 +58,7 @@ try {
       createInputClosureDescriptor,
       dependencyKeyAddress,
       isXnysSessionDate,
+      migrateAllLegacyEnrichedFiles,
       publishCanonicalMarketResolverRegistry,
       publishCanonicalRateSlice,
       verifyCanonicalRefreshCompletion,
@@ -85,6 +86,9 @@ try {
       }
       if (typeof verifyCanonicalRefreshCompletion !== "function") {
         throw new Error("canonical refresh completion verifier API is missing");
+      }
+      if (typeof migrateAllLegacyEnrichedFiles !== "function") {
+        throw new Error("legacy enriched migration API is missing");
       }
       const rate = await publishCanonicalRateSlice(store, "sofr_rates", "2026-04-30");
       if (rate.value.annualRateBasisPoints !== 366 || rate.value.series !== "sofr") {
@@ -196,19 +200,22 @@ try {
 
   writeFileSync(
     join(consumerDir, "consumer.ts"),
-    `import { ContentObjectStore, PartitionFileIntegrityError, publishCanonicalRateSlice, verifyCanonicalRefreshCompletion, type CanonicalJsonAddress, type CanonicalRateSliceV1, type CanonicalRefreshCompletionV2, type CutoffManifestV1, type MaterializedResolverClassV1 } from "tradeblocks-mcp/market/provenance";\n` +
+    `import { ContentObjectStore, PartitionFileIntegrityError, migrateAllLegacyEnrichedFiles, publishCanonicalRateSlice, verifyCanonicalRefreshCompletion, type CanonicalJsonAddress, type CanonicalRateSliceV1, type CanonicalRefreshCompletionV2, type CutoffManifestV1, type LegacyMigrationBounds, type MaterializedResolverClassV1 } from "tradeblocks-mcp/market/provenance";\n` +
       `const store = new ContentObjectStore("/tmp/provenance-types");\n` +
       `const address: CanonicalJsonAddress = "sha256:${"0".repeat(64)}";\n` +
       `const manifest: CutoffManifestV1 | undefined = undefined;\n` +
       `const completion: CanonicalRefreshCompletionV2 | undefined = undefined;\n` +
       `const rate: CanonicalRateSliceV1 | undefined = undefined;\n` +
       `const materialized: MaterializedResolverClassV1 | undefined = undefined;\n` +
+      `const migrationBounds: LegacyMigrationBounds = { to: "2026-07-20" };\n` +
       `void PartitionFileIntegrityError;\n` +
       `void verifyCanonicalRefreshCompletion;\n` +
       `void completion;\n` +
       `void publishCanonicalRateSlice;\n` +
       `void rate;\n` +
       `void materialized;\n` +
+      `void migrateAllLegacyEnrichedFiles;\n` +
+      `void migrationBounds;\n` +
       `void manifest;\n` +
       `void store.get(address);\n`,
   );

--- a/packages/mcp-server/src/market/provenance/canonical-market-resolver.ts
+++ b/packages/mcp-server/src/market/provenance/canonical-market-resolver.ts
@@ -1,3 +1,4 @@
+import type { DuckDBConnection } from "@duckdb/node-api";
 import { constants } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
@@ -17,7 +18,10 @@ import {
   publishInputResolverRegistry,
   publishMissingProbeEvidence,
   publishSemanticInputLeaf,
+  restrictInputClosureDescriptor,
   verifyCutoffManifest,
+  verifyInputClosure,
+  verifyInputResolverRegistry,
   verifySemanticInputLeaf,
 } from "./content-manifest.ts";
 import {
@@ -25,7 +29,11 @@ import {
   isRealMarketSessionDate,
   type BoundedMarketDatasetDefinition,
 } from "./dataset-registry.ts";
-import { FilePartitionCommitStore } from "./partition-commit-store.ts";
+import {
+  FilePartitionCommitStore,
+  INTERNAL_HISTORICAL_PARTITION_ADOPTION,
+  type StoredPartitionCommit,
+} from "./partition-commit-store.ts";
 import {
   XNYS_SESSION_CALENDAR_REVISION,
   enumerateXnysSessions,
@@ -47,6 +55,12 @@ export interface CanonicalControlIdentity {
 export interface PublishCanonicalMarketRegistryInput {
   /** Engine-observed data-root-relative control paths. */
   controlFiles?: readonly string[];
+}
+
+export interface AdoptCanonicalHistoricalClosureResult {
+  readonly closure: CanonicalJsonAddress;
+  readonly completeThrough: string;
+  readonly receipts: readonly StoredPartitionCommit[];
 }
 
 function compareCodePoints(left: string, right: string): number {
@@ -149,6 +163,97 @@ export async function publishCanonicalMarketResolverRegistry(
   return publishInputResolverRegistry(objects, {
     revision: `${CANONICAL_MARKET_RESOLVER_REVISION}.${XNYS_SESSION_CALENDAR_REVISION}`,
     classes: canonicalRegistryClasses(controls),
+  });
+}
+
+/**
+ * Bring existing canonical-layout Parquet bytes under producer authority for
+ * one authenticated input closure. The caller cannot nominate arbitrary files:
+ * identities are derived only from the verified canonical registry + closure,
+ * and the store independently validates schema, partition values, coverage,
+ * row count, inode stability, and exact bytes before publishing each receipt.
+ *
+ * This is the bounded migration seam for data that predates receipt stamping.
+ * It deliberately does not mint refresh-completion authority or a cutoff; a
+ * normal canonical refresh must still finalize the requested tail session.
+ */
+export async function adoptCanonicalHistoricalInputClosure(
+  partitions: FilePartitionCommitStore,
+  conn: DuckDBConnection,
+  closureAddress: CanonicalJsonAddress,
+  completeThrough: string,
+): Promise<AdoptCanonicalHistoricalClosureResult> {
+  if (!isXnysSessionDate(completeThrough)) {
+    throw new Error(
+      `Historical adoption cutoff is not a supported XNYS session: ${completeThrough}`,
+    );
+  }
+  const verifiedClosure = await verifyInputClosure(partitions.objects, closureAddress);
+  const registryObject = await verifyInputResolverRegistry(
+    partitions.objects,
+    verifiedClosure.value.registry,
+  );
+  validateCanonicalRegistry(registryObject.value);
+  const closure = restrictInputClosureDescriptor(verifiedClosure.value, completeThrough);
+  const identities = new Map<string, { dataset: string; partition: Record<string, string> }>();
+
+  for (const observation of closure.observations) {
+    if (observation.kind === "unmanifestable") {
+      throw new Error(`Historical adoption closure is unmanifestable: ${observation.reasonCode}`);
+    }
+    if (observation.kind === "control-file") continue;
+    if (
+      (observation.kind === "exact" || observation.kind === "missing-probe") &&
+      !isXnysSessionDate(observation.session)
+    ) {
+      throw new Error(
+        `Historical adoption ${observation.kind} is not an XNYS session: ${observation.session}`,
+      );
+    }
+    if (observation.kind === "missing-probe") {
+      const resolverClass = registryObject.value.classes.find(
+        (entry) => entry.dataClass === observation.dataClass,
+      );
+      if (!resolverClass || resolverClass.kind !== "partitioned") {
+        throw new Error("Historical adoption missing-probe is not partition-backed");
+      }
+      const inspected = await partitions.inspectPartition({
+        dataset: resolverClass.dataset,
+        partition: observation.selector,
+      });
+      if (inspected.status !== "absent") {
+        throw new Error(
+          `Historical adoption missing-probe is no longer absent: ${resolverClass.dataset} ${canonicalJson(observation.selector)} (${inspected.status})`,
+        );
+      }
+      continue;
+    }
+    const resolverClass = requireCanonicalClass(registryObject.value, observation);
+    if (resolverClass.kind !== "partitioned") continue;
+    const sessions =
+      observation.kind === "exact"
+        ? [sessionFromObservation(observation) as string]
+        : enumerateXnysSessions(observation.fromSession, observation.throughSession);
+    for (const session of sessions) {
+      const partition =
+        observation.kind === "exact"
+          ? { ...observation.selector }
+          : { ...observation.selectorPrefix, [resolverClass.sessionKey]: session };
+      const identity = { dataset: resolverClass.dataset, partition };
+      identities.set(canonicalJson(identity), identity);
+    }
+  }
+
+  const receipts: StoredPartitionCommit[] = [];
+  for (const identity of [...identities.values()].sort((left, right) =>
+    compareCodePoints(canonicalJson(left), canonicalJson(right)),
+  )) {
+    receipts.push(await partitions[INTERNAL_HISTORICAL_PARTITION_ADOPTION](conn, identity));
+  }
+  return Object.freeze({
+    closure: verifiedClosure.address,
+    completeThrough,
+    receipts: Object.freeze(receipts),
   });
 }
 

--- a/packages/mcp-server/src/market/provenance/index.ts
+++ b/packages/mcp-server/src/market/provenance/index.ts
@@ -49,15 +49,22 @@ export {
   enumerateXnysSessions,
 } from "./xnys-session-calendar.ts";
 export {
+  LegacyEnrichedMigrationError,
+  migrateAllLegacyEnrichedFiles,
+  type LegacyMigrationBounds,
+} from "../stores/enriched-legacy-migration.ts";
+export {
   CANONICAL_MARKET_RESOLVER_REVISION,
   BLACKOUT_SLICE_KIND,
   BLACKOUT_SLICE_VERSION,
   canonicalControlIdentity,
+  adoptCanonicalHistoricalInputClosure,
   publishCanonicalMarketResolverRegistry,
   CanonicalMarketInputResolver,
   verifyCanonicalMarketDataCutoff,
   proveCanonicalMarketDataPrefix,
   type CanonicalControlIdentity,
+  type AdoptCanonicalHistoricalClosureResult,
   type PublishCanonicalMarketRegistryInput,
 } from "./canonical-market-resolver.ts";
 export {

--- a/packages/mcp-server/src/market/provenance/partition-commit-store.ts
+++ b/packages/mcp-server/src/market/provenance/partition-commit-store.ts
@@ -148,6 +148,7 @@ interface AuthorityTip {
 type PartitionCommitTestFaultPoint =
   | "after-claim-open"
   | "after-event-before-head"
+  | "historical-after-snapshot"
   | "before-release-claim";
 const partitionCommitTestFaults = new WeakMap<
   FilePartitionCommitStore,
@@ -593,6 +594,39 @@ async function exactFileAddress(filePath: string): Promise<Omit<ExactFileFingerp
   } finally {
     await opened.handle.close();
   }
+}
+
+async function snapshotOpenFile(
+  source: fs.FileHandle,
+  snapshotPath: string,
+): Promise<Omit<ExactFileFingerprint, "rows">> {
+  const snapshot = await fs.open(snapshotPath, "wx", 0o400);
+  const hash = createHash("sha256");
+  let bytes = 0;
+  const buffer = Buffer.allocUnsafe(1024 * 1024);
+  try {
+    while (true) {
+      const read = await source.read(buffer, 0, buffer.byteLength, bytes);
+      if (read.bytesRead === 0) break;
+      hash.update(buffer.subarray(0, read.bytesRead));
+      let written = 0;
+      while (written < read.bytesRead) {
+        const result = await snapshot.write(
+          buffer,
+          written,
+          read.bytesRead - written,
+          bytes + written,
+        );
+        if (result.bytesWritten === 0) throw new Error("Unable to write inspection snapshot");
+        written += result.bytesWritten;
+      }
+      bytes += read.bytesRead;
+    }
+    await snapshot.sync();
+  } finally {
+    await snapshot.close();
+  }
+  return { address: `sha256:${hash.digest("hex")}`, bytes };
 }
 
 function sameCommitContent(
@@ -1292,30 +1326,81 @@ export class FilePartitionCommitStore implements PartitionCommitRecorder {
     conn: DuckDBConnection,
     identity: PartitionIdentity,
   ): Promise<StoredPartitionCommit> {
-    const captured = JSON.parse(canonicalJsonBytes(identity).toString("utf8")) as PartitionIdentity;
-    validateIdentity(captured);
+    const captured = captureIdentity(identity);
     const definition = canonicalPartitionDataset(captured.dataset) as NonNullable<
       ReturnType<typeof canonicalPartitionDataset>
     >;
     const relativePath = canonicalRelativePath(captured);
     const targetPath = path.resolve(this.targetPath(relativePath));
-    const before = await exactFileAddress(targetPath);
-    const inspected = await inspectCanonicalParquet(conn, targetPath, captured);
-    const after = await exactFileAddress(targetPath);
-    if (before.address !== after.address || before.bytes !== after.bytes) {
-      throw new PartitionFileIntegrityError(
-        targetPath,
-        "existing Parquet changed during semantic inspection",
-      );
-    }
-    return this.adoptExistingFileCommit({
-      dataset: captured.dataset,
-      partition: captured.partition,
-      schemaRevision: definition.schemaRevision,
-      relativePath,
-      coverage: inspected.coverage,
-      quality: { inputRows: inspected.rows, writtenRows: inspected.rows, droppedRows: 0 },
-      file: { ...after, rows: inspected.rows },
+    return this.withPartitionLock(captured, async () => {
+      const realMarketRoot = await this.validateMarketRoot();
+      const validatedTargetPath = await this.validatedTargetPath(relativePath, realMarketRoot);
+      if (validatedTargetPath !== targetPath) {
+        throw new PartitionFileIntegrityError(
+          validatedTargetPath,
+          "validated target differs from the registered path",
+        );
+      }
+      const opened = await openRegularFileNoFollow(targetPath);
+      const snapshotRoot = path.join(this.provenanceRootDir, "inspection-snapshots");
+      await this.ensureDurableDirectory(snapshotRoot);
+      const snapshotDir = await fs.mkdtemp(path.join(snapshotRoot, "adopt-"));
+      const snapshotPath = path.join(snapshotDir, "partition.parquet");
+      try {
+        const snapshotFingerprint = await snapshotOpenFile(opened.handle, snapshotPath);
+        const snapshotObserved = await exactFileAddress(snapshotPath);
+        if (
+          snapshotObserved.address !== snapshotFingerprint.address ||
+          snapshotObserved.bytes !== snapshotFingerprint.bytes
+        ) {
+          throw new PartitionFileIntegrityError(
+            snapshotPath,
+            "inspection snapshot bytes disagree with the pinned canonical inode",
+          );
+        }
+        await partitionCommitTestFaults.get(this)?.("historical-after-snapshot");
+        const inspected = await inspectCanonicalParquet(conn, snapshotPath, captured);
+        const snapshotAfter = await exactFileAddress(snapshotPath);
+        if (
+          snapshotAfter.address !== snapshotFingerprint.address ||
+          snapshotAfter.bytes !== snapshotFingerprint.bytes
+        ) {
+          throw new PartitionFileIntegrityError(
+            snapshotPath,
+            "inspection snapshot changed during semantic inspection",
+          );
+        }
+        const canonicalAfter = await exactOpenFileAddress(opened.handle);
+        const afterStat = await opened.handle.stat();
+        if (
+          !afterStat.isFile() ||
+          afterStat.nlink !== 1 ||
+          !sameInode(opened.stat, afterStat) ||
+          canonicalAfter.address !== snapshotFingerprint.address ||
+          canonicalAfter.bytes !== snapshotFingerprint.bytes
+        ) {
+          throw new PartitionFileIntegrityError(
+            targetPath,
+            "canonical inode changed during historical semantic inspection",
+          );
+        }
+        await requireNamedRegularInode(targetPath, opened.stat);
+        return this.adoptExistingFileCommit(
+          {
+            dataset: captured.dataset,
+            partition: captured.partition,
+            schemaRevision: definition.schemaRevision,
+            relativePath,
+            coverage: inspected.coverage,
+            quality: { inputRows: inspected.rows, writtenRows: inspected.rows, droppedRows: 0 },
+            file: { ...snapshotFingerprint, rows: inspected.rows },
+          },
+          true,
+        );
+      } finally {
+        await opened.handle.close();
+        await fs.rm(snapshotDir, { recursive: true });
+      }
     });
   }
 
@@ -1327,11 +1412,12 @@ export class FilePartitionCommitStore implements PartitionCommitRecorder {
    */
   private async adoptExistingFileCommit(
     input: RecordPartitionCommitInput,
+    lockHeld = false,
   ): Promise<StoredPartitionCommit> {
     const captured = captureInput(input);
     const targetPath = path.resolve(this.targetPath(captured.relativePath));
     const realMarketRoot = await this.validateMarketRoot();
-    return this.withPartitionLock(captured, async () => {
+    const adopt = async () => {
       const validatedTargetPath = await this.validatedTargetPath(
         captured.relativePath,
         realMarketRoot,
@@ -1443,7 +1529,8 @@ export class FilePartitionCommitStore implements PartitionCommitRecorder {
       } finally {
         await handle.close();
       }
-    });
+    };
+    return lockHeld ? adopt() : this.withPartitionLock(captured, adopt);
   }
 
   async publishFileCommit(input: PublishPartitionFileInput): Promise<StoredPartitionCommit> {

--- a/packages/mcp-server/src/test-exports.ts
+++ b/packages/mcp-server/src/test-exports.ts
@@ -363,6 +363,7 @@ export {
   BLACKOUT_SLICE_KIND,
   BLACKOUT_SLICE_VERSION,
   canonicalControlIdentity,
+  adoptCanonicalHistoricalInputClosure,
   publishCanonicalMarketResolverRegistry,
   CanonicalMarketInputResolver,
   verifyCanonicalMarketDataCutoff,

--- a/packages/mcp-server/tests/unit/market-provenance.test.ts
+++ b/packages/mcp-server/tests/unit/market-provenance.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "@jest/globals";
-import { DuckDBInstance } from "@duckdb/node-api";
+import { DuckDBInstance, type DuckDBConnection } from "@duckdb/node-api";
 import { createHash } from "node:crypto";
 import {
   chmodSync,
@@ -24,10 +24,13 @@ import {
   FilePartitionCommitStore,
   PartitionFileIntegrityError,
   PartitionFilePublicationError,
+  adoptCanonicalHistoricalInputClosure,
   addressBytes,
   addressCanonicalJson,
   canonicalJson,
   parseCanonicalJsonAddress,
+  publishCanonicalMarketResolverRegistry,
+  publishInputClosure,
   setPartitionCommitTestFault,
 } from "../../src/test-exports.ts";
 import { INTERNAL_HISTORICAL_PARTITION_ADOPTION } from "../../src/market/provenance/partition-commit-store.ts";
@@ -160,6 +163,29 @@ describe("market-data provenance foundation", () => {
     const targetFor = (partition: Record<string, string>) =>
       join(rootDir, "spot", `ticker=${partition.ticker}`, `date=${partition.date}`, "data.parquet");
 
+    const writeCanonicalSpot = async (
+      conn: DuckDBConnection,
+      partition: Record<string, string>,
+      close = 225.5,
+    ) => {
+      const targetPath = targetFor(partition);
+      mkdirSync(dirname(targetPath), { recursive: true });
+      await conn.run(`
+        COPY (
+          SELECT '${partition.ticker}'::VARCHAR AS ticker,
+                 '${partition.date}'::VARCHAR AS date,
+                 '09:30'::VARCHAR AS time,
+                 225.0::DOUBLE AS open,
+                 226.0::DOUBLE AS high,
+                 224.0::DOUBLE AS low,
+                 ${close}::DOUBLE AS close,
+                 NULL::DOUBLE AS bid,
+                 NULL::DOUBLE AS ask
+        ) TO '${targetPath.replaceAll("'", "''")}' (FORMAT PARQUET)
+      `);
+      return targetPath;
+    };
+
     const publicationInput = (preparedPath: string, targetPath: string, bytes: Buffer) => ({
       ...identity,
       relativePath,
@@ -275,6 +301,190 @@ describe("market-data provenance foundation", () => {
           store[INTERNAL_HISTORICAL_PARTITION_ADOPTION](conn, wrongIdentity),
         ).rejects.toThrow(/rows disagree with the registered partition/);
       } finally {
+        conn.closeSync();
+        instance.closeSync();
+      }
+    });
+
+    it("adopts only the authenticated historical closure and keeps the cutoff tail separate", async () => {
+      const store = new FilePartitionCommitStore(rootDir);
+      const targetPath = targetFor(identity.partition);
+      mkdirSync(dirname(targetPath), { recursive: true });
+      const instance = await DuckDBInstance.create(":memory:");
+      const conn = await instance.connect();
+      try {
+        await conn.run(`
+          COPY (
+            SELECT 'IWM'::VARCHAR AS ticker,
+                   '2026-07-20'::VARCHAR AS date,
+                   '09:30'::VARCHAR AS time,
+                   225.0::DOUBLE AS open,
+                   226.0::DOUBLE AS high,
+                   224.0::DOUBLE AS low,
+                   225.5::DOUBLE AS close,
+                   NULL::DOUBLE AS bid,
+                   NULL::DOUBLE AS ask
+          ) TO '${targetPath.replaceAll("'", "''")}' (FORMAT PARQUET)
+        `);
+        const registry = await publishCanonicalMarketResolverRegistry(store.objects);
+        const closure = await publishInputClosure(store.objects, {
+          registry: registry.address,
+          observations: [
+            {
+              kind: "exact",
+              dataClass: "spot",
+              selector: identity.partition,
+              session: "2026-07-20",
+            },
+          ],
+        });
+
+        const adopted = await adoptCanonicalHistoricalInputClosure(
+          store,
+          conn,
+          closure.address,
+          "2026-07-20",
+        );
+
+        expect(adopted.closure).toBe(closure.address);
+        expect(adopted.receipts).toHaveLength(1);
+        await expect(store.inspectPartition(identity)).resolves.toMatchObject({ status: "match" });
+        expect(existsSync(join(rootDir, ".provenance", "refresh-completions"))).toBe(false);
+      } finally {
+        conn.closeSync();
+        instance.closeSync();
+      }
+    });
+
+    it("restricts range adoption to the requested XNYS prefix", async () => {
+      const store = new FilePartitionCommitStore(rootDir);
+      const source = { ticker: "IWM", date: "2026-07-17" };
+      const tail = { ticker: "IWM", date: "2026-07-20" };
+      const instance = await DuckDBInstance.create(":memory:");
+      const conn = await instance.connect();
+      try {
+        await writeCanonicalSpot(conn, source);
+        await writeCanonicalSpot(conn, tail);
+        const registry = await publishCanonicalMarketResolverRegistry(store.objects);
+        const closure = await publishInputClosure(store.objects, {
+          registry: registry.address,
+          observations: [
+            {
+              kind: "range",
+              dataClass: "spot",
+              selectorPrefix: { ticker: "IWM" },
+              fromSession: source.date,
+              throughSession: tail.date,
+            },
+          ],
+        });
+
+        const adopted = await adoptCanonicalHistoricalInputClosure(
+          store,
+          conn,
+          closure.address,
+          source.date,
+        );
+
+        expect(adopted.receipts).toHaveLength(1);
+        await expect(
+          store.inspectPartition({ dataset: "spot", partition: source }),
+        ).resolves.toMatchObject({ status: "match" });
+        await expect(
+          store.inspectPartition({ dataset: "spot", partition: tail }),
+        ).resolves.toMatchObject({ status: "orphan" });
+      } finally {
+        conn.closeSync();
+        instance.closeSync();
+      }
+    });
+
+    it("requires missing probes to remain absent", async () => {
+      const store = new FilePartitionCommitStore(rootDir);
+      const exact = { ticker: "IWM", date: "2026-07-17" };
+      const probe = { ticker: "IWM", date: "2026-07-20" };
+      const instance = await DuckDBInstance.create(":memory:");
+      const conn = await instance.connect();
+      try {
+        await writeCanonicalSpot(conn, exact);
+        const registry = await publishCanonicalMarketResolverRegistry(store.objects);
+        const closure = await publishInputClosure(store.objects, {
+          registry: registry.address,
+          observations: [
+            { kind: "exact", dataClass: "spot", selector: exact, session: exact.date },
+            { kind: "missing-probe", dataClass: "spot", selector: probe, session: probe.date },
+          ],
+        });
+
+        await expect(
+          adoptCanonicalHistoricalInputClosure(store, conn, closure.address, probe.date),
+        ).resolves.toMatchObject({ receipts: [expect.any(Object)] });
+
+        await writeCanonicalSpot(conn, probe);
+        await expect(
+          adoptCanonicalHistoricalInputClosure(store, conn, closure.address, probe.date),
+        ).rejects.toThrow(/missing-probe is no longer absent.*orphan/);
+
+        unlinkSync(targetFor(probe));
+        await publish(store, { bytes: Buffer.from("committed-probe"), rows: 1 });
+        await expect(
+          adoptCanonicalHistoricalInputClosure(store, conn, closure.address, probe.date),
+        ).rejects.toThrow(/missing-probe is no longer absent.*match/);
+
+        unlinkSync(targetFor(probe));
+        await expect(
+          adoptCanonicalHistoricalInputClosure(store, conn, closure.address, probe.date),
+        ).rejects.toThrow(/missing-probe is no longer absent.*missing/);
+      } finally {
+        conn.closeSync();
+        instance.closeSync();
+      }
+    });
+
+    it.each(["exact", "missing-probe"] as const)(
+      "rejects a non-XNYS %s observation",
+      async (kind) => {
+        const store = new FilePartitionCommitStore(rootDir);
+        const weekend = { ticker: "IWM", date: "2026-07-18" };
+        const instance = await DuckDBInstance.create(":memory:");
+        const conn = await instance.connect();
+        try {
+          const registry = await publishCanonicalMarketResolverRegistry(store.objects);
+          const closure = await publishInputClosure(store.objects, {
+            registry: registry.address,
+            observations: [{ kind, dataClass: "spot", selector: weekend, session: weekend.date }],
+          });
+
+          await expect(
+            adoptCanonicalHistoricalInputClosure(store, conn, closure.address, "2026-07-20"),
+          ).rejects.toThrow(/is not an XNYS session/);
+        } finally {
+          conn.closeSync();
+          instance.closeSync();
+        }
+      },
+    );
+
+    it("refuses a canonical-name inode swap after capturing the inspection snapshot", async () => {
+      const store = new FilePartitionCommitStore(rootDir);
+      const targetPath = targetFor(identity.partition);
+      const displacedPath = join(externalDir, "historical-displaced.parquet");
+      const instance = await DuckDBInstance.create(":memory:");
+      const conn = await instance.connect();
+      try {
+        await writeCanonicalSpot(conn, identity.partition);
+        setPartitionCommitTestFault(store, (point) => {
+          if (point !== "historical-after-snapshot") return;
+          renameSync(targetPath, displacedPath);
+          writeFileSync(targetPath, "attacker replacement");
+        });
+
+        await expect(
+          store[INTERNAL_HISTORICAL_PARTITION_ADOPTION](conn, identity),
+        ).rejects.toBeInstanceOf(PartitionFileIntegrityError);
+        await expect(store.inspectPartition(identity)).resolves.toMatchObject({ status: "orphan" });
+      } finally {
+        setPartitionCommitTestFault(store);
         conn.closeSync();
         instance.closeSync();
       }

--- a/releases/v3.5.0.md
+++ b/releases/v3.5.0.md
@@ -1,0 +1,24 @@
+# Tradeblocks 3.5.0
+
+## Canonical historical input adoption
+
+`tradeblocks-mcp/market/provenance` now exports
+`adoptCanonicalHistoricalInputClosure()`, a producer-owned migration seam for
+canonical-layout Parquet data that predates partition receipt stamping.
+
+The function accepts an authenticated input-closure address and cutoff, derives
+the bounded partition identities from the verified canonical registry, and
+independently checks each existing file's schema, partition values, session
+coverage, row count, inode stability, and exact bytes before publishing a
+receipt. Callers cannot nominate arbitrary file paths or self-assert coverage.
+Missing probes must still be absent; materialized and control inputs retain
+their existing content-object paths.
+
+Historical adoption intentionally does not create refresh-completion authority
+or a cutoff manifest. A normal canonical refresh must still finalize the cutoff
+tail. Existing refresh and provenance behavior is unchanged unless the new
+function is called.
+
+The same production subpath now exports `migrateAllLegacyEnrichedFiles()` and
+its bounded migration options, so callers can split legacy whole-file enriched
+data into canonical session partitions without depending on test-only exports.


### PR DESCRIPTION
Tier: 3 — publishes a bounded historical provenance-migration API
Worktree: `/home/romeo/code/tradeblocks-org/tradeblocks-fix-provenance-closure-backfill`

## Summary

- add a closure-scoped migration API that derives partition identities from a verified canonical registry and input closure
- prove existing Parquet semantics against a private immutable snapshot while holding the partition lock, then bind the receipt to the still-canonical inode and exact bytes
- preserve missing probes, reject non-session identities, and leave cutoff authority to the normal canonical refresh path
- expose the bounded legacy-enriched migration through the production provenance subpath
- release the additive surface as 3.5.0 with no default behavior change

## Validation

- `npm run test:mcp` — 136 suites, 1,783 tests passed
- root typecheck and lint passed
- focused provenance and legacy-migration contracts — 59 tests passed
- packed `.tgz` runtime and NodeNext declaration verification passed under Node 18
- export-surface and changed-file Prettier checks passed
- `git diff --check` passed
