### PR TITLE
fix(release): sync mcp-server version to 3.6.0 with root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22409,7 +22409,7 @@
     },
     "packages/mcp-server": {
       "name": "tradeblocks-mcp",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "license": "MIT",
       "dependencies": {
         "@duckdb/node-api": "^1.4.4-r.4",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks-mcp",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "MCP server for options trade analysis",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "type": "module",


### PR DESCRIPTION
## Problem

The release run on master ([#93](https://github.com/tradeblocks-org/tradeblocks/actions/runs/29946480576)) failed at **Verify root and package versions are in sync**:

> Version divergence: root package.json (3.6.0) != packages/mcp-server/package.json (3.5.0). This pipeline publishes off the mcp-server version, so a mismatch silently skips the npm publish (the release no-ops green and nothing ships).

PR #389 bumped root `package.json` to `3.6.0` and added `releases/v3.6.0.md`, but left `packages/mcp-server/package.json` at `3.5.0`.

## Fix

Bump `tradeblocks-mcp` to `3.6.0` in `packages/mcp-server/package.json` and its `package-lock.json` entry (regenerated via `npm install --package-lock-only`) to restore lockstep. The intended release target of 3.6.0 is unchanged.

## Verification

- Reproduced the CI gate locally: root `3.6.0` == mcp `3.6.0` → **SYNC OK**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
