### PR TITLE
Add parameter-study selection statistic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tradeblocks",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tradeblocks",
-      "version": "3.6.1",
+      "version": "3.7.0",
       "workspaces": [
         "packages/*"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "private": true,
   "workspaces": [

--- a/packages/lib/calculations/index.ts
+++ b/packages/lib/calculations/index.ts
@@ -45,6 +45,7 @@ export * from "./statistical-utils.ts";
 export * from "./mfe-mae.ts";
 export * from "./paired-block-bootstrap.ts";
 export * from "./selection-adjusted-lower-bound.ts";
+export * from "./parameter-study-selection.ts";
 
 // Re-export types for convenience
 export * from "../models/portfolio-stats.ts";

--- a/packages/lib/calculations/parameter-study-selection.ts
+++ b/packages/lib/calculations/parameter-study-selection.ts
@@ -1,0 +1,322 @@
+import {
+  pairedBlockBootstrap,
+  type DaySeries,
+  type PairedBlockBootstrapStatus,
+} from "./paired-block-bootstrap.ts";
+import {
+  pairedSelectionAdjustedLowerBound,
+  type PairedSelectionAdjustedLowerBoundResult,
+  type SelectionAdjustedIncumbent,
+  type SelectionAdjustedMember,
+} from "./selection-adjusted-lower-bound.ts";
+import { normalQuantile } from "./statistical-utils.ts";
+
+/** Version of the complete parameter-study selection calculation contract. */
+export const PARAMETER_STUDY_SELECTION_PRODUCER_VERSION =
+  "tradeblocks.parameter-study-selection/v1" as const;
+
+/** Version of the expected-maximum approximation and its frozen assumptions. */
+export const EXPECTED_MAX_NULL_MODEL_VERSION = "fst-normal-order-statistic/v1" as const;
+
+export interface ParameterStudyExpectedMaxNullModel {
+  /** The only distribution supported by this producer version. */
+  distribution: "gaussian";
+  /** The null is centered: skill-less candidates have expected contribution zero. */
+  nullLocation: 0;
+  /** Standard deviation of one candidate's additive sum statistic under the null. */
+  nullStatisticStandardDeviation: number;
+  /** Caller-owned unit binding for both the statistic and null scale. */
+  unit: string;
+  /** The exact statistic whose centered null dispersion is modeled. */
+  statistic: "additive-sum";
+  /** Selection-window bounds used to derive the null dispersion. */
+  window: { start: string; end: string };
+  /** Immutable caller-owned evidence reference from which the null deviation was derived. */
+  scaleSourceRef: string;
+  /** V1 prices the conservative independent-trial model against exact raw K. */
+  dependenceModel: "independent";
+  modelVersion: typeof EXPECTED_MAX_NULL_MODEL_VERSION;
+}
+
+export interface ParameterStudySelectionInput {
+  incumbent: SelectionAdjustedIncumbent;
+  /** Complete stable family used for the family-local interval and adjustment. */
+  stableFamilyMembers: SelectionAdjustedMember[];
+  /** Upstream-chosen stable representative. This producer never chooses an argmax. */
+  selectedMemberRef: string;
+  /** Caller-derived moving-block length in trading sessions. */
+  holdingRule: { blockDays: number };
+  /** Two-sided centroid interval and one-sided representative-bound level. */
+  confidenceLevel: number;
+  resamples: number;
+  seed: number;
+  /** Caller-calibrated floor in effective moving blocks. */
+  effectiveNFloorBlocks: number;
+  /** Grow-only cumulative count of every exposed candidate in the selection arc. */
+  cumulativeRawK: number;
+  /** Immutable caller-owned ledger/snapshot reference binding cumulativeRawK. */
+  cumulativeRawKSourceRef: string;
+  expectedMaxNullModel: ParameterStudyExpectedMaxNullModel;
+}
+
+export interface FamilyCentroidInterval {
+  /** Sum of the complete-case family-centroid daily contribution minus incumbent. */
+  point: number | null;
+  level: number;
+  low: number | null;
+  high: number | null;
+  method: "paired-day-block-family-centroid";
+  status: PairedBlockBootstrapStatus;
+  effectiveN: number;
+  overlapWindow: { start: string; end: string } | null;
+  blockDays: number;
+}
+
+export interface ExpectedMaxOfSearch {
+  value: number;
+  standardizedValue: number;
+  method: "false-strategy-theorem-gaussian-order-statistic";
+  bindings: {
+    cumulativeRawK: number;
+    familyK: number;
+    nullLocation: 0;
+    cumulativeRawKSourceRef: string;
+    nullStatisticStandardDeviation: number;
+    unit: string;
+    statistic: "additive-sum";
+    window: { start: string; end: string };
+    scaleSourceRef: string;
+    distribution: "gaussian";
+    dependenceModel: "independent";
+    modelVersion: typeof EXPECTED_MAX_NULL_MODEL_VERSION;
+  };
+}
+
+export interface ParameterStudySelectionResult {
+  producerVersion: typeof PARAMETER_STUDY_SELECTION_PRODUCER_VERSION;
+  stableFamilyMemberRefs: string[];
+  selectedMemberRef: string;
+  familyCentroidInterval: FamilyCentroidInterval;
+  representativeLowerBound: PairedSelectionAdjustedLowerBoundResult;
+  expectedMaxOfSearch: ExpectedMaxOfSearch;
+}
+
+const EULER_MASCHERONI = 0.5772156649015329;
+
+function assertExpectedMaxBindings(input: ParameterStudySelectionInput, familyK: number): void {
+  if (!Number.isSafeInteger(input.cumulativeRawK) || input.cumulativeRawK < 1) {
+    throw new RangeError("cumulativeRawK must be a positive safe integer");
+  }
+  if (input.cumulativeRawK < familyK) {
+    throw new RangeError("cumulativeRawK must be at least the stable family cardinality");
+  }
+  if (
+    typeof input.cumulativeRawKSourceRef !== "string" ||
+    input.cumulativeRawKSourceRef.trim().length === 0
+  ) {
+    throw new TypeError("cumulativeRawKSourceRef must be a non-empty string");
+  }
+
+  const model = input.expectedMaxNullModel;
+  if (!model || typeof model !== "object") {
+    throw new TypeError("expectedMaxNullModel must be an object");
+  }
+  if (model.distribution !== "gaussian") {
+    throw new TypeError('expectedMaxNullModel.distribution must be "gaussian"');
+  }
+  if (model.nullLocation !== 0) {
+    throw new RangeError("expectedMaxNullModel.nullLocation must be zero");
+  }
+  if (
+    typeof model.nullStatisticStandardDeviation !== "number" ||
+    !Number.isFinite(model.nullStatisticStandardDeviation)
+  ) {
+    throw new TypeError(
+      "expectedMaxNullModel.nullStatisticStandardDeviation must be a finite number",
+    );
+  }
+  if (model.nullStatisticStandardDeviation <= 0) {
+    throw new RangeError(
+      "expectedMaxNullModel.nullStatisticStandardDeviation must be greater than zero",
+    );
+  }
+  if (typeof model.unit !== "string" || model.unit.trim().length === 0) {
+    throw new TypeError("expectedMaxNullModel.unit must be a non-empty string");
+  }
+  if (model.statistic !== "additive-sum") {
+    throw new TypeError('expectedMaxNullModel.statistic must be "additive-sum"');
+  }
+  if (
+    !model.window ||
+    typeof model.window.start !== "string" ||
+    typeof model.window.end !== "string" ||
+    model.window.start.length === 0 ||
+    model.window.end.length === 0 ||
+    model.window.start > model.window.end
+  ) {
+    throw new TypeError("expectedMaxNullModel.window must contain ordered start and end days");
+  }
+  if (typeof model.scaleSourceRef !== "string" || model.scaleSourceRef.trim().length === 0) {
+    throw new TypeError("expectedMaxNullModel.scaleSourceRef must be a non-empty string");
+  }
+  if (model.dependenceModel !== "independent") {
+    throw new TypeError('expectedMaxNullModel.dependenceModel must be "independent"');
+  }
+  if (model.modelVersion !== EXPECTED_MAX_NULL_MODEL_VERSION) {
+    throw new TypeError(
+      `expectedMaxNullModel.modelVersion must be "${EXPECTED_MAX_NULL_MODEL_VERSION}"`,
+    );
+  }
+}
+
+function observedValueMap(series: DaySeries): Map<string, number> {
+  const observed = new Map<string, number>();
+  for (let index = 0; index < series.index.length; index++) {
+    if (series.observedMask[index]) observed.set(series.index[index], series.values[index]);
+  }
+  return observed;
+}
+
+/**
+ * Construct the additive family-centroid path on the complete-family mask.
+ * A missing member makes the day unobserved; a genuine observed zero remains data.
+ */
+function familyCentroidSeries(members: SelectionAdjustedMember[]): DaySeries {
+  const days = new Set<string>();
+  const memberMaps = members.map((member) => {
+    for (const day of member.series.index) days.add(day);
+    return observedValueMap(member.series);
+  });
+  const index = Array.from(days).sort();
+  const values: number[] = [];
+  const observedMask: boolean[] = [];
+
+  for (const day of index) {
+    const observed = memberMaps.every((member) => member.has(day));
+    observedMask.push(observed);
+    values.push(
+      observed
+        ? memberMaps.reduce((sum, member) => sum + member.get(day)!, 0) / memberMaps.length
+        : 0,
+    );
+  }
+
+  return { index, values, observedMask };
+}
+
+const sum = (values: number[]): number => values.reduce((total, value) => total + value, 0);
+
+const sumDifference = (member: number[], incumbent: number[]): number => {
+  let total = 0;
+  for (let index = 0; index < member.length; index++) total += member[index] - incumbent[index];
+  return total;
+};
+
+function standardizedExpectedMaximum(rawK: number): number {
+  if (rawK === 1) return 0;
+  return (
+    (1 - EULER_MASCHERONI) * normalQuantile(1 - 1 / rawK) +
+    EULER_MASCHERONI * normalQuantile(1 - 1 / (rawK * Math.E))
+  );
+}
+
+/**
+ * Produce the canonical additive selection statistic for one parameter study.
+ *
+ * The stable-family centroid and the chosen representative answer different
+ * questions and remain separate:
+ *
+ * - the centroid interval estimates the complete stable family's additive path;
+ * - the representative lower bound pays for selecting within that local family;
+ * - expected max prices the caller-asserted cumulative raw search count under
+ *   explicit centered independent-Gaussian null assumptions and binds its source.
+ *
+ * The representative is supplied by the caller and may be below the observed
+ * argmax. This function never selects a winner and never derives or reduces K.
+ */
+export function parameterStudySelectionStatistic(
+  input: ParameterStudySelectionInput,
+): ParameterStudySelectionResult {
+  if (!input || typeof input !== "object") throw new TypeError("input must be an object");
+  if (!Array.isArray(input.stableFamilyMembers) || input.stableFamilyMembers.length === 0) {
+    throw new RangeError("stableFamilyMembers must contain at least one member");
+  }
+
+  const stableFamilyMembers = [...input.stableFamilyMembers].sort((left, right) =>
+    left.ref < right.ref ? -1 : left.ref > right.ref ? 1 : 0,
+  );
+  assertExpectedMaxBindings(input, stableFamilyMembers.length);
+  const model = input.expectedMaxNullModel;
+
+  const representativeLowerBound = pairedSelectionAdjustedLowerBound({
+    incumbent: input.incumbent,
+    eligibleMembers: stableFamilyMembers,
+    selectedMemberRef: input.selectedMemberRef,
+    statistic: sumDifference,
+    holdingRule: input.holdingRule,
+    confidenceLevel: input.confidenceLevel,
+    resamples: input.resamples,
+    seed: input.seed,
+    effectiveNFloorBlocks: input.effectiveNFloorBlocks,
+  });
+
+  const centroid = familyCentroidSeries(stableFamilyMembers);
+  const centroidBootstrap = pairedBlockBootstrap({
+    armA: centroid,
+    armB: input.incumbent.series,
+    statistic: sum,
+    holdingRule: input.holdingRule,
+    ciLevel: input.confidenceLevel,
+    resamples: input.resamples,
+    seed: input.seed,
+    effectiveNFloorBlocks: input.effectiveNFloorBlocks,
+  });
+  if (
+    centroidBootstrap.overlapWindow &&
+    (model.window.start !== centroidBootstrap.overlapWindow.start ||
+      model.window.end !== centroidBootstrap.overlapWindow.end)
+  ) {
+    throw new RangeError(
+      "expectedMaxNullModel.window must match the complete-family overlap window",
+    );
+  }
+
+  const standardizedValue = standardizedExpectedMaximum(input.cumulativeRawK);
+
+  return {
+    producerVersion: PARAMETER_STUDY_SELECTION_PRODUCER_VERSION,
+    stableFamilyMemberRefs: stableFamilyMembers.map((member) => member.ref),
+    selectedMemberRef: input.selectedMemberRef,
+    familyCentroidInterval: {
+      point: centroidBootstrap.point,
+      level: input.confidenceLevel,
+      low: centroidBootstrap.ci.low,
+      high: centroidBootstrap.ci.high,
+      method: "paired-day-block-family-centroid",
+      status: centroidBootstrap.status,
+      effectiveN: centroidBootstrap.effectiveN,
+      overlapWindow: centroidBootstrap.overlapWindow,
+      blockDays: centroidBootstrap.blockDays,
+    },
+    representativeLowerBound,
+    expectedMaxOfSearch: {
+      value: model.nullLocation + model.nullStatisticStandardDeviation * standardizedValue,
+      standardizedValue,
+      method: "false-strategy-theorem-gaussian-order-statistic",
+      bindings: {
+        cumulativeRawK: input.cumulativeRawK,
+        familyK: stableFamilyMembers.length,
+        cumulativeRawKSourceRef: input.cumulativeRawKSourceRef,
+        nullLocation: model.nullLocation,
+        nullStatisticStandardDeviation: model.nullStatisticStandardDeviation,
+        unit: model.unit,
+        statistic: model.statistic,
+        window: { ...model.window },
+        scaleSourceRef: model.scaleSourceRef,
+        distribution: model.distribution,
+        dependenceModel: model.dependenceModel,
+        modelVersion: model.modelVersion,
+      },
+    },
+  };
+}

--- a/packages/lib/calculations/parameter-study-selection.ts
+++ b/packages/lib/calculations/parameter-study-selection.ts
@@ -70,6 +70,14 @@ export interface FamilyCentroidInterval {
   effectiveN: number;
   overlapWindow: { start: string; end: string } | null;
   blockDays: number;
+  /** Honest refusal when a two-sided endpoint is unattainable at the requested level. */
+  refusalReason: "insufficient-resample-resolution" | null;
+  resampleQuantiles: {
+    lowerOneBasedRank: number;
+    upperOneBasedRank: number;
+    sampleSize: number;
+    rule: "floor(alpha / 2 * (resamples + 1)); ceil((1 - alpha / 2) * (resamples + 1))";
+  };
 }
 
 export interface ExpectedMaxOfSearch {
@@ -109,6 +117,9 @@ function assertExpectedMaxBindings(input: ParameterStudySelectionInput, familyK:
   }
   if (input.cumulativeRawK < familyK) {
     throw new RangeError("cumulativeRawK must be at least the stable family cardinality");
+  }
+  if (1 - 1 / (input.cumulativeRawK * Math.E) === 1) {
+    throw new RangeError("cumulativeRawK is too large for stable expected-max quantiles");
   }
   if (
     typeof input.cumulativeRawKSourceRef !== "string" ||
@@ -228,8 +239,9 @@ function standardizedExpectedMaximum(rawK: number): number {
  *
  * - the centroid interval estimates the complete stable family's additive path;
  * - the representative lower bound pays for selecting within that local family;
- * - expected max prices the caller-asserted cumulative raw search count under
- *   explicit centered independent-Gaussian null assumptions and binds its source.
+ * - expected max gives an expected null reference level for the caller-asserted
+ *   cumulative raw search count under explicit centered independent-Gaussian
+ *   assumptions and binds its source; it is not an alpha-calibrated decision.
  *
  * The representative is supplied by the caller and may be below the observed
  * argmax. This function never selects a winner and never derives or reduces K.
@@ -271,6 +283,13 @@ export function parameterStudySelectionStatistic(
     seed: input.seed,
     effectiveNFloorBlocks: input.effectiveNFloorBlocks,
   });
+  const twoSidedTail = (1 - input.confidenceLevel) / 2;
+  const lowerOneBasedRank = Math.floor(twoSidedTail * (input.resamples + 1));
+  const upperOneBasedRank = Math.ceil((1 - twoSidedTail) * (input.resamples + 1));
+  const centroidResolutionAttainable =
+    lowerOneBasedRank >= 1 && upperOneBasedRank <= input.resamples;
+  const centroidResolutionRefused =
+    centroidBootstrap.status === "resolved" && !centroidResolutionAttainable;
   if (
     centroidBootstrap.overlapWindow &&
     (model.window.start !== centroidBootstrap.overlapWindow.start ||
@@ -290,13 +309,20 @@ export function parameterStudySelectionStatistic(
     familyCentroidInterval: {
       point: centroidBootstrap.point,
       level: input.confidenceLevel,
-      low: centroidBootstrap.ci.low,
-      high: centroidBootstrap.ci.high,
+      low: centroidResolutionRefused ? null : centroidBootstrap.ci.low,
+      high: centroidResolutionRefused ? null : centroidBootstrap.ci.high,
       method: "paired-day-block-family-centroid",
-      status: centroidBootstrap.status,
+      status: centroidResolutionRefused ? "underpowered" : centroidBootstrap.status,
       effectiveN: centroidBootstrap.effectiveN,
       overlapWindow: centroidBootstrap.overlapWindow,
       blockDays: centroidBootstrap.blockDays,
+      refusalReason: centroidResolutionRefused ? "insufficient-resample-resolution" : null,
+      resampleQuantiles: {
+        lowerOneBasedRank,
+        upperOneBasedRank,
+        sampleSize: input.resamples,
+        rule: "floor(alpha / 2 * (resamples + 1)); ceil((1 - alpha / 2) * (resamples + 1))",
+      },
     },
     representativeLowerBound,
     expectedMaxOfSearch: {

--- a/releases/v3.7.0.md
+++ b/releases/v3.7.0.md
@@ -1,0 +1,28 @@
+# Tradeblocks 3.7.0
+
+## Parameter-study selection evidence
+
+`@tradeblocks/lib/calculations` now exports
+`parameterStudySelectionStatistic()`, a deterministic additive producer for a
+complete stable parameter-study family.
+
+The result keeps three distinct evidence layers bound together:
+
+- a paired moving-day-block interval for the complete-family centroid path;
+- a simultaneous selection-adjusted lower bound for the caller-chosen stable
+  representative, which does not need to be the observed argmax; and
+- an expected-max-of-search hurdle bound to exact cumulative raw `K`, null
+  sum-statistic standard deviation, and explicit centered
+  independent-Gaussian model assumptions.
+
+The producer returns its version, sorted family references, local family size,
+cumulative raw search count, and null-model version. It rejects a cumulative
+count smaller than the supplied stable family and binds the caller-asserted
+count to an immutable ledger reference. The null standard deviation is likewise
+bound to the additive-sum statistic, unit, selection window, and immutable
+source reference.
+
+Existing paired-bootstrap and selection-adjusted-lower-bound APIs are
+unchanged. Callers remain responsible for supplying complete additive daily
+contribution series, a data-derived block length, a calibrated effective-N
+floor, and the grow-only cumulative raw search count.

--- a/releases/v3.7.0.md
+++ b/releases/v3.7.0.md
@@ -11,9 +11,13 @@ The result keeps three distinct evidence layers bound together:
 - a paired moving-day-block interval for the complete-family centroid path;
 - a simultaneous selection-adjusted lower bound for the caller-chosen stable
   representative, which does not need to be the observed argmax; and
-- an expected-max-of-search hurdle bound to exact cumulative raw `K`, null
-  sum-statistic standard deviation, and explicit centered
+- an expected null maximum/reference level bound to exact cumulative raw `K`,
+  null sum-statistic standard deviation, and explicit centered
   independent-Gaussian model assumptions.
+
+The expected null maximum is a descriptive search reference, not an alpha- or
+FWER-calibrated decision threshold. The producer deliberately emits no pass or
+selection decision.
 
 The producer returns its version, sorted family references, local family size,
 cumulative raw search count, and null-model version. It rejects a cumulative
@@ -26,3 +30,7 @@ Existing paired-bootstrap and selection-adjusted-lower-bound APIs are
 unchanged. Callers remain responsible for supplying complete additive daily
 contribution series, a data-derived block length, a calibrated effective-N
 floor, and the grow-only cumulative raw search count.
+
+The centroid interval refuses instead of interpolating when the requested
+two-sided confidence endpoints are unattainable at the supplied finite
+resample count. For example, a 95% interval requires at least 39 resamples.

--- a/tests/lib/calculations/parameter-study-selection.test.ts
+++ b/tests/lib/calculations/parameter-study-selection.test.ts
@@ -1,0 +1,305 @@
+import {
+  EXPECTED_MAX_NULL_MODEL_VERSION,
+  PARAMETER_STUDY_SELECTION_PRODUCER_VERSION,
+  pairedBlockBootstrap,
+  parameterStudySelectionStatistic,
+  type DaySeries,
+  type ParameterStudySelectionInput,
+} from "@tradeblocks/lib";
+import { describe, expect, it } from "@jest/globals";
+
+function isoDays(length: number, start = "2020-01-01"): string[] {
+  const days: string[] = [];
+  const day = new Date(`${start}T00:00:00Z`);
+  for (let index = 0; index < length; index++) {
+    days.push(day.toISOString().slice(0, 10));
+    day.setUTCDate(day.getUTCDate() + 1);
+  }
+  return days;
+}
+
+function series(values: number[], observedMask = values.map(() => true)): DaySeries {
+  return { index: isoDays(values.length), values, observedMask };
+}
+
+function seededValues(seed: number, length: number): number[] {
+  let state = seed >>> 0;
+  const values: number[] = [];
+  for (let index = 0; index < length; index++) {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    values.push(state / 4294967296 - 0.5);
+  }
+  return values;
+}
+
+function buildInput(
+  overrides: Partial<ParameterStudySelectionInput> = {},
+): ParameterStudySelectionInput {
+  const incumbentValues = seededValues(1, 40);
+  const noises = [seededValues(11, 40), seededValues(12, 40), seededValues(13, 40)];
+  const shifts = [0.2, 0.8, -0.1];
+  const stableFamilyMembers = shifts.map((shift, memberIndex) => ({
+    ref: `member-${String.fromCharCode(97 + memberIndex)}`,
+    series: series(
+      incumbentValues.map((value, dayIndex) => value + shift + noises[memberIndex][dayIndex] * 0.2),
+    ),
+  }));
+
+  return {
+    incumbent: { ref: "incumbent", series: series(incumbentValues) },
+    stableFamilyMembers,
+    selectedMemberRef: "member-a",
+    holdingRule: { blockDays: 4 },
+    confidenceLevel: 0.95,
+    resamples: 199,
+    seed: 42,
+    effectiveNFloorBlocks: 8,
+    cumulativeRawK: 9,
+    cumulativeRawKSourceRef: "sha256:selection-arc-ledger",
+    expectedMaxNullModel: {
+      distribution: "gaussian",
+      nullLocation: 0,
+      nullStatisticStandardDeviation: 2,
+      unit: "net-pnl",
+      statistic: "additive-sum",
+      window: { start: "2020-01-01", end: "2020-02-09" },
+      scaleSourceRef: "sha256:null-scale",
+      dependenceModel: "independent",
+      modelVersion: EXPECTED_MAX_NULL_MODEL_VERSION,
+    },
+    ...overrides,
+  };
+}
+
+const sum = (values: number[]): number => values.reduce((total, value) => total + value, 0);
+
+describe("parameterStudySelectionStatistic", () => {
+  it("composes the centroid interval, representative bound, and raw-K expected max", () => {
+    const input = buildInput();
+    const result = parameterStudySelectionStatistic(input);
+    const centroidValues = input.stableFamilyMembers[0].series.values.map(
+      (_, dayIndex) =>
+        input.stableFamilyMembers.reduce(
+          (total, member) => total + member.series.values[dayIndex],
+          0,
+        ) / input.stableFamilyMembers.length,
+    );
+    const directCentroid = pairedBlockBootstrap({
+      armA: series(centroidValues),
+      armB: input.incumbent.series,
+      statistic: sum,
+      holdingRule: input.holdingRule,
+      ciLevel: input.confidenceLevel,
+      resamples: input.resamples,
+      seed: input.seed,
+      effectiveNFloorBlocks: input.effectiveNFloorBlocks,
+    });
+
+    expect(result.producerVersion).toBe(PARAMETER_STUDY_SELECTION_PRODUCER_VERSION);
+    expect(result.stableFamilyMemberRefs).toEqual(["member-a", "member-b", "member-c"]);
+    expect(result.familyCentroidInterval).toEqual({
+      point: directCentroid.point,
+      level: input.confidenceLevel,
+      low: directCentroid.ci.low,
+      high: directCentroid.ci.high,
+      method: "paired-day-block-family-centroid",
+      status: directCentroid.status,
+      effectiveN: directCentroid.effectiveN,
+      overlapWindow: directCentroid.overlapWindow,
+      blockDays: directCentroid.blockDays,
+    });
+    expect(result.familyCentroidInterval.point).toBeCloseTo(
+      centroidValues.reduce(
+        (total, value, index) => total + value - input.incumbent.series.values[index],
+        0,
+      ),
+      14,
+    );
+    expect(result.representativeLowerBound.selectedMemberRef).toBe("member-a");
+    expect(result.expectedMaxOfSearch.bindings).toEqual({
+      cumulativeRawK: 9,
+      familyK: 3,
+      cumulativeRawKSourceRef: "sha256:selection-arc-ledger",
+      nullLocation: 0,
+      nullStatisticStandardDeviation: 2,
+      unit: "net-pnl",
+      statistic: "additive-sum",
+      window: { start: "2020-01-01", end: "2020-02-09" },
+      scaleSourceRef: "sha256:null-scale",
+      distribution: "gaussian",
+      dependenceModel: "independent",
+      modelVersion: EXPECTED_MAX_NULL_MODEL_VERSION,
+    });
+  });
+
+  it("bounds an upstream representative without replacing it with the observed argmax", () => {
+    const result = parameterStudySelectionStatistic(buildInput());
+    const representative = result.representativeLowerBound.memberPoints.find(
+      (member) => member.ref === "member-a",
+    )!;
+    const observedMax = result.representativeLowerBound.memberPoints.find(
+      (member) => member.ref === "member-b",
+    )!;
+
+    expect(representative.point!).toBeLessThan(observedMax.point!);
+    expect(result.selectedMemberRef).toBe("member-a");
+    expect(result.representativeLowerBound.point).toBe(representative.point);
+  });
+
+  it("is deterministic and invariant to stable-family input order", () => {
+    const input = buildInput();
+    const first = parameterStudySelectionStatistic(input);
+    const repeated = parameterStudySelectionStatistic(input);
+    const permuted = parameterStudySelectionStatistic({
+      ...input,
+      stableFamilyMembers: [...input.stableFamilyMembers].reverse(),
+    });
+
+    expect(repeated).toEqual(first);
+    expect(permuted).toEqual(first);
+  });
+
+  it("uses the complete observed-family mask and preserves observed zeros", () => {
+    const input = buildInput();
+    const mask = Array.from({ length: 40 }, () => true);
+    mask[8] = false;
+    mask[9] = false;
+    const changedMembers = input.stableFamilyMembers.map((member, index) =>
+      index === 1
+        ? {
+            ...member,
+            series: series(
+              member.series.values.map((value, dayIndex) => (dayIndex === 10 ? 0 : value)),
+              mask,
+            ),
+          }
+        : member,
+    );
+    const result = parameterStudySelectionStatistic({
+      ...input,
+      stableFamilyMembers: changedMembers,
+    });
+
+    expect(result.representativeLowerBound.diagnostics.overlapDays).toBe(38);
+    expect(result.familyCentroidInterval.effectiveN).toBe(38 / 4);
+    expect(result.familyCentroidInterval.status).toBe("resolved");
+  });
+
+  it("propagates the caller-calibrated effective-N refusal to both intervals", () => {
+    const result = parameterStudySelectionStatistic(buildInput({ effectiveNFloorBlocks: 11 }));
+
+    expect(result.representativeLowerBound.status).toBe("notComparable");
+    expect(result.representativeLowerBound.lowerBound.value).toBeNull();
+    expect(result.familyCentroidInterval.status).toBe("notComparable");
+    expect(result.familyCentroidInterval.low).toBeNull();
+    expect(result.familyCentroidInterval.high).toBeNull();
+  });
+
+  it("prices one raw trial at zero and grows monotonically with raw K and null scale", () => {
+    const base = buildInput();
+    const oneMember = [base.stableFamilyMembers[0]];
+    const one = parameterStudySelectionStatistic({
+      ...base,
+      stableFamilyMembers: oneMember,
+      cumulativeRawK: 1,
+    });
+    const two = parameterStudySelectionStatistic({
+      ...base,
+      stableFamilyMembers: oneMember,
+      cumulativeRawK: 2,
+    });
+    const twenty = parameterStudySelectionStatistic({
+      ...base,
+      stableFamilyMembers: oneMember,
+      cumulativeRawK: 20,
+    });
+    const doubleScale = parameterStudySelectionStatistic({
+      ...base,
+      stableFamilyMembers: oneMember,
+      cumulativeRawK: 20,
+      expectedMaxNullModel: {
+        ...base.expectedMaxNullModel,
+        nullStatisticStandardDeviation: 4,
+      },
+    });
+
+    expect(one.expectedMaxOfSearch.value).toBe(0);
+    expect(two.expectedMaxOfSearch.value).toBeGreaterThan(0);
+    expect(twenty.expectedMaxOfSearch.value).toBeGreaterThan(two.expectedMaxOfSearch.value);
+    expect(doubleScale.expectedMaxOfSearch.value).toBeCloseTo(
+      twenty.expectedMaxOfSearch.value * 2,
+      14,
+    );
+  });
+
+  it("pins the False Strategy Theorem approximation for a known raw K", () => {
+    const input = buildInput({ cumulativeRawK: 27 });
+    const result = parameterStudySelectionStatistic(input);
+
+    expect(result.expectedMaxOfSearch.standardizedValue).toBeCloseTo(2.0296006399506106, 14);
+    expect(result.expectedMaxOfSearch.value).toBeCloseTo(4.059201279901221, 14);
+    expect(result.expectedMaxOfSearch.method).toBe(
+      "false-strategy-theorem-gaussian-order-statistic",
+    );
+  });
+
+  it("rejects a reset raw K and malformed or ambiguous null bindings", () => {
+    const input = buildInput();
+
+    expect(() => parameterStudySelectionStatistic({ ...input, cumulativeRawK: 2 })).toThrow(
+      "cumulativeRawK must be at least the stable family cardinality",
+    );
+    expect(() => parameterStudySelectionStatistic({ ...input, cumulativeRawK: 1.5 })).toThrow(
+      "cumulativeRawK must be a positive safe integer",
+    );
+    expect(() =>
+      parameterStudySelectionStatistic({
+        ...input,
+        expectedMaxNullModel: {
+          ...input.expectedMaxNullModel,
+          nullStatisticStandardDeviation: 0,
+        },
+      }),
+    ).toThrow("expectedMaxNullModel.nullStatisticStandardDeviation must be greater than zero");
+    expect(() =>
+      parameterStudySelectionStatistic({ ...input, cumulativeRawKSourceRef: "" }),
+    ).toThrow("cumulativeRawKSourceRef must be a non-empty string");
+    expect(() =>
+      parameterStudySelectionStatistic({
+        ...input,
+        expectedMaxNullModel: {
+          ...input.expectedMaxNullModel,
+          dependenceModel: "paired-day" as "independent",
+        },
+      }),
+    ).toThrow('expectedMaxNullModel.dependenceModel must be "independent"');
+    expect(() =>
+      parameterStudySelectionStatistic({
+        ...input,
+        expectedMaxNullModel: { ...input.expectedMaxNullModel, scaleSourceRef: "" },
+      }),
+    ).toThrow("expectedMaxNullModel.scaleSourceRef must be a non-empty string");
+    expect(() =>
+      parameterStudySelectionStatistic({
+        ...input,
+        expectedMaxNullModel: {
+          ...input.expectedMaxNullModel,
+          window: { start: "2020-01-02", end: "2020-02-09" },
+        },
+      }),
+    ).toThrow("expectedMaxNullModel.window must match the complete-family overlap window");
+  });
+
+  it("rejects incomplete representative and duplicate family bindings", () => {
+    const input = buildInput();
+    expect(() =>
+      parameterStudySelectionStatistic({ ...input, selectedMemberRef: "missing" }),
+    ).toThrow("selectedMemberRef must identify an eligible member");
+    expect(() =>
+      parameterStudySelectionStatistic({
+        ...input,
+        stableFamilyMembers: [input.stableFamilyMembers[0], input.stableFamilyMembers[0]],
+      }),
+    ).toThrow("eligibleMembers contains duplicate ref: member-a");
+  });
+});

--- a/tests/lib/calculations/parameter-study-selection.test.ts
+++ b/tests/lib/calculations/parameter-study-selection.test.ts
@@ -107,6 +107,13 @@ describe("parameterStudySelectionStatistic", () => {
       effectiveN: directCentroid.effectiveN,
       overlapWindow: directCentroid.overlapWindow,
       blockDays: directCentroid.blockDays,
+      refusalReason: null,
+      resampleQuantiles: {
+        lowerOneBasedRank: 5,
+        upperOneBasedRank: 195,
+        sampleSize: 199,
+        rule: "floor(alpha / 2 * (resamples + 1)); ceil((1 - alpha / 2) * (resamples + 1))",
+      },
     });
     expect(result.familyCentroidInterval.point).toBeCloseTo(
       centroidValues.reduce(
@@ -195,6 +202,28 @@ describe("parameterStudySelectionStatistic", () => {
     expect(result.familyCentroidInterval.high).toBeNull();
   });
 
+  it("refuses a two-sided centroid interval below finite-resample resolution", () => {
+    const tooFew = parameterStudySelectionStatistic(buildInput({ resamples: 38 }));
+    const attainable = parameterStudySelectionStatistic(buildInput({ resamples: 39 }));
+
+    expect(tooFew.representativeLowerBound.status).toBe("resolved");
+    expect(tooFew.familyCentroidInterval).toMatchObject({
+      status: "underpowered",
+      low: null,
+      high: null,
+      refusalReason: "insufficient-resample-resolution",
+      resampleQuantiles: {
+        lowerOneBasedRank: 0,
+        upperOneBasedRank: 39,
+        sampleSize: 38,
+      },
+    });
+    expect(attainable.familyCentroidInterval.status).toBe("resolved");
+    expect(attainable.familyCentroidInterval.low).not.toBeNull();
+    expect(attainable.familyCentroidInterval.high).not.toBeNull();
+    expect(attainable.familyCentroidInterval.refusalReason).toBeNull();
+  });
+
   it("prices one raw trial at zero and grows monotonically with raw K and null scale", () => {
     const base = buildInput();
     const oneMember = [base.stableFamilyMembers[0]];
@@ -252,6 +281,9 @@ describe("parameterStudySelectionStatistic", () => {
     expect(() => parameterStudySelectionStatistic({ ...input, cumulativeRawK: 1.5 })).toThrow(
       "cumulativeRawK must be a positive safe integer",
     );
+    expect(() =>
+      parameterStudySelectionStatistic({ ...input, cumulativeRawK: Number.MAX_SAFE_INTEGER }),
+    ).toThrow("cumulativeRawK is too large for stable expected-max quantiles");
     expect(() =>
       parameterStudySelectionStatistic({
         ...input,


### PR DESCRIPTION
Tier: 2

Worktree: /home/romeo/code/tradeblocks-org/tradeblocks-romeo-622-parameter-study-selection

## What changed

- Add `parameterStudySelectionStatistic()` to the public calculation entrypoint.
- Produce a complete-family paired day-block centroid interval, a simultaneous lower bound for the upstream-selected representative, and an expected null maximum bound to cumulative raw K.
- Bind raw K and the centered Gaussian null scale to caller-owned evidence references, statistic, unit, selection window, and versioned model assumptions.
- Publish the additive API as Tradeblocks 3.7.0 with direct public-entrypoint coverage.

## Why

This is the bounded public calculation layer for the next Stellar Cartography parameter-study phase tracked in tradeblocks-org/enterprise#622. It keeps winner selection upstream, reuses the existing paired-bootstrap primitives, and prevents hidden or reset search counts from being substituted for cumulative raw K.

## Compatibility

Additive public API only. Existing calculation exports and behavior are unchanged.

## Validation

- `npm test -- --runInBand` — 79 suites, 1,341 tests passed
- `npm run verify` — typecheck, ESLint, and Prettier passed
- `npm run build` — production Next.js build passed

Refs tradeblocks-org/enterprise#622
