### PR TITLE
fix(mcp-server): release the DuckDB lock when the launcher process dies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tradeblocks",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tradeblocks",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "workspaces": [
         "packages/*"
       ],
@@ -22561,7 +22561,7 @@
     },
     "packages/mcp-server": {
       "name": "tradeblocks-mcp",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "license": "MIT",
       "dependencies": {
         "@duckdb/node-api": "^1.4.4-r.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "private": true,
   "workspaces": [

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks-mcp",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "MCP server for options trade analysis",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "type": "module",

--- a/packages/mcp-server/src/db/connection.ts
+++ b/packages/mcp-server/src/db/connection.ts
@@ -66,7 +66,10 @@ let storedThreads: string | null = null;
 let storedMemoryLimit: string | null = null;
 let storedMarketDbPath: string | null = null;
 const execFileAsync = promisify(execFile);
-const isWindows = process.platform === "win32";
+// Exported so other lock-recovery-adjacent callers (e.g. the stdio
+// parent-death watchdog in index.ts) can branch on platform without
+// re-deriving it.
+export const isWindows = process.platform === "win32";
 
 /**
  * Default DuckDB memory limit when `DUCKDB_MEMORY_LIMIT` is unset.
@@ -112,7 +115,10 @@ function parseLockHolderPid(message: string): number | null {
   return Number.isFinite(pid) ? pid : null;
 }
 
-function isProcessAlive(pid: number): boolean {
+// Exported so other lock-recovery-adjacent callers (e.g. the stdio
+// parent-death watchdog in index.ts) can reuse this instead of reimplementing
+// a `process.kill(pid, 0)` liveness probe.
+export function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -40,10 +40,16 @@ import { registerMarketFetchTools } from "./tools/market-fetch.ts";
 import { registerTickerTools } from "./tools/tickers.ts";
 import { loadRegistry } from "./market/tickers/loader.ts";
 import { closeConnection, getConnection, getCurrentConnection } from "./db/index.ts";
+import { isProcessAlive, isWindows } from "./db/connection.ts";
 import { setDataRoot } from "./db/data-root.ts";
 import { createMarketStores } from "./market/stores/index.ts";
 import type { StoreContext, MarketStores } from "./market/stores/index.ts";
 import type { TradeBlocksPlugin, TradeBlocksPluginContext } from "./plugins.ts";
+import { shouldShutdownOnParentChange } from "./parent-watchdog.ts";
+
+// How often the stdio parent-death watchdog polls process.ppid. See the
+// watchdog install site in startTradeBlocksMcp() below.
+const PARENT_WATCHDOG_INTERVAL_MS = 2000;
 
 export interface StartTradeBlocksMcpOptions {
   plugins?: TradeBlocksPlugin[];
@@ -341,6 +347,14 @@ export async function startTradeBlocksMcp(options: StartTradeBlocksMcpOptions = 
     return server;
   };
 
+  // Graceful shutdown for DuckDB connection
+  // The connection is lazily initialized, so this only does work if a tool
+  // actually opened the database during this session
+  const shutdown = async () => {
+    await closeConnection();
+    process.exit(0);
+  };
+
   if (http) {
     // Load auth config for HTTP mode
     const { loadAuthConfig } = await import("./auth/config.ts");
@@ -370,15 +384,47 @@ export async function startTradeBlocksMcp(options: StartTradeBlocksMcpOptions = 
       await closeConnection();
       process.exit(0);
     });
+
+    // Proactive parent-death watchdog — defense in depth alongside the
+    // stdin/SIGTERM/SIGINT handlers above.
+    //
+    // Some launchers (e.g. `npx tradeblocks-mcp ...`) sit between the real
+    // client and this process: client -> launcher -> node (this process). If
+    // the launcher is killed without cleanly propagating a signal to us, we
+    // are orphaned (reparented on Unix) and NEITHER handler above fires: no
+    // SIGTERM/SIGINT ever arrives (only the launcher got it, if anything
+    // did), and stdin never EOFs because the client — not the launcher —
+    // holds the pipe's write-end. Left alone we'd linger holding the DuckDB
+    // analytics database's write lock, and the next session's connection
+    // attempt would fail with a stale-lock error.
+    //
+    // See shouldShutdownOnParentChange for the cross-platform decision logic.
+    const startupPpid = process.ppid;
+    const startAlreadyOrphaned = !isWindows && startupPpid === 1;
+    if (!startAlreadyOrphaned) {
+      // Skip installing entirely when we start already orphaned (Unix PPID 1,
+      // e.g. launched under systemd) — there is no launcher to watch, and a
+      // systemd-launched process must never self-terminate on that basis.
+      const watchdog = setInterval(() => {
+        const shutdownNeeded = shouldShutdownOnParentChange({
+          isWindows,
+          startupPpid,
+          currentPpid: process.ppid,
+          // Windows PPID doesn't change when the parent dies, so liveness of
+          // the ORIGINAL parent is the only usable signal there. Skip the
+          // liveness probe on Unix, where it's unused by the decision fn.
+          startupParentAlive: isWindows ? isProcessAlive(startupPpid) : true,
+        });
+        if (shutdownNeeded) {
+          clearInterval(watchdog);
+          void shutdown();
+        }
+      }, PARENT_WATCHDOG_INTERVAL_MS);
+      // Never let the watchdog's own timer keep the process alive.
+      watchdog.unref();
+    }
   }
 
-  // Graceful shutdown for DuckDB connection
-  // The connection is lazily initialized, so this only does work if a tool
-  // actually opened the database during this session
-  const shutdown = async () => {
-    await closeConnection();
-    process.exit(0);
-  };
   process.on("SIGINT", shutdown);
   process.on("SIGTERM", shutdown);
 }

--- a/packages/mcp-server/src/parent-watchdog.ts
+++ b/packages/mcp-server/src/parent-watchdog.ts
@@ -1,0 +1,60 @@
+/**
+ * Parent-death detection for the stdio MCP transport.
+ *
+ * Some launchers (e.g. `npx tradeblocks-mcp ...`) sit between the real
+ * client and this process: client -> launcher -> node (MCP server). If the
+ * launcher is killed without cleanly propagating a signal to its child, this
+ * process is orphaned and neither of the existing shutdown paths fires — no
+ * SIGTERM/SIGINT ever arrives (only the launcher got it, if anything did),
+ * and stdin never EOFs because the client, not the launcher, holds the
+ * pipe's write-end. Left alone, the orphan lingers holding the DuckDB
+ * analytics database's write lock, and the next session's connection
+ * attempt fails with a stale-lock error.
+ *
+ * This module holds the pure "should we shut down?" decision so it can be
+ * unit-tested without spawning real processes. The poll loop that calls it
+ * on an interval lives in index.ts, stdio mode only.
+ */
+
+export interface ShouldShutdownOnParentChangeParams {
+  /** True when running on Windows (`process.platform === "win32"`). */
+  isWindows: boolean;
+  /** `process.ppid` captured once at process startup. */
+  startupPpid: number;
+  /** `process.ppid` read at the moment of the check. Ignored on Windows. */
+  currentPpid: number;
+  /**
+   * Whether the ORIGINAL parent process (`startupPpid`) is still alive right
+   * now. Ignored on Unix, where reparenting — not liveness — is the signal.
+   */
+  startupParentAlive: boolean;
+}
+
+/**
+ * Decide whether the stdio MCP server should proactively exit because its
+ * launching parent process appears to have died.
+ *
+ * Unix: a child that loses its parent is reparented (typically to PID 1, the
+ * OS's orphan reaper), so comparing the current PPID against the PPID
+ * captured at startup is the signal. If the process was ALREADY parented to
+ * PID 1 when it started (e.g. launched directly under systemd), there is no
+ * launcher to watch — never fire, regardless of `currentPpid`.
+ *
+ * Windows: PPID does not change when a parent process dies, so reparenting
+ * can't be used as the signal there. Instead, watch whether the original
+ * parent (captured at startup) is still alive.
+ */
+export function shouldShutdownOnParentChange(params: ShouldShutdownOnParentChangeParams): boolean {
+  const { isWindows, startupPpid, currentPpid, startupParentAlive } = params;
+
+  if (isWindows) {
+    return !startupParentAlive;
+  }
+
+  if (startupPpid === 1) {
+    // Already orphaned at startup (e.g. systemd-launched) — nothing to watch.
+    return false;
+  }
+
+  return currentPpid !== startupPpid;
+}

--- a/packages/mcp-server/tests/fixtures/parent-watchdog-launcher.mjs
+++ b/packages/mcp-server/tests/fixtures/parent-watchdog-launcher.mjs
@@ -1,0 +1,29 @@
+// Launcher stand-in used by tests/integration/parent-death-watchdog.test.ts.
+//
+// Mirrors the real-world `npx tradeblocks-mcp ...` launch: opens the FIFO
+// read-end itself (as a real launcher hands node its stdin), spawns the MCP
+// server with that read-end as fd0, records its PID, and stays alive.
+//
+// The test process holds an INDEPENDENT write-end on the same FIFO (opened
+// before this launcher runs), so killing this launcher does not close the
+// pipe — the MCP server's stdin never EOFs, faithfully modeling "the client
+// keeps the pipe open; only the launcher dies."
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+
+const [mcpEntry, dataDir, outLog, errLog, pidFile, fifoPath] = process.argv.slice(2);
+
+const out = fs.openSync(outLog, "w");
+const err = fs.openSync(errLog, "w");
+const rfd = fs.openSync(fifoPath, fs.constants.O_RDONLY); // writer (test) already open
+
+const child = spawn(process.execPath, [mcpEntry, dataDir], { stdio: [rfd, out, err] });
+fs.writeFileSync(pidFile, String(child.pid));
+
+// Keep the event loop alive so a plain SIGKILL is required to remove this
+// launcher — matches how a real `npx` wrapper stays resident.
+setInterval(() => {}, 1 << 30);
+
+child.on("exit", (code, signal) => {
+  fs.appendFileSync(errLog, `\n[launcher] child exited code=${code} signal=${signal}\n`);
+});

--- a/packages/mcp-server/tests/integration/parent-death-watchdog.test.ts
+++ b/packages/mcp-server/tests/integration/parent-death-watchdog.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Integration test: stdio parent-death detection.
+ *
+ * Real-world topology: client -> launcher (e.g. `npx tradeblocks-mcp ...`)
+ * -> node (this MCP server). When the launcher is killed without cleanly
+ * propagating to its child, the MCP server is orphaned (reparented on Unix)
+ * with neither of its shutdown paths firing: no SIGTERM/SIGINT ever arrives
+ * (only the launcher got it, if anything), and stdin never EOFs because the
+ * client — not the launcher — holds the pipe's write-end. Left alone, the
+ * orphan lingers holding the DuckDB analytics database's write lock, and the
+ * next session's connection attempt fails with a stale-lock error.
+ *
+ * This test reproduces that topology with a FIFO so the "client" write-end
+ * is independent of the "launcher" process's lifecycle, kills the launcher,
+ * and asserts the MCP server process exits on its own within a bounded
+ * window — the proactive parent-death watchdog is the only thing that can
+ * save it here.
+ *
+ * Spawns the BUILT server (server/index.js) — run `npm run build:mcp` first.
+ * POSIX only (Unix PPID reparenting is the mechanism under test); skipped on
+ * Windows.
+ */
+
+import { spawn, execFileSync, type ChildProcess } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const MCP_ENTRY = path.resolve(here, "../../server/index.js");
+const LAUNCHER_SCRIPT = path.resolve(here, "../fixtures/parent-watchdog-launcher.mjs");
+
+const describePosixOnly = process.platform === "win32" ? describe.skip : describe;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readFileSafe(filePath: string): string {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+describePosixOnly("stdio parent-death watchdog (POSIX)", () => {
+  let dir: string;
+  let fifoPath: string;
+  let writeFd: number | null = null;
+  let launcher: ChildProcess | null = null;
+  let mcpPid: number | null = null;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "tb-parent-watchdog-"));
+    fifoPath = path.join(dir, "stdin.fifo");
+    execFileSync("mkfifo", [fifoPath]);
+    writeFd = null;
+    launcher = null;
+    mcpPid = null;
+  });
+
+  afterEach(() => {
+    if (writeFd !== null) {
+      try {
+        fs.closeSync(writeFd);
+      } catch {
+        /* already closed */
+      }
+    }
+    if (mcpPid !== null && isAlive(mcpPid)) {
+      try {
+        process.kill(mcpPid, "SIGKILL");
+      } catch {
+        /* already gone */
+      }
+    }
+    if (launcher?.pid && isAlive(launcher.pid)) {
+      try {
+        process.kill(launcher.pid, "SIGKILL");
+      } catch {
+        /* already gone */
+      }
+    }
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("MCP server exits on its own when its launcher dies while the client keeps stdin open", async () => {
+    // Fail loud (not "0 tests ran") if `npm run build:mcp` hasn't been run.
+    expect(fs.existsSync(MCP_ENTRY)).toBe(true);
+
+    const dataDir = path.join(dir, "data");
+    fs.mkdirSync(dataDir, { recursive: true });
+    const outLog = path.join(dir, "mcp.out.log");
+    const errLog = path.join(dir, "mcp.err.log");
+    const pidFile = path.join(dir, "mcp.pid");
+
+    // Open a non-blocking read end first to unblock the writer open below,
+    // then hold an INDEPENDENT write-end — this is the "client" side of the
+    // pipe, and it survives the launcher's death.
+    const keeperFd = fs.openSync(fifoPath, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK);
+    writeFd = fs.openSync(fifoPath, "w");
+    fs.closeSync(keeperFd);
+
+    launcher = spawn(
+      process.execPath,
+      [LAUNCHER_SCRIPT, MCP_ENTRY, dataDir, outLog, errLog, pidFile, fifoPath],
+      { stdio: ["ignore", "ignore", "inherit"] },
+    );
+
+    // Wait for the MCP server to report ready (it opens the DuckDB
+    // connection during startup, before this line ever prints).
+    for (let i = 0; i < 150; i++) {
+      if (fs.existsSync(pidFile)) {
+        mcpPid = parseInt(fs.readFileSync(pidFile, "utf8").trim(), 10);
+      }
+      if (mcpPid && readFileSafe(errLog).includes("ready")) break;
+      await sleep(100);
+    }
+    if (!mcpPid || !isAlive(mcpPid)) {
+      throw new Error(`MCP server never reported ready. stderr:\n${readFileSafe(errLog)}`);
+    }
+
+    // Kill the launcher. The FIFO write-end stays open (this test process
+    // holds it), so the MCP server's stdin never EOFs, and it receives no
+    // signal directly — only a proactive parent-death watchdog can save it.
+    process.kill(launcher.pid!, "SIGKILL");
+
+    let exitedWithinBudget = false;
+    for (let i = 0; i < 80; i++) {
+      if (!isAlive(mcpPid!)) {
+        exitedWithinBudget = true;
+        break;
+      }
+      await sleep(100);
+    }
+
+    expect(exitedWithinBudget).toBe(true);
+  }, 20_000);
+});

--- a/packages/mcp-server/tests/unit/parent-watchdog.test.ts
+++ b/packages/mcp-server/tests/unit/parent-watchdog.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Unit tests for the stdio parent-death decision function.
+ *
+ * Pure, cross-platform coverage for `shouldShutdownOnParentChange` — the
+ * "should we shut down?" logic factored out of index.ts's poll loop so it
+ * can be exercised without spawning real processes. See
+ * tests/integration/parent-death-watchdog.test.ts for the POSIX
+ * end-to-end proof.
+ */
+
+import { shouldShutdownOnParentChange } from "../../src/parent-watchdog.ts";
+
+describe("shouldShutdownOnParentChange", () => {
+  it("fires on Unix when reparented (PPID changed from the captured startup PPID)", () => {
+    // The launcher (PID 4242) died; the OS reparented us to PID 1 (init).
+    expect(
+      shouldShutdownOnParentChange({
+        isWindows: false,
+        startupPpid: 4242,
+        currentPpid: 1,
+        startupParentAlive: false, // irrelevant on Unix
+      }),
+    ).toBe(true);
+  });
+
+  it("fires on Windows when the original parent is no longer alive", () => {
+    // Windows PPID never changes, so currentPpid stays equal to startupPpid
+    // even after the parent dies — startupParentAlive is the only signal.
+    expect(
+      shouldShutdownOnParentChange({
+        isWindows: true,
+        startupPpid: 4242,
+        currentPpid: 4242,
+        startupParentAlive: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not fire on Unix while the launcher's PID is still our parent", () => {
+    expect(
+      shouldShutdownOnParentChange({
+        isWindows: false,
+        startupPpid: 4242,
+        currentPpid: 4242,
+        startupParentAlive: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not fire on Windows while the original parent is still alive", () => {
+    expect(
+      shouldShutdownOnParentChange({
+        isWindows: true,
+        startupPpid: 4242,
+        currentPpid: 4242,
+        startupParentAlive: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("never fires on Unix when already orphaned at startup (PPID 1, e.g. systemd)", () => {
+    // No launcher to watch — installing the watchdog would be dead weight,
+    // and even if it ran, it must never self-terminate a systemd-launched
+    // process just because it stays parented to PID 1.
+    expect(
+      shouldShutdownOnParentChange({
+        isWindows: false,
+        startupPpid: 1,
+        currentPpid: 1,
+        startupParentAlive: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("stays silent for an already-orphaned Unix start even if currentPpid drifts", () => {
+    // Defense in depth: the "already orphaned at startup" guard holds
+    // regardless of what currentPpid later reports.
+    expect(
+      shouldShutdownOnParentChange({
+        isWindows: false,
+        startupPpid: 1,
+        currentPpid: 99,
+        startupParentAlive: true,
+      }),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a stdio-mode parent-death watchdog to `tradeblocks-mcp` so the server exits cleanly and releases its DuckDB analytics lock when its launching parent process dies without a clean signal.

## Why

When the server is started through an intermediate launcher (`npx tradeblocks-mcp ...`), the process tree is client → launcher → node. If the launcher is terminated without propagating a signal to the node process, the node process is orphaned and neither existing shutdown path fires: no `SIGTERM`/`SIGINT` arrives (only the launcher got it, if anything), and stdin never EOFs because the client — not the launcher — holds the pipe's write-end.

The orphaned process then keeps `analytics.duckdb` open, so the next session's read-write connection attempt fails with `Could not set lock on file ... Conflicting lock is held ...` until the existing lock-recovery + retry masks it a few seconds later. Users see this as an intermittent "MCP failed" flash on restart even though tool calls succeed after the automatic retry.

## How

Poll `process.ppid` every ~2s in stdio mode and, on parent death, run the same graceful shutdown the existing handlers use (`closeConnection()` then exit). Signal-independent, so it closes the gap the launcher topology opens:

- **Unix:** fire when the current PPID differs from the PPID captured at startup (reparenting only happens when the parent dies).
- **Windows:** PPID does not change on parent death, so fire when the original parent process is no longer alive.
- Skip installing the watchdog entirely when the process starts already orphaned (Unix PPID 1, e.g. launched under systemd), and never install it in HTTP mode, so a long-running server can't self-terminate.
- The interval timer is `unref()`'d, so the watchdog never keeps the process alive on its own.

Additive defense-in-depth alongside the existing `SIGTERM`/`SIGINT`/stdin-end handlers — none of them are changed.

## Tests

- `shouldShutdownOnParentChange` is factored into a small pure module with unit coverage of the full decision matrix (Unix reparent, Windows dead-parent, the already-orphaned guard, and the negative cases).
- A POSIX integration test reproduces the launcher topology with a FIFO (an independent client write-end vs. the launcher process), spawns the built server, kills the launcher, and asserts the server self-exits within a bounded window. Confirmed failing before the fix and passing after.

## Compatibility

No public API change; backwards compatible. HTTP mode and systemd-launched usage are unaffected by construction.
