### PR TITLE
fix(provenance): accept immutable manifest self-prefix

### DIFF
--- a/packages/mcp-server/src/market/provenance/content-manifest.ts
+++ b/packages/mcp-server/src/market/provenance/content-manifest.ts
@@ -1834,6 +1834,12 @@ export async function proveCutoffManifestPrefix(
 ): Promise<{ valid: boolean; reason?: string }> {
   const ancestor = await verifyCutoffManifest(partitions, ancestorAddress, resolver);
   const descendant = await verifyCutoffManifest(partitions, descendantAddress, resolver);
+  // Prefix is reflexive for one immutable, content-addressed manifest. This is
+  // the producer proof used by already-current resume operations: both reads
+  // above still re-verify the exact object before equality is accepted.
+  if (ancestorAddress === descendantAddress) {
+    return { valid: true };
+  }
   if (ancestor.manifest.completeThrough >= descendant.manifest.completeThrough) {
     return { valid: false, reason: "cutoff-not-increasing" };
   }

--- a/packages/mcp-server/tests/unit/canonical-market-resolver.test.ts
+++ b/packages/mcp-server/tests/unit/canonical-market-resolver.test.ts
@@ -340,6 +340,9 @@ describe("producer-owned canonical market resolver", () => {
     });
 
     await expect(
+      proveCanonicalMarketDataPrefix(partitions, ancestor.address, ancestor.address),
+    ).resolves.toEqual({ valid: true });
+    await expect(
       proveCanonicalMarketDataPrefix(partitions, ancestor.address, descendant.address),
     ).resolves.toEqual({ valid: true });
     const verified = await verifyCanonicalMarketDataCutoff(partitions, descendant.address);

--- a/packages/mcp-server/tests/unit/content-manifest.test.ts
+++ b/packages/mcp-server/tests/unit/content-manifest.test.ts
@@ -655,6 +655,25 @@ describe("market-data content manifests", () => {
     });
 
     await expect(
+      proveCutoffManifestPrefix(partitions, ancestor.address, ancestor.address, resolver),
+    ).resolves.toEqual({ valid: true });
+
+    const sameCutoffDifferentManifest = await publishCutoffManifest(partitions, {
+      closure: ancestorClosure.address,
+      completeThrough: "2026-07-20",
+      resolver,
+      predecessor: { manifest: ancestor.address, aggregateRoot: ancestor.value.aggregateRoot },
+    });
+    await expect(
+      proveCutoffManifestPrefix(
+        partitions,
+        ancestor.address,
+        sameCutoffDifferentManifest.address,
+        resolver,
+      ),
+    ).resolves.toEqual({ valid: false, reason: "cutoff-not-increasing" });
+
+    await expect(
       proveCutoffManifestPrefix(partitions, ancestor.address, descendant.address, resolver),
     ).resolves.toMatchObject({ valid: true });
 


### PR DESCRIPTION
Tier: 2 — published provenance-contract correction under the current ADR 0004 public-repo route

Worktree: /home/romeo/code/tradeblocks-org/tradeblocks-romeo-1435-reflexive-prefix

## What changed

- Treat one fully verified immutable cutoff manifest as a valid prefix of itself.
- Continue rejecting distinct manifests at the same cutoff as `cutoff-not-increasing`.
- Cover both the low-level proof and the canonical market-data wrapper.

## Why

Enterprise #1435 quiet carry supplies the same source and target manifest by design. Both Holodeck authority checks call this producer proof, but the strict date comparison rejected exact address equality before the engine could prove idempotent carry.

## Validation

- Focused provenance tests: 20/20
- Full MCP suite: 136 suites, 1,783 tests
- Typecheck: pass
- Lint: pass
- Changed-file Prettier and `git diff --check`: pass
- MCP build: pass

Repository-wide Prettier still reports the ignored generated `packages/mcp-server/src/utils/iv-solver-worker.js`; this diff does not touch or track that generated file.