### PR TITLE
fix(lib): use erasable syntax for PlBasis so the package loads under Node's strip-only TypeScript

### DIFF
--- a/packages/lib/models/trade.ts
+++ b/packages/lib/models/trade.ts
@@ -2,10 +2,11 @@
  * Trade model based on legacy Python Trade class
  * Represents individual trade record from portfolio CSV
  */
-export enum PlBasis {
-  NetIncludesFees = "net_includes_fees",
-  GrossBeforeFees = "gross_before_fees",
-}
+export const PlBasis = {
+  NetIncludesFees: "net_includes_fees",
+  GrossBeforeFees: "gross_before_fees",
+} as const;
+export type PlBasis = (typeof PlBasis)[keyof typeof PlBasis];
 
 export interface Trade {
   // Core trade identification

--- a/packages/lib/models/validators.ts
+++ b/packages/lib/models/validators.ts
@@ -55,7 +55,7 @@ export const tradeSchema = z.object({
   avgClosingCost: z.number().finite().optional(),
   reasonForClose: z.string().optional(),
   pl: z.number().finite(),
-  plBasis: z.nativeEnum(PlBasis).optional(),
+  plBasis: z.enum(PlBasis).optional(),
   numContracts: z.number().int().positive(),
   fundsAtClose: z.number().finite(),
   marginReq: z.number().finite().min(0),

--- a/packages/lib/tsconfig.json
+++ b/packages/lib/tsconfig.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "declarationMap": true,
     "composite": true,
+    "erasableSyntaxOnly": true,
     "paths": {}
   },
   "include": ["./**/*.ts"],

--- a/packages/mcp-server/src/tools/imports.ts
+++ b/packages/mcp-server/src/tools/imports.ts
@@ -74,7 +74,7 @@ export function registerImportTools(server: McpServer, baseDir: string): void {
               "'dailylog' for daily portfolio values, 'reportinglog' for actual/reported trades",
           ),
         plBasis: z
-          .nativeEnum(PlBasis)
+          .enum(PlBasis)
           .default(PlBasis.NetIncludesFees)
           .describe(
             "Basis of the tradelog P/L column. Use 'net_includes_fees' for Option Omega exports (default), or 'gross_before_fees' when commission/fee columns still need to be deducted.",

--- a/packages/mcp-server/tsconfig.json
+++ b/packages/mcp-server/tsconfig.json
@@ -15,6 +15,7 @@
     "declaration": true,
     "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
+    "erasableSyntaxOnly": true,
     "noEmit": true
   },
   "include": ["src/**/*"],

--- a/tests/unit/metric-contract.test.ts
+++ b/tests/unit/metric-contract.test.ts
@@ -31,6 +31,11 @@ function trade(overrides: Partial<Trade> = {}): Trade {
 }
 
 describe("P/L and Sharpe calculation contract", () => {
+  it("preserves the serialized P/L basis values", () => {
+    expect(PlBasis.NetIncludesFees).toBe("net_includes_fees");
+    expect(PlBasis.GrossBeforeFees).toBe("gross_before_fees");
+  });
+
   it("does not deduct Option Omega fees a second time", () => {
     const trades = [
       trade({

--- a/tests/unit/metric-contract.test.ts
+++ b/tests/unit/metric-contract.test.ts
@@ -5,6 +5,7 @@ import {
   PlBasis,
   PerformanceCalculator,
   PortfolioStatsCalculator,
+  tradeSchema,
   type DailyLogEntry,
   type Trade,
 } from "@tradeblocks/lib";
@@ -34,6 +35,16 @@ describe("P/L and Sharpe calculation contract", () => {
   it("preserves the serialized P/L basis values", () => {
     expect(PlBasis.NetIncludesFees).toBe("net_includes_fees");
     expect(PlBasis.GrossBeforeFees).toBe("gross_before_fees");
+  });
+
+  it("validates only supported P/L basis values", () => {
+    const plBasisSchema = tradeSchema.shape.plBasis;
+
+    expect(plBasisSchema.safeParse(PlBasis.NetIncludesFees).success).toBe(true);
+    expect(plBasisSchema.safeParse(PlBasis.GrossBeforeFees).success).toBe(true);
+    expect(plBasisSchema.safeParse("net_includes_fee").success).toBe(false);
+    expect(plBasisSchema.safeParse("TOTALLY_BOGUS").success).toBe(false);
+    expect(plBasisSchema.safeParse(undefined).success).toBe(true);
   });
 
   it("does not deduct Option Omega fees a second time", () => {


### PR DESCRIPTION
## Problem

Consumers that import this package **as TypeScript source** crash at module load on Node 25:

```
SyntaxError [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]:
TypeScript enum is not supported in strip-only mode
  at packages/lib/models/trade.ts:5  →  export enum PlBasis
```

Node 25 executes `.ts` in *strip-only* mode, which only supports syntax that erases to nothing. `enum` is the common exception — it emits a runtime object, so it cannot be stripped. The crash happens before any code runs, so nothing downstream gets a chance to report it.

`PlBasis` was introduced in #402 and is the **only** enum in `packages/lib`.

## Fix

Replace the enum with the standard erasable pattern — a `const` object plus a same-named type alias — so both value and type usages keep working unchanged:

```ts
export const PlBasis = {
  NetIncludesFees: "net_includes_fees",
  GrossBeforeFees: "gross_before_fees",
} as const;
export type PlBasis = (typeof PlBasis)[keyof typeof PlBasis];
```

**Serialized values are unchanged.** This is a representation change only — no behavior change, no wire-format change. A new test asserts both strings exactly, so a future representation change cannot silently alter them.

Both Zod consumers move from `z.nativeEnum(PlBasis)` to `z.enum(PlBasis)`. The installed Zod is **4.4.3**, which accepts enum-like const objects via `z.enum` and deprecates `z.nativeEnum` — so this adopts the currently supported spelling rather than working around the old one.

## Preventing recurrence

Enables **`erasableSyntaxOnly`** in `packages/lib/tsconfig.json`. TypeScript now rejects non-erasable syntax at typecheck time, so this class of defect can no longer reach a runtime crash in a consumer. A scan found no other non-erasable constructs in the package, so the option is enabled cleanly with no further refactoring.

Installed TypeScript is 5.9.3, which supports the option.

## Verification

- Library typecheck: `tsc --noEmit --project packages/lib/tsconfig.json` — clean, exit 0.
- **Node 25 direct source import** — the exact failing path — now succeeds:
  ```
  $ node -e "import('./packages/lib/models/trade.ts').then(({PlBasis}) => console.log(JSON.stringify(PlBasis)))"
  {"NetIncludesFees":"net_includes_fees","GrossBeforeFees":"gross_before_fees"}
  ```
- Full Jest suite: **80 suites passed**.
- No existing test assertion was changed, removed, or weakened — one test added.

**The guard is mutation-tested, not merely enabled:** reintroducing an `enum` in `packages/lib` produces `error TS1294: This syntax is not allowed when 'erasableSyntaxOnly' is enabled.` Removing it restores a clean typecheck.
