### PR TITLE
test(mcp-server): remove leaked market-store fixture temp dirs after run

### DIFF
--- a/packages/mcp-server/tests/fixtures/market-stores/build-fixture.ts
+++ b/packages/mcp-server/tests/fixtures/market-stores/build-fixture.ts
@@ -13,6 +13,7 @@
  * Pattern adapted from `tests/unit/parquet-writer-multi.test.ts:15-47` and the
  * Phase 2 Wave 1 `views.test.ts` fixture.
  */
+import { afterAll } from "@jest/globals";
 import { DuckDBInstance, type DuckDBConnection } from "@duckdb/node-api";
 import { mkdirSync, rmSync } from "fs";
 import { tmpdir } from "os";
@@ -33,6 +34,22 @@ export interface BuildFixtureOpts {
   parquetMode: boolean;
 }
 
+// Every tmp dir handed out by buildStoreFixture is tracked here so the
+// end-of-file sweep below can remove anything a test left behind: a failed
+// assertion skips the in-test cleanup() call, and a DuckDB checkpoint-on-close
+// can resurrect an already-removed dir when a connection opened inside it is
+// closed after cleanup(). Dirs stay in the set for the sweep even after
+// cleanup() (rmSync with force is a no-op for dirs that stayed gone). The
+// system temp dir is a fixed-budget tmpfs; fixture dirs must never outlive
+// the test run.
+const fixtureTmpDirs = new Set<string>();
+
+afterAll(() => {
+  for (const dir of fixtureTmpDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 /**
  * Create an isolated fixture with:
  *   - Fresh `:memory:` DuckDB instance + connection
@@ -45,6 +62,7 @@ export interface BuildFixtureOpts {
 export async function buildStoreFixture(opts: BuildFixtureOpts): Promise<FixtureHandle> {
   const tmpDir = join(tmpdir(), `mkt-store-${Date.now()}-${Math.random().toString(36).slice(2)}`);
   mkdirSync(join(tmpDir, "market"), { recursive: true });
+  fixtureTmpDirs.add(tmpDir);
 
   const db = await DuckDBInstance.create(":memory:");
   const conn: DuckDBConnection = await db.connect();

--- a/packages/mcp-server/tests/unit/market-imports.test.ts
+++ b/packages/mcp-server/tests/unit/market-imports.test.ts
@@ -27,7 +27,7 @@
 import * as fs from "fs/promises";
 import * as os from "os";
 import * as path from "path";
-import { describe, it, expect, beforeEach, afterEach, jest } from "@jest/globals";
+import { describe, it, expect, beforeEach, afterEach, afterAll, jest } from "@jest/globals";
 import { registerMarketImportTools } from "../../src/tools/market-imports.ts";
 import { closeConnection } from "../../src/test-exports.ts";
 import type { MarketStores } from "../../src/market/stores/index.ts";
@@ -127,10 +127,16 @@ const COLUMN_MAPPING: Record<string, string> = {
 describe("tools/market-imports — auto-enrich composition", () => {
   let baseDir: string;
   let csvPath: string;
+  // A DuckDB checkpoint-on-close can resurrect an already-removed baseDir
+  // after the per-test rm below, so every dir is swept again in afterAll —
+  // the system temp dir is a fixed-budget tmpfs and per-run fixture dirs
+  // must never outlive the test run.
+  const baseDirs: string[] = [];
 
   beforeEach(async () => {
     await closeConnection();
     baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "tb-import-unit-"));
+    baseDirs.push(baseDir);
     csvPath = path.join(baseDir, "spx.csv");
     await fs.writeFile(csvPath, FIXTURE_CSV);
   });
@@ -138,6 +144,12 @@ describe("tools/market-imports — auto-enrich composition", () => {
   afterEach(async () => {
     await closeConnection();
     await fs.rm(baseDir, { recursive: true, force: true });
+  });
+
+  afterAll(async () => {
+    for (const dir of baseDirs) {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
   });
 
   it("calls writeBars BEFORE enriched.compute", async () => {


### PR DESCRIPTION
Test fixture builders leaked a temp directory per run into the system temp dir and never cleaned up, which grows without bound on tmpfs-backed temp mounts with fixed inode budgets.

## What

- `packages/mcp-server/tests/fixtures/market-stores/build-fixture.ts` — the builder now tracks every temp dir it hands out in a module-level set and registers an `afterAll` sweep that force-removes anything left at end of run.
- `packages/mcp-server/tests/unit/market-imports.test.ts` — leaked one `tb-import-unit-*` dir per run; now swept in `afterAll`.

## Why the sweep, not just inline cleanup

Consumers already called `cleanup()` — but (1) end-of-body cleanup is skipped when an assertion fails first, and (2) DuckDB's checkpoint-on-close can recreate an already-removed fixture dir when a connection opened inside it is closed later (the leftover dirs contained only `market.duckdb`). The `afterAll` sweep keeps dirs in its set even after inline cleanup, so a resurrected dir is still removed at end of run.

## Verification

Full mcp-server suite with a fresh isolated TMPDIR: 139/140 suites, 1817/1818 pass; zero fixture residue afterwards. The one failure (`tests/integration/parent-death-watchdog.test.ts`) is pre-existing and fails identically on the untouched branch tip. eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
