### PR TITLE
fix(risk-simulator): de-cluster worst-case injection, gate incoherent dollar sizing, mode-aware ruin stats

### DIFF
--- a/app/(platform)/risk-simulator/page.tsx
+++ b/app/(platform)/risk-simulator/page.tsx
@@ -1293,11 +1293,20 @@ export default function RiskSimulatorPage() {
                       </div>
                       <p className="text-xs text-muted-foreground">
                         {worstCaseBasedOn === "simulation" ? (
-                          <>
-                            Exactly {worstCasePercentage}% of the simulation horizon (≈{" "}
-                            {worstCaseSimulationBudget} synthetic trades) split evenly across
-                            strategies.
-                          </>
+                          worstCaseMode === "probabilistic" ? (
+                            <>
+                              Each simulated trade has a literal {worstCasePercentage}% chance of
+                              becoming a max-loss event (≈ {worstCaseSimulationBudget} per
+                              simulation on average), with the loss sizes split evenly across
+                              strategies.
+                            </>
+                          ) : (
+                            <>
+                              Exactly {worstCasePercentage}% of the simulation horizon (≈{" "}
+                              {worstCaseSimulationBudget} synthetic trades) split evenly across
+                              strategies.
+                            </>
+                          )
                         ) : (
                           <>
                             Weighted by each strategy&apos;s historical trade count, but capped at{" "}

--- a/app/(platform)/risk-simulator/page.tsx
+++ b/app/(platform)/risk-simulator/page.tsx
@@ -32,7 +32,6 @@ import {
   runMonteCarloSimulation,
   buildOriginalOrderEquityPath,
   defaultMeanBlockLength,
-  effectiveResamplePoolSize,
   worstCaseInjectionCount,
   PortfolioStatsCalculator,
   getBlock,
@@ -99,11 +98,16 @@ export default function RiskSimulatorPage() {
   // Worst-case scenario parameters
   const [worstCaseEnabled, setWorstCaseEnabled] = useState(false);
   const [worstCasePercentage, setWorstCasePercentage] = useState(5);
-  const [worstCaseMode, setWorstCaseMode] = useState<"pool" | "guarantee">("pool");
+  const [worstCaseMode, setWorstCaseMode] = useState<"probabilistic" | "guarantee">(
+    "probabilistic",
+  );
   const [worstCaseBasedOn, setWorstCaseBasedOn] = useState<"simulation" | "historical">(
     "simulation",
   );
   const [worstCaseSizing, setWorstCaseSizing] = useState<"absolute" | "relative">("relative");
+  // Whether the last completed run used the percentage-mode default ruin
+  // threshold (a 50% decline) rather than a value the user typed.
+  const [ruinThresholdDefaulted, setRuinThresholdDefaulted] = useState(false);
 
   // Chart display options
   const [scaleType, setScaleType] = useState<"linear" | "log">("linear");
@@ -292,16 +296,10 @@ export default function RiskSimulatorPage() {
     return count;
   }, [filteredTrades, resampleMethod, resamplePercentage]);
 
-  // The block-length hint has to describe the pool the run will actually draw
-  // from: in "pool" mode the synthetic worst-case trades join the pool, so
-  // leaving them out understates the automatic block length.
-  const effectivePoolSize = effectiveResamplePoolSize(estimatedPoolSize, {
-    enabled: worstCaseEnabled,
-    mode: worstCaseMode,
-    injectedCount: worstCaseSimulationBudget,
-  });
-
-  const autoBlockLength = defaultMeanBlockLength(Math.max(1, effectivePoolSize));
+  // The resample pool holds only real history — worst-case injection replaces
+  // slots after the draw and never changes the pool size — so the automatic
+  // block length always derives from the base pool.
+  const autoBlockLength = defaultMeanBlockLength(Math.max(1, estimatedPoolSize));
   const blockStepUnit = resampleMethod === "daily" ? "days" : "trades";
 
   // Prefer the block length a completed run reported over the pre-run estimate,
@@ -330,6 +328,14 @@ export default function RiskSimulatorPage() {
     unit: simulationPeriodUnit,
     paceText: tradesToTime(simulationLength, tradesPerYear).displayText,
   });
+
+  // Fixed historical dollars are incoherent in a scale-free percentage-return
+  // stream, so the option is unavailable there and the run always uses
+  // capital-relative sizing under the percentage method.
+  const isPercentageMethod = resampleMethod === "percentage";
+  const effectiveWorstCaseSizing: "absolute" | "relative" = isPercentageMethod
+    ? "relative"
+    : worstCaseSizing;
 
   const shouldShowHistoricalCapHint =
     worstCaseEnabled &&
@@ -406,12 +412,21 @@ export default function RiskSimulatorPage() {
         worstCasePercentage,
         worstCaseMode,
         worstCaseBasedOn,
-        worstCaseSizing,
+        worstCaseSizing: effectiveWorstCaseSizing,
+        // Zero-balance is structurally dead under percentage returns (capital
+        // cannot cross zero), so percentage runs default the ruin threshold
+        // to a 50% decline when the user has not set one. The lib stays
+        // explicit: it only ever sees a concrete threshold.
         ruinThresholdPct:
           ruinThresholdPercent !== null && ruinThresholdPercent > 0
             ? ruinThresholdPercent / 100
-            : undefined,
+            : isPercentageMethod
+              ? 0.5
+              : undefined,
       };
+      setRuinThresholdDefaulted(
+        isPercentageMethod && (ruinThresholdPercent === null || ruinThresholdPercent <= 0),
+      );
 
       const simulationResult = runMonteCarloSimulation(filteredTrades, params);
       setResult(simulationResult);
@@ -992,7 +1007,10 @@ export default function RiskSimulatorPage() {
                     <p>
                       <strong>Fixed Sizing Modes:</strong> Use <strong>Individual Trades</strong> or{" "}
                       <strong>Daily Returns</strong> only if you always trade fixed dollar amounts.
-                      Enable normalization to compare across different lot sizes.
+                      Enable normalization to compare across different lot sizes. These are also the
+                      home of dollar stress tests: to reproduce an Option Omega-style worst-case
+                      run, pick <strong>Individual Trades</strong> and size the injected losses with
+                      “Use historical dollars.”
                     </p>
                     <p>
                       <strong>Resampling:</strong> Stationary blocks keep short streaks of
@@ -1247,14 +1265,15 @@ export default function RiskSimulatorPage() {
                               </div>
                               <div className="px-4 pb-4">
                                 <p className="text-xs text-muted-foreground leading-relaxed">
-                                  Controls how many max-loss trades are created. In pool mode,
-                                  they&apos;re added to the resample pool. In guarantee mode,
-                                  they&apos;re forced into every simulation. Loss size is scaled to
-                                  your starting capital by default so 1% really means “a 1% hit to
-                                  the account per strategy.” Disable that below if you want to
-                                  inject the raw historical dollar margins instead. When margin data
-                                  is missing, we automatically use that strategy&apos;s largest
-                                  recorded loss so the test still reflects its downside.
+                                  Controls how many max-loss trades are injected. In probabilistic
+                                  mode each simulated trade has this chance of being replaced by a
+                                  max-loss event; in guarantee mode the exact count is forced into
+                                  every simulation. Loss size is scaled to your starting capital by
+                                  default so 1% really means “a 1% hit to the account per strategy.”
+                                  Switch to historical dollars below if you want to inject the raw
+                                  dollar margins instead. When margin data is missing, we
+                                  automatically use that strategy&apos;s largest recorded loss so
+                                  the test still reflects its downside.
                                 </p>
                               </div>
                             </div>
@@ -1317,12 +1336,14 @@ export default function RiskSimulatorPage() {
                               <div className="px-4 pb-4 space-y-3">
                                 <div>
                                   <p className="text-xs font-medium text-foreground">
-                                    Add to resample pool:
+                                    Probabilistic (chance per slot):
                                   </p>
                                   <p className="text-xs text-muted-foreground mt-1">
-                                    Max-loss trades are added to the pool and sampled randomly. They
-                                    may appear 0, 1, or multiple times per simulation. More
-                                    conservative approach.
+                                    After each simulated trade is drawn from your real history, it
+                                    has an independent chance of being replaced by a max-loss event.
+                                    Some simulations see more losses than requested, some fewer —
+                                    like real disaster risk. The losses land at independent
+                                    positions, never as a manufactured back-to-back run.
                                   </p>
                                 </div>
                                 <div>
@@ -1345,18 +1366,18 @@ export default function RiskSimulatorPage() {
                         <div className="flex items-center gap-2">
                           <input
                             type="radio"
-                            id="worst-case-pool"
+                            id="worst-case-probabilistic"
                             name="worst-case-mode"
-                            checked={worstCaseMode === "pool"}
-                            onChange={() => setWorstCaseMode("pool")}
+                            checked={worstCaseMode === "probabilistic"}
+                            onChange={() => setWorstCaseMode("probabilistic")}
                             className="cursor-pointer"
-                            aria-label="worst-case-pool"
+                            aria-label="worst-case-probabilistic"
                           />
                           <Label
-                            htmlFor="worst-case-pool"
+                            htmlFor="worst-case-probabilistic"
                             className="cursor-pointer text-sm font-normal"
                           >
-                            Add to pool (may randomly appear)
+                            Probabilistic (chance per slot)
                           </Label>
                         </div>
                         <div className="flex items-center gap-2">
@@ -1411,7 +1432,10 @@ export default function RiskSimulatorPage() {
                                   &nbsp;Injects the raw worst-case dollar amount from the trade log.
                                   Pick this if you want to replay the exact historical blow-ups and
                                   you&apos;re confident those dollar figures match today&apos;s
-                                  allocations.
+                                  allocations. Only available with the dollar sampling methods — a
+                                  fixed dollar loss has no stable meaning in a stream of percentage
+                                  returns. For an Option Omega-style dollar stress test, pair
+                                  Individual Trades sampling with this option.
                                 </p>
                               </div>
                             </div>
@@ -1424,7 +1448,7 @@ export default function RiskSimulatorPage() {
                             type="radio"
                             id="worst-case-sizing-relative"
                             name="worst-case-sizing"
-                            checked={worstCaseSizing === "relative"}
+                            checked={effectiveWorstCaseSizing === "relative"}
                             onChange={() => setWorstCaseSizing("relative")}
                             className="cursor-pointer"
                             aria-label="worst-case-sizing-relative"
@@ -1441,18 +1465,30 @@ export default function RiskSimulatorPage() {
                             type="radio"
                             id="worst-case-sizing-absolute"
                             name="worst-case-sizing"
-                            checked={worstCaseSizing === "absolute"}
+                            checked={effectiveWorstCaseSizing === "absolute"}
                             onChange={() => setWorstCaseSizing("absolute")}
-                            className="cursor-pointer"
+                            disabled={isPercentageMethod}
+                            className="cursor-pointer disabled:cursor-not-allowed"
                             aria-label="worst-case-sizing-absolute"
                           />
                           <Label
                             htmlFor="worst-case-sizing-absolute"
-                            className="cursor-pointer text-sm font-normal"
+                            className={
+                              isPercentageMethod
+                                ? "text-sm font-normal text-muted-foreground"
+                                : "cursor-pointer text-sm font-normal"
+                            }
                           >
                             Use historical dollars
                           </Label>
                         </div>
+                        {isPercentageMethod && (
+                          <p className="text-xs text-muted-foreground">
+                            Not available with Percentage Returns: a fixed dollar loss has no stable
+                            meaning when every path compounds at its own scale — switch to
+                            Individual Trades or Daily Returns to stress with historical dollars.
+                          </p>
+                        )}
                       </div>
                     </div>
 
@@ -1727,8 +1763,10 @@ export default function RiskSimulatorPage() {
                                 For example, 50 means an account that ever falls 50% below its
                                 starting value is counted as ruined, even if it later recovers. When
                                 set, the results include a Probability of Ruin card showing what
-                                fraction of simulations ever touched that line. Leave blank to skip
-                                this statistic.
+                                fraction of simulations ever touched that line. With Percentage
+                                Returns this is the primary ruin statistic (an account there can
+                                shrink but never hit zero), so leaving it blank uses a default of
+                                50; with the dollar sampling methods, blank skips the statistic.
                               </p>
                             </div>
                           </div>
@@ -1739,7 +1777,7 @@ export default function RiskSimulatorPage() {
                       id="ruin-threshold"
                       type="number"
                       value={ruinThresholdPercent ?? ""}
-                      placeholder="Off"
+                      placeholder={isPercentageMethod ? "Default 50" : "Off"}
                       onChange={(e) => {
                         const next = parseInt(e.target.value, 10);
                         setRuinThresholdPercent(
@@ -1753,7 +1791,9 @@ export default function RiskSimulatorPage() {
                     <p className="text-xs text-muted-foreground">
                       {ruinThresholdPercent !== null
                         ? `A path ever down ${ruinThresholdPercent}% from starting capital counts as ruined`
-                        : "Optional: percent decline from starting capital that counts as ruin"}
+                        : isPercentageMethod
+                          ? "Blank uses the default: a path ever down 50% from starting capital counts as ruined"
+                          : "Optional: percent decline from starting capital that counts as ruin"}
                     </p>
                   </div>
                 </div>
@@ -1862,7 +1902,11 @@ export default function RiskSimulatorPage() {
           </Card>
 
           {/* Statistics Cards */}
-          <StatisticsCards result={result} originalOrder={originalOrder} />
+          <StatisticsCards
+            result={result}
+            originalOrder={originalOrder}
+            ruinThresholdDefaulted={ruinThresholdDefaulted}
+          />
 
           {/* Distribution Charts */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/app/(platform)/risk-simulator/page.tsx
+++ b/app/(platform)/risk-simulator/page.tsx
@@ -63,6 +63,7 @@ import {
   selectBlockLengthHint,
 } from "./block-length-hint";
 import { describeSimulationHorizon } from "./horizon-notice";
+import { describeWorstCaseBudget } from "./worst-case-copy";
 import { Download, HelpCircle, Loader2, Play, RotateCcw } from "lucide-react";
 import { useTheme } from "next-themes";
 import dynamic from "next/dynamic";
@@ -1292,29 +1293,12 @@ export default function RiskSimulatorPage() {
                         <div className="w-16 text-right font-medium">{worstCasePercentage}%</div>
                       </div>
                       <p className="text-xs text-muted-foreground">
-                        {worstCaseBasedOn === "simulation" ? (
-                          worstCaseMode === "probabilistic" ? (
-                            <>
-                              Each simulated trade has a literal {worstCasePercentage}% chance of
-                              becoming a max-loss event (≈ {worstCaseSimulationBudget} per
-                              simulation on average), with the loss sizes split evenly across
-                              strategies.
-                            </>
-                          ) : (
-                            <>
-                              Exactly {worstCasePercentage}% of the simulation horizon (≈{" "}
-                              {worstCaseSimulationBudget} synthetic trades) split evenly across
-                              strategies.
-                            </>
-                          )
-                        ) : (
-                          <>
-                            Weighted by each strategy&apos;s historical trade count, but capped at{" "}
-                            {worstCasePercentage}% of the simulation (≈ {worstCaseSimulationBudget}{" "}
-                            trades) so the &quot;Force {worstCasePercentage}%&quot; promise stays
-                            accurate.
-                          </>
-                        )}
+                        {describeWorstCaseBudget({
+                          mode: worstCaseMode,
+                          basedOn: worstCaseBasedOn,
+                          percentage: worstCasePercentage,
+                          budget: worstCaseSimulationBudget,
+                        })}
                       </p>
                       {shouldShowHistoricalCapHint && (
                         <p className="text-[11px] text-amber-600">

--- a/app/(platform)/risk-simulator/worst-case-copy.ts
+++ b/app/(platform)/risk-simulator/worst-case-copy.ts
@@ -1,0 +1,48 @@
+/**
+ * Mode-aware captions for the worst-case injection budget.
+ *
+ * Guarantee mode forces an exact count into every simulation, so its captions
+ * may promise "exactly" and "force". Probabilistic mode replaces each
+ * simulated slot at the literal chance the percentage field states, so its
+ * captions speak in per-slot-chance and average terms — nothing is forced.
+ */
+
+export interface WorstCaseBudgetCopyInput {
+  mode: "probabilistic" | "guarantee";
+  basedOn: "simulation" | "historical";
+  /** The worst-case percentage the user typed (0-100) */
+  percentage: number;
+  /** Synthetic-trade budget for the run (expected count in probabilistic mode) */
+  budget: number;
+}
+
+export function describeWorstCaseBudget({
+  mode,
+  basedOn,
+  percentage,
+  budget,
+}: WorstCaseBudgetCopyInput): string {
+  if (basedOn === "simulation") {
+    if (mode === "probabilistic") {
+      return (
+        `Each simulated trade has a literal ${percentage}% chance of becoming a max-loss event ` +
+        `(≈ ${budget} per simulation on average), with the loss sizes split evenly across strategies.`
+      );
+    }
+    return (
+      `Exactly ${percentage}% of the simulation horizon (≈ ${budget} synthetic trades) ` +
+      `split evenly across strategies.`
+    );
+  }
+
+  if (mode === "probabilistic") {
+    return (
+      `Loss values are weighted by each strategy's historical trade count; each simulated trade ` +
+      `keeps a literal ${percentage}% replacement chance (≈ ${budget} per simulation on average).`
+    );
+  }
+  return (
+    `Weighted by each strategy's historical trade count, but capped at ${percentage}% of the ` +
+    `simulation (≈ ${budget} trades) so the "Force ${percentage}%" promise stays accurate.`
+  );
+}

--- a/components/risk-simulator/statistics-cards.tsx
+++ b/components/risk-simulator/statistics-cards.tsx
@@ -19,10 +19,25 @@ import {
 interface StatisticsCardsProps {
   result: MonteCarloResult;
   originalOrder?: OriginalOrderPath | null;
+  /**
+   * True when the run's ruin threshold was the percentage-mode default (a 50%
+   * decline) rather than a value the user typed, so the card can say so.
+   */
+  ruinThresholdDefaulted?: boolean;
 }
 
-export function StatisticsCards({ result, originalOrder }: StatisticsCardsProps) {
+export function StatisticsCards({
+  result,
+  originalOrder,
+  ruinThresholdDefaulted = false,
+}: StatisticsCardsProps) {
   const { statistics, parameters } = result;
+
+  // A percentage return clamps at -100% of current equity, so a percentage
+  // path can shrink toward zero but never cross it. Zero-Balance Paths is
+  // structurally 0% there — never a live statistic. Probability of Ruin is
+  // the honest ruin figure for percentage mode.
+  const isPercentageMode = parameters.resampleMethod === "percentage";
 
   // Calculate annualized return
   const yearsSimulated = parameters.simulationLength / parameters.tradesPerYear;
@@ -221,47 +236,7 @@ export function StatisticsCards({ result, originalOrder }: StatisticsCardsProps)
             </Card>
           )}
 
-          {/* Zero-Balance Paths */}
-          <Card className="p-4">
-            <div className="flex items-start justify-between mb-3">
-              <div className="flex items-center gap-2">
-                <CircleOff className="h-5 w-5 text-red-500" />
-                <span className="text-sm font-medium text-muted-foreground">
-                  Zero-Balance Paths
-                </span>
-              </div>
-              <HoverCard>
-                <HoverCardTrigger asChild>
-                  <HelpCircle className="h-4 w-4 text-muted-foreground/60 cursor-help" />
-                </HoverCardTrigger>
-                <HoverCardContent className="w-80 p-0 overflow-hidden">
-                  <div className="space-y-3">
-                    <div className="bg-primary/5 border-b px-4 py-3">
-                      <h4 className="text-sm font-semibold text-primary">Zero-Balance Paths</h4>
-                    </div>
-                    <div className="px-4 pb-4 space-y-3">
-                      <p className="text-sm font-medium text-foreground leading-relaxed">
-                        Percentage of simulations whose account value ever touched zero.
-                      </p>
-                      <p className="text-xs text-muted-foreground leading-relaxed">
-                        A path counts even if the touch happened mid-simulation. For most strategies
-                        this should be 0% — anything above that means some reshuffled versions of
-                        your history wiped out the account entirely.
-                      </p>
-                    </div>
-                  </div>
-                </HoverCardContent>
-              </HoverCard>
-            </div>
-            <div>
-              <div className="text-2xl font-bold">
-                {(statistics.zeroBalancePaths * 100).toFixed(1)}%
-              </div>
-              <div className="text-xs text-muted-foreground mt-1">Simulations that ever hit $0</div>
-            </div>
-          </Card>
-
-          {/* Probability of Ruin */}
+          {/* Probability of Ruin — the primary ruin figure in percentage mode */}
           {statistics.probabilityOfRuin !== undefined &&
             parameters.ruinThresholdPct !== undefined && (
               <Card className="p-4">
@@ -295,21 +270,97 @@ export function StatisticsCards({ result, originalOrder }: StatisticsCardsProps)
                             the loss level you could not survive (financially or psychologically)
                             and treat this as the chance of hitting it.
                           </p>
+                          {ruinThresholdDefaulted && (
+                            <p className="text-xs text-muted-foreground leading-relaxed">
+                              This run used the default 50%-decline threshold. Set Ruin Threshold in
+                              Advanced Settings to pick your own line.
+                            </p>
+                          )}
                         </div>
                       </div>
                     </HoverCardContent>
                   </HoverCard>
                 </div>
                 <div>
-                  <div className="text-2xl font-bold text-red-600 dark:text-red-400">
+                  <div
+                    className="text-2xl font-bold text-red-600 dark:text-red-400"
+                    data-testid="ruin-value"
+                  >
                     {(statistics.probabilityOfRuin * 100).toFixed(1)}%
                   </div>
-                  <div className="text-xs text-muted-foreground mt-1">
+                  <div className="text-xs text-muted-foreground mt-1" data-testid="ruin-caption">
                     Ever down {(parameters.ruinThresholdPct * 100).toFixed(0)}% from start
+                    {ruinThresholdDefaulted ? " (the default threshold)" : ""}
                   </div>
                 </div>
               </Card>
             )}
+
+          {/* Zero-Balance Paths — live only for dollar sampling methods */}
+          {isPercentageMode ? (
+            <Card className="p-4 opacity-60">
+              <div className="flex items-start justify-between mb-3">
+                <div className="flex items-center gap-2">
+                  <CircleOff className="h-5 w-5 text-muted-foreground" />
+                  <span className="text-sm font-medium text-muted-foreground">
+                    Zero-Balance Paths
+                  </span>
+                </div>
+              </div>
+              <div>
+                <div className="text-2xl font-bold text-muted-foreground">—</div>
+                <div
+                  className="text-xs text-muted-foreground mt-1"
+                  data-testid="zero-balance-unavailable"
+                >
+                  Not measurable with percentage returns: a percentage loss can never take the
+                  account below zero, so this would always read 0%. Probability of Ruin is the
+                  honest figure here; dollar sampling methods report zero-balance paths.
+                </div>
+              </div>
+            </Card>
+          ) : (
+            <Card className="p-4">
+              <div className="flex items-start justify-between mb-3">
+                <div className="flex items-center gap-2">
+                  <CircleOff className="h-5 w-5 text-red-500" />
+                  <span className="text-sm font-medium text-muted-foreground">
+                    Zero-Balance Paths
+                  </span>
+                </div>
+                <HoverCard>
+                  <HoverCardTrigger asChild>
+                    <HelpCircle className="h-4 w-4 text-muted-foreground/60 cursor-help" />
+                  </HoverCardTrigger>
+                  <HoverCardContent className="w-80 p-0 overflow-hidden">
+                    <div className="space-y-3">
+                      <div className="bg-primary/5 border-b px-4 py-3">
+                        <h4 className="text-sm font-semibold text-primary">Zero-Balance Paths</h4>
+                      </div>
+                      <div className="px-4 pb-4 space-y-3">
+                        <p className="text-sm font-medium text-foreground leading-relaxed">
+                          Percentage of simulations whose account value ever touched zero.
+                        </p>
+                        <p className="text-xs text-muted-foreground leading-relaxed">
+                          A path counts even if the touch happened mid-simulation. For most
+                          strategies this should be 0% — anything above that means some reshuffled
+                          versions of your history wiped out the account entirely.
+                        </p>
+                      </div>
+                    </div>
+                  </HoverCardContent>
+                </HoverCard>
+              </div>
+              <div>
+                <div className="text-2xl font-bold" data-testid="zero-balance-value">
+                  {(statistics.zeroBalancePaths * 100).toFixed(1)}%
+                </div>
+                <div className="text-xs text-muted-foreground mt-1">
+                  Simulations that ever hit $0
+                </div>
+              </div>
+            </Card>
+          )}
         </div>
       </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tradeblocks",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tradeblocks",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "workspaces": [
         "packages/*"
       ],
@@ -22781,7 +22781,7 @@
     },
     "packages/mcp-server": {
       "name": "tradeblocks-mcp",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "license": "MIT",
       "dependencies": {
         "@duckdb/node-api": "^1.4.4-r.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "private": true,
   "workspaces": [

--- a/packages/lib/calculations/monte-carlo.ts
+++ b/packages/lib/calculations/monte-carlo.ts
@@ -90,9 +90,8 @@ export interface MonteCarloParams {
    * losses never join the resample pool, so a stationary-block walk can
    * never step through them as a contiguous catastrophe run.
    * - "probabilistic" (default): each slot is independently replaced with
-   *   probability injectedCount / (poolSize + injectedCount) — the honest
-   *   per-slot meaning of the former pool membership. "pool" is accepted as
-   *   an alias for this mode.
+   *   probability worstCasePercentage / 100 — the literal per-slot chance
+   *   the field promises. "pool" is accepted as an alias for this mode.
    * - "guarantee": exactly the requested count is spliced into every
    *   simulation at independent random positions.
    */
@@ -1236,13 +1235,15 @@ export function runMonteCarloSimulation(
   // contiguous region a stationary-block walk could traverse, manufacturing
   // consecutive max-loss runs no user asked for. "probabilistic" (with
   // "pool" as its accepted alias, and the default) replaces each slot
-  // independently at the probability pool membership would have implied;
-  // "guarantee" splices the exact count at independent positions.
+  // independently at the literal chance the percentage field promises —
+  // worstCasePercentage / 100, not a ratio derived from a pool the
+  // synthetics no longer join. "guarantee" splices the exact count at
+  // independent positions.
   const worstCaseMode: "probabilistic" | "guarantee" =
     params.worstCaseMode === "guarantee" ? "guarantee" : "probabilistic";
   const replacementProbability =
     worstCaseMode === "probabilistic" && worstCaseTrades.length > 0
-      ? worstCaseTrades.length / (resamplePool.length + worstCaseTrades.length)
+      ? Math.min(1, (params.worstCasePercentage ?? 0) / 100)
       : 0;
 
   // Stationary-block resampling is the default: block resampling preserves

--- a/packages/lib/calculations/monte-carlo.ts
+++ b/packages/lib/calculations/monte-carlo.ts
@@ -296,6 +296,14 @@ export interface MonteCarloResult {
    * changes the pool size.
    */
   effectiveMeanBlockLength: number | null;
+
+  /**
+   * Per-slot replacement probability the run actually used for probabilistic
+   * worst-case injection: exactly worstCasePercentage / 100 (clamped at 1),
+   * never a ratio derived from the pool. Null when injection is disabled,
+   * created no synthetic losses, or ran in "guarantee" mode.
+   */
+  effectiveWorstCaseReplacementProbability: number | null;
 }
 
 /**
@@ -1330,6 +1338,8 @@ export function runMonteCarloSimulation(
     timestamp,
     actualResamplePoolSize,
     effectiveMeanBlockLength: useStationaryBlocks ? meanBlockLength : null,
+    effectiveWorstCaseReplacementProbability:
+      replacementProbability > 0 ? replacementProbability : null,
   };
 }
 

--- a/packages/lib/calculations/monte-carlo.ts
+++ b/packages/lib/calculations/monte-carlo.ts
@@ -84,13 +84,29 @@ export interface MonteCarloParams {
   /** Percentage of trades that should be max-loss scenarios (0-100) */
   worstCasePercentage?: number;
 
-  /** How to inject worst-case trades: add to pool or guarantee in every simulation */
-  worstCaseMode?: "pool" | "guarantee";
+  /**
+   * How to inject worst-case trades. Injection is a per-slot replacement
+   * layer applied AFTER the sampler draws from real history — synthetic
+   * losses never join the resample pool, so a stationary-block walk can
+   * never step through them as a contiguous catastrophe run.
+   * - "probabilistic" (default): each slot is independently replaced with
+   *   probability injectedCount / (poolSize + injectedCount) — the honest
+   *   per-slot meaning of the former pool membership. "pool" is accepted as
+   *   an alias for this mode.
+   * - "guarantee": exactly the requested count is spliced into every
+   *   simulation at independent random positions.
+   */
+  worstCaseMode?: "probabilistic" | "pool" | "guarantee";
 
   /** What to base the percentage on: simulation length (default) or historical data */
   worstCaseBasedOn?: "simulation" | "historical";
 
-  /** How to size each synthetic loss: absolute historical dollars or scale to account capital */
+  /**
+   * How to size each synthetic loss: absolute historical dollars or scale to
+   * account capital. "absolute" is only coherent when the simulation itself
+   * runs in dollars — combining it with resampleMethod "percentage" is a
+   * validation error (see ABSOLUTE_SIZING_PERCENTAGE_ERROR).
+   */
   worstCaseSizing?: "absolute" | "relative";
 
   /**
@@ -276,8 +292,9 @@ export interface MonteCarloResult {
   /**
    * Mean block length actually used for stationary-block resampling, null when
    * resampleMode is "iid". Reflects the auto default (cube root of the pool
-   * size, including any injected worst-case losses) when meanBlockLength was
-   * not supplied.
+   * size) when meanBlockLength was not supplied. The pool holds only real
+   * history — worst-case injection replaces slots after the draw and never
+   * changes the pool size.
    */
   effectiveMeanBlockLength: number | null;
 }
@@ -355,31 +372,17 @@ export function worstCaseInjectionCount(
 }
 
 /**
- * Size of the resample pool a run will actually draw from.
- *
- * In "pool" mode the synthetic worst-case trades join the pool, so they count
- * toward the pool size the automatic mean block length is derived from. In
- * "guarantee" mode they are spliced into each path after resampling and leave
- * the pool unchanged.
- *
- * @param basePoolSize - Pool size before worst-case injection
- * @param worstCase - Worst-case injection settings for the run
- * @returns Effective pool size
+ * Validation message for the one worst-case configuration that has no
+ * coherent meaning: a fixed historical-dollar loss injected into a stream of
+ * percentage returns. Percentage paths are scale-free, so a fixed dollar
+ * amount either gets pre-baked into a ratio of starting capital (neither
+ * dollars nor honest) or applied against live capital (ruinous, because the
+ * percentage stream lacks the grown-account dollar wins that offset fixed
+ * shocks in dollar resampling). Shared with the MCP schema so both surfaces
+ * reject the combination with the same words.
  */
-export function effectiveResamplePoolSize(
-  basePoolSize: number,
-  worstCase: {
-    enabled: boolean;
-    mode: "pool" | "guarantee";
-    injectedCount: number;
-  },
-): number {
-  const base = Math.max(0, basePoolSize);
-  if (!worstCase.enabled || worstCase.mode !== "pool") {
-    return base;
-  }
-  return base + Math.max(0, worstCase.injectedCount);
-}
+export const ABSOLUTE_SIZING_PERCENTAGE_ERROR =
+  "Historical-dollar loss sizing is not available with percentage returns: a fixed dollar amount has no stable meaning in a scale-free return stream. Use a dollar sampling method ('trades' or 'daily') for historical-dollar stress tests, or 'relative' sizing to scale each loss to account capital.";
 
 /**
  * A ruin threshold is only honored when it is strictly positive. Zero puts the
@@ -1115,6 +1118,19 @@ export function runMonteCarloSimulation(
     );
   }
 
+  const worstCaseRequested =
+    params.worstCaseEnabled === true &&
+    params.worstCasePercentage !== undefined &&
+    params.worstCasePercentage > 0;
+
+  if (
+    worstCaseRequested &&
+    params.resampleMethod === "percentage" &&
+    params.worstCaseSizing === "absolute"
+  ) {
+    throw new Error(ABSOLUTE_SIZING_PERCENTAGE_ERROR);
+  }
+
   const timestamp = new Date();
 
   // Get resample pool based on method
@@ -1175,7 +1191,7 @@ export function runMonteCarloSimulation(
 
   // Handle worst-case scenario injection
   let worstCaseTrades: number[] = [];
-  if (params.worstCaseEnabled && params.worstCasePercentage && params.worstCasePercentage > 0) {
+  if (worstCaseRequested && params.worstCasePercentage) {
     // Create synthetic max-loss trades
     const syntheticTrades = createSyntheticMaxLossTrades(
       trades,
@@ -1192,16 +1208,14 @@ export function runMonteCarloSimulation(
     const capitalBasis = capitalBasisRaw > 0 ? capitalBasisRaw : 1;
 
     if (params.resampleMethod === "percentage") {
+      // Absolute sizing is rejected above, so percentage-mode synthetics are
+      // always capital-relative losses.
       worstCaseTrades = syntheticTrades.map((t) => {
-        if (lossSizing === "relative") {
-          const ratio = t.syntheticCapitalRatio;
-          if (ratio && ratio > 0) {
-            return -Math.abs(ratio);
-          }
-          return t.pl / capitalBasis;
+        const ratio = t.syntheticCapitalRatio;
+        if (ratio && ratio > 0) {
+          return -Math.abs(ratio);
         }
-        const pl = params.normalizeTo1Lot ? scaleTradeToOneLot(t) : t.pl;
-        return pl / capitalBasis;
+        return t.pl / capitalBasis;
       });
     } else {
       worstCaseTrades = syntheticTrades.map((t) => {
@@ -1215,15 +1229,21 @@ export function runMonteCarloSimulation(
         return params.normalizeTo1Lot ? scaleTradeToOneLot(t) : t.pl;
       });
     }
-
-    // If mode is "pool", add to resample pool. With stationary-block
-    // resampling the injected synthetic losses simply join the pool and can
-    // appear inside blocks; "guarantee" mode splices them into each path
-    // after resampling, exactly as in iid mode.
-    if (params.worstCaseMode === "pool") {
-      resamplePool = [...resamplePool, ...worstCaseTrades];
-    }
   }
+
+  // Injection is a per-slot replacement layer applied after the draw, never
+  // pool membership: synthetics appended to the pool would sit in one
+  // contiguous region a stationary-block walk could traverse, manufacturing
+  // consecutive max-loss runs no user asked for. "probabilistic" (with
+  // "pool" as its accepted alias, and the default) replaces each slot
+  // independently at the probability pool membership would have implied;
+  // "guarantee" splices the exact count at independent positions.
+  const worstCaseMode: "probabilistic" | "guarantee" =
+    params.worstCaseMode === "guarantee" ? "guarantee" : "probabilistic";
+  const replacementProbability =
+    worstCaseMode === "probabilistic" && worstCaseTrades.length > 0
+      ? worstCaseTrades.length / (resamplePool.length + worstCaseTrades.length)
+      : 0;
 
   // Stationary-block resampling is the default: block resampling preserves
   // the historical clustering of consecutive trades, which real P&L exhibits,
@@ -1234,7 +1254,7 @@ export function runMonteCarloSimulation(
   const meanBlockLength = params.meanBlockLength ?? defaultMeanBlockLength(resamplePool.length);
 
   const enforcedGuaranteeTrades =
-    params.worstCaseEnabled && params.worstCaseMode === "guarantee" && params.simulationLength > 0
+    worstCaseMode === "guarantee" && params.simulationLength > 0
       ? worstCaseTrades.slice(0, Math.min(worstCaseTrades.length, params.simulationLength))
       : [];
 
@@ -1271,6 +1291,16 @@ export function runMonteCarloSimulation(
       }
 
       resampledPLs = combined;
+    } else if (replacementProbability > 0) {
+      // Per-slot replacement: each drawn slot is independently swapped for a
+      // synthetic max-loss event. A dedicated RNG stream keeps the baseline
+      // draw identical whether or not injection is enabled.
+      const rng = seed !== undefined ? createSeededRandom(seed + 999999) : Math.random;
+      for (let position = 0; position < resampledPLs.length; position++) {
+        if (rng() < replacementProbability) {
+          resampledPLs[position] = worstCaseTrades[Math.floor(rng() * worstCaseTrades.length)];
+        }
+      }
     }
 
     // Run simulation

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tradeblocks-mcp",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "MCP server for options trade analysis",
   "author": "David Romeo <davidmromeo@gmail.com>",
   "type": "module",

--- a/packages/mcp-server/src/tools/analysis.ts
+++ b/packages/mcp-server/src/tools/analysis.ts
@@ -557,13 +557,13 @@ export function registerAnalysisTools(server: McpServer, baseDir: string): void 
           .max(100)
           .default(5)
           .describe(
-            "Percentage of simulation length that should be max-loss scenarios (0-100, default: 5)",
+            "Worst-case intensity (0-100, default: 5). In probabilistic mode this is the literal per-slot replacement chance (5 = each simulated step has a 5% chance of becoming a max-loss event); in guarantee mode it is the exact share of the simulation length forced into every path.",
           ),
         worstCaseMode: z
           .enum(["probabilistic", "pool", "guarantee"])
           .default("probabilistic")
           .describe(
-            "How to inject worst-case losses. Injection is a per-slot replacement layer applied after the sampler draws from real history — synthetic losses never join the resample pool, so block resampling cannot walk through them as a contiguous catastrophe run. 'probabilistic' (default): each simulated step is independently replaced with probability injectedCount / (poolSize + injectedCount); 'pool' is the legacy alias for the same behavior. 'guarantee' forces exactly the requested count into every simulation at independent random positions.",
+            "How to inject worst-case losses. Injection is a per-slot replacement layer applied after the sampler draws from real history — synthetic losses never join the resample pool, so block resampling cannot walk through them as a contiguous catastrophe run. 'probabilistic' (default): each simulated step is independently replaced with probability worstCasePercentage / 100, the literal per-slot chance; 'pool' is the legacy alias for the same behavior. 'guarantee' forces exactly the requested count into every simulation at independent random positions.",
           ),
         worstCaseSizing: z
           .enum(["absolute", "relative"])

--- a/packages/mcp-server/src/tools/analysis.ts
+++ b/packages/mcp-server/src/tools/analysis.ts
@@ -16,6 +16,7 @@ import {
 } from "../utils/output-formatter.ts";
 import {
   WalkForwardAnalyzer,
+  ABSOLUTE_SIZING_PERCENTAGE_ERROR,
   assessResults,
   getRecommendedParameters,
   runMonteCarloSimulation,
@@ -559,16 +560,16 @@ export function registerAnalysisTools(server: McpServer, baseDir: string): void 
             "Percentage of simulation length that should be max-loss scenarios (0-100, default: 5)",
           ),
         worstCaseMode: z
-          .enum(["pool", "guarantee"])
-          .default("pool")
+          .enum(["probabilistic", "pool", "guarantee"])
+          .default("probabilistic")
           .describe(
-            "How to inject worst-case: 'pool' adds synthetic losses to resample pool, 'guarantee' ensures worst-case appears in every simulation",
+            "How to inject worst-case losses. Injection is a per-slot replacement layer applied after the sampler draws from real history — synthetic losses never join the resample pool, so block resampling cannot walk through them as a contiguous catastrophe run. 'probabilistic' (default): each simulated step is independently replaced with probability injectedCount / (poolSize + injectedCount); 'pool' is the legacy alias for the same behavior. 'guarantee' forces exactly the requested count into every simulation at independent random positions.",
           ),
         worstCaseSizing: z
           .enum(["absolute", "relative"])
           .default("relative")
           .describe(
-            "Worst-case sizing: 'absolute' uses historical dollar amounts, 'relative' scales to account capital ratio",
+            "Worst-case sizing: 'absolute' uses historical dollar amounts, 'relative' scales to account capital ratio. 'absolute' requires a dollar sampling method ('trades' or 'daily') — combined with resampleMethod 'percentage' the tool returns an error, because a fixed dollar loss has no stable meaning in a scale-free return stream.",
           ),
         worstCaseBasedOn: z
           .enum(["simulation", "historical"])
@@ -607,6 +608,16 @@ export function registerAnalysisTools(server: McpServer, baseDir: string): void 
       historicalInitialCapital,
     }) => {
       try {
+        // Reject the one incoherent combination up front, with the same
+        // message the calculation library uses, so callers see it whether or
+        // not injection would have created any synthetic losses.
+        if (resampleMethod === "percentage" && worstCaseSizing === "absolute") {
+          return {
+            content: [{ type: "text", text: ABSOLUTE_SIZING_PERCENTAGE_ERROR }],
+            isError: true,
+          };
+        }
+
         const block = await loadBlock(baseDir, blockId);
         let trades = block.trades;
 
@@ -701,7 +712,7 @@ export function registerAnalysisTools(server: McpServer, baseDir: string): void 
             normalizeTo1Lot: params.normalizeTo1Lot ?? false,
             worstCaseEnabled: includeWorstCase,
             worstCasePercentage: params.worstCasePercentage ?? 0,
-            worstCaseMode: params.worstCaseMode ?? "pool",
+            worstCaseMode: params.worstCaseMode ?? "probabilistic",
             worstCaseBasedOn: params.worstCaseBasedOn ?? "simulation",
             worstCaseSizing: params.worstCaseSizing ?? "relative",
           },

--- a/packages/mcp-server/src/tools/analysis.ts
+++ b/packages/mcp-server/src/tools/analysis.ts
@@ -499,7 +499,7 @@ export function registerAnalysisTools(server: McpServer, baseDir: string): void 
           .enum(["trades", "daily", "percentage"])
           .default("trades")
           .describe(
-            "What to resample: 'trades' (individual trade P&L), 'daily' (daily aggregated returns), 'percentage' (percentage returns for compounding strategies)",
+            "What to resample: 'trades' (individual trade P&L), 'daily' (daily aggregated returns), 'percentage' (percentage returns for compounding strategies). Under 'percentage', zeroBalancePaths is structurally 0 — per-step returns clamp at -100% of current equity, so capital can never cross zero — and probabilityOfRuin (via ruinThresholdPct) is the meaningful ruin statistic.",
           ),
         resampleMode: z
           .enum(["stationary-block", "iid"])
@@ -689,7 +689,11 @@ export function registerAnalysisTools(server: McpServer, baseDir: string): void 
           stats.probabilityOfRuin !== undefined
             ? ` | P(Ruin): ${formatPercent(stats.probabilityOfRuin * 100)}`
             : "";
-        const summary = `Monte Carlo: ${blockId}${strategy ? ` (${strategy})` : ""} | ${numSimulations} sims | Mean Return: ${formatPercent(stats.meanTotalReturn * 100)} | P(Profit): ${formatPercent(stats.probabilityOfProfit * 100)} | 95% VaR: ${formatPercent(stats.valueAtRisk.p5 * 100)}${ruinNote}`;
+        const zeroBalanceNote =
+          resampleMethod === "percentage"
+            ? " | Note: zeroBalancePaths is structurally 0 under percentage returns (per-step losses clamp at -100% of current equity, so capital cannot cross zero) — read probabilityOfRuin for ruin risk."
+            : "";
+        const summary = `Monte Carlo: ${blockId}${strategy ? ` (${strategy})` : ""} | ${numSimulations} sims | Mean Return: ${formatPercent(stats.meanTotalReturn * 100)} | P(Profit): ${formatPercent(stats.probabilityOfProfit * 100)} | 95% VaR: ${formatPercent(stats.valueAtRisk.p5 * 100)}${ruinNote}${zeroBalanceNote}`;
 
         // Build structured data for Claude reasoning
         const structuredData = {
@@ -728,7 +732,10 @@ export function registerAnalysisTools(server: McpServer, baseDir: string): void 
             medianMaxDrawdown: stats.medianMaxDrawdown,
             meanSharpeRatio: stats.meanSharpeRatio,
             probabilityOfProfit: stats.probabilityOfProfit,
-            // Fraction of paths whose capital touched zero at any step
+            // Fraction of paths whose capital touched zero at any step.
+            // Structurally 0 under resampleMethod "percentage" (per-step
+            // returns clamp at -100% of current equity, so capital can never
+            // cross zero) — probabilityOfRuin is the ruin statistic there.
             zeroBalancePaths: stats.zeroBalancePaths,
             // Fraction of paths that ever fell to ruinThresholdPct below
             // starting capital; null unless a threshold was supplied

--- a/packages/mcp-server/src/tools/blocks/health.ts
+++ b/packages/mcp-server/src/tools/blocks/health.ts
@@ -942,7 +942,7 @@ export function registerHealthBlockTools(server: McpServer, baseDir: string): vo
             tradesPerYear: calculatedTradesPerYear,
             worstCaseEnabled: true,
             worstCasePercentage: 5,
-            worstCaseMode: "pool",
+            worstCaseMode: "probabilistic",
             worstCaseBasedOn: "simulation",
             worstCaseSizing: "relative",
           };

--- a/packages/mcp-server/tests/integration/monte-carlo-tool.test.ts
+++ b/packages/mcp-server/tests/integration/monte-carlo-tool.test.ts
@@ -201,3 +201,60 @@ describe("run_monte_carlo ruin statistics", () => {
     );
   });
 });
+
+describe("run_monte_carlo worst-case injection surface", () => {
+  it("defaults the injection mode to probabilistic", () => {
+    const parsed = schema.parse({ blockId: BLOCK_ID }) as Record<string, unknown>;
+    expect(parsed.worstCaseMode).toBe("probabilistic");
+  });
+
+  it("accepts 'pool' as a legacy alias and 'guarantee' unchanged", () => {
+    expect(schema.parse({ blockId: BLOCK_ID, worstCaseMode: "pool" })).toMatchObject({
+      worstCaseMode: "pool",
+    });
+    expect(schema.parse({ blockId: BLOCK_ID, worstCaseMode: "guarantee" })).toMatchObject({
+      worstCaseMode: "guarantee",
+    });
+  });
+
+  it("'pool' produces the same results as 'probabilistic'", async () => {
+    const input = {
+      numSimulations: 200,
+      randomSeed: 42,
+      includeWorstCase: true,
+      worstCasePercentage: 5,
+      worstCaseSizing: "absolute",
+    };
+    const probabilistic = await runTool({ ...input, worstCaseMode: "probabilistic" });
+    const pool = await runTool({ ...input, worstCaseMode: "pool" });
+    expect(pool.data.statistics).toEqual(probabilistic.data.statistics);
+  });
+
+  it("rejects absolute sizing under the percentage method with the shared message", async () => {
+    const parsed = schema.parse({
+      blockId: BLOCK_ID,
+      resampleMethod: "percentage",
+      worstCaseSizing: "absolute",
+      randomSeed: 42,
+    });
+    const result = await handler(parsed);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]?.text).toContain(
+      "Historical-dollar loss sizing is not available with percentage returns",
+    );
+    expect(result.content[0]?.text).toContain("'trades' or 'daily'");
+  });
+
+  it("allows relative sizing under the percentage method", async () => {
+    const { data } = await runTool({
+      numSimulations: 200,
+      randomSeed: 42,
+      resampleMethod: "percentage",
+      includeWorstCase: true,
+      worstCasePercentage: 5,
+      worstCaseSizing: "relative",
+    });
+    expect(data.parameters.resampleMethod).toBe("percentage");
+  });
+});

--- a/packages/mcp-server/tests/integration/monte-carlo-tool.test.ts
+++ b/packages/mcp-server/tests/integration/monte-carlo-tool.test.ts
@@ -246,6 +246,26 @@ describe("run_monte_carlo worst-case injection surface", () => {
     expect(result.content[0]?.text).toContain("'trades' or 'daily'");
   });
 
+  it("flags zeroBalancePaths as structurally 0 in percentage-mode summaries", async () => {
+    // The field stays in the output (consumers may key on it), but an agent
+    // reading the summary must not mistake it for a live risk signal:
+    // percentage-mode returns clamp at -100% of current equity, so capital
+    // can never cross zero and the field always reads 0.
+    const { data, summary } = await runTool({ ...BASE_INPUT, resampleMethod: "percentage" });
+
+    expect(data.statistics.zeroBalancePaths).toBe(0);
+    expect(summary).toMatch(/structurally 0/);
+    expect(summary).toMatch(/probabilityOfRuin/);
+  });
+
+  it("adds no zero-balance note for dollar sampling methods", async () => {
+    const trades = await runTool(BASE_INPUT);
+    expect(trades.summary).not.toMatch(/structurally 0/);
+
+    const daily = await runTool({ ...BASE_INPUT, resampleMethod: "daily" });
+    expect(daily.summary).not.toMatch(/structurally 0/);
+  });
+
   it("allows relative sizing under the percentage method", async () => {
     const { data } = await runTool({
       numSimulations: 200,

--- a/releases/v3.9.0.md
+++ b/releases/v3.9.0.md
@@ -1,0 +1,64 @@
+# Tradeblocks 3.9.0
+
+## Worst-case injection no longer clusters under block resampling
+
+If you ran worst-case stress tests in "pool" mode with stationary-block
+resampling — both defaults — your results were overstated. Pool mode appended
+the synthetic max-loss trades to the resample pool as one contiguous run, so a
+block walk that entered that region stepped through consecutive max-loss
+trades: a catastrophe cluster no setting asked for. On a real 670-trade log
+stressed with a $90k loss at 5%, that displaced the median outcome by roughly
+half and doubled the share of wiped-out paths.
+
+Injection is now a per-slot replacement layer applied after the sampler draws
+from real history. Synthetic losses never join the pool, land at independent
+positions, and can never arrive as a manufactured back-to-back run. Pool-mode
+results shift accordingly: medians and tails move to the de-clustered figures.
+**Re-baseline any stored pool-mode stress results when upgrading.** Guarantee
+mode keeps its exact-count semantics and was never affected by the clustering.
+
+## Probabilistic injection is the honest name for pool mode
+
+The de-clustered semantics get the name they deserve: `worstCaseMode:
+"probabilistic"` is the new default and canonical value. Each simulated step
+is independently replaced by a max-loss event with probability injectedCount /
+(poolSize + injectedCount) — exactly the per-slot chance pool membership
+always implied, and the same binomial "chance per slot" stress that
+Option Omega's worst-case test runs. Some simulations see more losses than
+requested, some fewer, like real disaster risk. `"pool"` remains accepted as
+an alias for the same behavior, so existing calls and saved configurations
+keep working. `"guarantee"` still forces the exact count into every
+simulation.
+
+## Historical dollars and percentage returns no longer mix
+
+Injecting a fixed historical-dollar loss into a percentage-return simulation
+never had a coherent meaning: a fixed dollar amount has no stable size in a
+stream where every path compounds at its own scale. The shipped behavior
+pre-baked the loss into a ratio of starting capital — neither dollars nor
+honest — and the alternative, applying dollars against live capital, ruins
+nearly every path. The combination is now a validation error in the library,
+a rejected request in `run_monte_carlo`, and a disabled option in the Risk
+Simulator, each pointing to the coherent recipe: dollar stress tests belong
+to the dollar sampling methods. To reproduce an Option Omega-style worst-case
+run, use Individual Trades with "Use historical dollars."
+
+## The Reality Check now matches the sampling method
+
+Zero-Balance Paths is structurally dead under percentage returns: a
+percentage loss clamps at -100% of current equity, so capital can shrink but
+never cross zero, and the card always read exactly 0.0% right where the UI
+recommends users live. Under Percentage Returns the Risk Simulator now leads
+with Probability of Ruin — defaulting to a 50%-decline threshold when you
+have not set one, with the existing Ruin Threshold input overriding — and
+shows Zero-Balance Paths as unavailable with one honest sentence. Dollar
+sampling methods keep Zero-Balance Paths as the primary ruin figure.
+
+## `run_monte_carlo` parameters
+
+The tool accepts `worstCaseMode: "probabilistic"` (the new default, with
+`"pool"` documented as its legacy alias) and rejects `worstCaseSizing:
+"absolute"` combined with `resampleMethod: "percentage"` with the same
+message the library uses. `portfolio_health_check` runs its stress leg in
+probabilistic mode — the same injection it always meant, now without the
+block-walk clustering.

--- a/releases/v3.9.0.md
+++ b/releases/v3.9.0.md
@@ -20,12 +20,11 @@ mode keeps its exact-count semantics and was never affected by the clustering.
 ## Probabilistic injection is the honest name for pool mode
 
 The de-clustered semantics get the name they deserve: `worstCaseMode:
-"probabilistic"` is the new default and canonical value. Each simulated step
-is independently replaced by a max-loss event with probability injectedCount /
-(poolSize + injectedCount) — exactly the per-slot chance pool membership
-always implied, and the same binomial "chance per slot" stress that
-Option Omega's worst-case test runs. Some simulations see more losses than
-requested, some fewer, like real disaster risk. `"pool"` remains accepted as
+"probabilistic"` is the new default and canonical value, and the percentage
+means exactly what it says: at 5%, each simulated step has a literal 5%
+chance of being replaced by a max-loss event — the same binomial "chance per
+slot" stress that Option Omega's worst-case test runs. Some simulations see
+more losses than requested, some fewer, like real disaster risk. `"pool"` remains accepted as
 an alias for the same behavior, so existing calls and saved configurations
 keep working. `"guarantee"` still forces the exact count into every
 simulation.

--- a/tests/unit/monte-carlo-injection-semantics.test.ts
+++ b/tests/unit/monte-carlo-injection-semantics.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Worst-case injection semantics: per-slot replacement, not pool membership.
+ *
+ * The sampler draws only real history; injection replaces slots AFTER the
+ * draw. "probabilistic" (canonical name for the old "pool" value) replaces
+ * each slot independently with probability injectedCount / (poolSize +
+ * injectedCount); "guarantee" splices the exact count at independent
+ * positions. Neither mode may produce synthetic losses that walk in as
+ * contiguous blocks — that was the defect: synthetics appended to the pool
+ * formed a contiguous region a stationary-block walk could traverse,
+ * manufacturing catastrophe clusters no user asked for.
+ *
+ * The regression fixture mirrors the real case that exposed the defect: a few
+ * hundred dollar trades whose sum is strongly positive, one dominant
+ * max-margin value, probabilistic injection with absolute (historical-dollar)
+ * sizing, equity allowed to go negative.
+ */
+
+import {
+  runMonteCarloSimulation,
+  worstCaseInjectionCount,
+  ABSOLUTE_SIZING_PERCENTAGE_ERROR,
+  MonteCarloParams,
+  MonteCarloResult,
+  Trade,
+} from "@tradeblocks/lib";
+
+function createTrade(overrides: Partial<Trade> = {}): Trade {
+  const baseDate = new Date("2024-01-01");
+  return {
+    dateOpened: baseDate,
+    timeOpened: "09:30:00",
+    openingPrice: 100,
+    legs: "TEST",
+    premium: 100,
+    closingPrice: 100,
+    dateClosed: baseDate,
+    timeClosed: "16:00:00",
+    avgClosingCost: 100,
+    reasonForClose: "Test",
+    pl: 100,
+    numContracts: 1,
+    fundsAtClose: 100000,
+    marginReq: 1000,
+    strategy: "Test Strategy",
+    openingCommissionsFees: 1,
+    closingCommissionsFees: 1,
+    openingShortLongRatio: 1,
+    closingShortLongRatio: 1,
+    openingVix: 15,
+    closingVix: 15,
+    gap: 0,
+    movement: 0,
+    maxProfit: 100,
+    maxLoss: -500,
+    ...overrides,
+  };
+}
+
+/**
+ * Deterministic fixture in the shape of the real 670-trade case: 300 dollar
+ * trades, strongly positive sum (mean +$4,500/trade), one dominant max-margin
+ * value ($90,000) that becomes the flat synthetic loss under absolute sizing.
+ * The P&L cycle is shuffled with a seeded LCG so the pool carries no serial
+ * structure — that keeps the analytic tolerance derivation below honest for
+ * stationary-block resampling (no autocorrelation to inflate the variance of
+ * path sums beyond the iid figure).
+ */
+const PL_CYCLE = [9000, -2500, 7000, 12000, -4000, 6000, 15000, -1500, 3000, 1000];
+const POOL_SIZE = 300;
+const DOMINANT_MARGIN = 90000;
+const INITIAL_CAPITAL = 1_000_000;
+
+function buildFixtureTrades(): Trade[] {
+  const pls: number[] = [];
+  for (let i = 0; i < POOL_SIZE; i++) {
+    pls.push(PL_CYCLE[i % PL_CYCLE.length]);
+  }
+  let state = 12345;
+  const rng = () => {
+    state = (state * 1664525 + 1013904223) % 4294967296;
+    return state / 4294967296;
+  };
+  for (let i = pls.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [pls[i], pls[j]] = [pls[j], pls[i]];
+  }
+
+  let funds = INITIAL_CAPITAL;
+  return pls.map((pl, i) => {
+    funds += pl;
+    const date = new Date("2024-01-01");
+    date.setDate(date.getDate() + i);
+    return createTrade({
+      pl,
+      dateOpened: date,
+      dateClosed: date,
+      fundsAtClose: funds,
+      marginReq: i === 137 ? DOMINANT_MARGIN : 5000,
+      maxLoss: -500,
+    });
+  });
+}
+
+const fixtureTrades = buildFixtureTrades();
+const fixturePoolPls = fixtureTrades.map((t) => t.pl);
+
+const WORST_CASE_PERCENTAGE = 5;
+const SIMULATION_LENGTH = 300;
+const NUM_SIMULATIONS = 500;
+const INJECTED_COUNT = worstCaseInjectionCount(SIMULATION_LENGTH, WORST_CASE_PERCENTAGE); // 15
+const REPLACEMENT_PROBABILITY = INJECTED_COUNT / (POOL_SIZE + INJECTED_COUNT);
+
+const fixtureParams: MonteCarloParams = {
+  numSimulations: NUM_SIMULATIONS,
+  simulationLength: SIMULATION_LENGTH,
+  resampleMethod: "trades",
+  initialCapital: INITIAL_CAPITAL,
+  tradesPerYear: 252,
+  randomSeed: 42,
+  worstCaseEnabled: true,
+  worstCasePercentage: WORST_CASE_PERCENTAGE,
+  worstCaseMode: "probabilistic",
+  worstCaseSizing: "absolute",
+};
+
+/**
+ * Recover per-step dollar P&L from a path's cumulative-return equity curve.
+ * All fixture P&L values are integers, so recovered steps are exact up to
+ * float round-trip noise well below $1.
+ */
+function recoverStepPls(equityCurve: number[], initialCapital: number): number[] {
+  const pls: number[] = [];
+  let previous = initialCapital;
+  for (const cumulativeReturn of equityCurve) {
+    const capital = initialCapital * (1 + cumulativeReturn);
+    pls.push(capital - previous);
+    previous = capital;
+  }
+  return pls;
+}
+
+function isSyntheticStep(pl: number): boolean {
+  return Math.abs(pl - -DOMINANT_MARGIN) < 1;
+}
+
+function syntheticFlagsPerPath(result: MonteCarloResult): boolean[][] {
+  return result.simulations.map((sim) =>
+    recoverStepPls(sim.equityCurve, result.parameters.initialCapital).map(isSyntheticStep),
+  );
+}
+
+function countAdjacentSyntheticPairs(flags: boolean[]): number {
+  let pairs = 0;
+  for (let i = 1; i < flags.length; i++) {
+    if (flags[i] && flags[i - 1]) pairs++;
+  }
+  return pairs;
+}
+
+describe("per-slot replacement injection (probabilistic mode)", () => {
+  const result = runMonteCarloSimulation(fixtureTrades, fixtureParams);
+  const flags = syntheticFlagsPerPath(result);
+
+  it("no real trade P&L collides with the synthetic loss value", () => {
+    expect(fixturePoolPls.some(isSyntheticStep)).toBe(false);
+  });
+
+  it("replaces slots at the pool-membership-equivalent probability", () => {
+    // Each slot is an independent Bernoulli(p) replacement, so across
+    // numSimulations * simulationLength slots the observed fraction has
+    // standard error sqrt(p * (1 - p) / N) with N = 150,000 — about 0.00055.
+    // The tolerance is 10 standard errors: far below any behavioral change
+    // (dropping the layer gives 0; pool membership gives ~p but fails the
+    // clustering assertions below), while immune to seed luck.
+    const totalSlots = NUM_SIMULATIONS * SIMULATION_LENGTH;
+    const syntheticSlots = flags.reduce((sum, path) => sum + path.filter(Boolean).length, 0);
+    const observed = syntheticSlots / totalSlots;
+    const standardError = Math.sqrt(
+      (REPLACEMENT_PROBABILITY * (1 - REPLACEMENT_PROBABILITY)) / totalSlots,
+    );
+    expect(Math.abs(observed - REPLACEMENT_PROBABILITY)).toBeLessThan(10 * standardError);
+  });
+
+  it("synthetic events are never block-contiguous: adjacency matches independent replacement", () => {
+    // Independent replacement puts a synthetic pair at consecutive slots with
+    // probability p^2, so the expected adjacent-pair count is
+    // numSimulations * (simulationLength - 1) * p^2 ≈ 339. Pool-membership
+    // injection under stationary blocks (the reverted behavior this test
+    // exists to catch) walks through the contiguous synthetic region, giving
+    // adjacency at roughly p * (1 - 1/meanBlockLength) per slot — more than
+    // ten times the independent rate. The 2x band cleanly separates the two
+    // regimes; the pair count is a sum of ~150k weakly dependent Bernoullis,
+    // so its relative sampling noise is a few percent.
+    const totalPairs = flags.reduce((sum, path) => sum + countAdjacentSyntheticPairs(path), 0);
+    const expectedPairs = NUM_SIMULATIONS * (SIMULATION_LENGTH - 1) * REPLACEMENT_PROBABILITY ** 2;
+    expect(totalPairs).toBeGreaterThan(expectedPairs / 2);
+    expect(totalPairs).toBeLessThan(expectedPairs * 2);
+  });
+
+  it("equity may go negative under dollar stress (no artificial floor)", () => {
+    const anyNegative = result.simulations.some((sim) => sim.finalValue < 0);
+    expect(anyNegative).toBe(true);
+    expect(result.statistics.zeroBalancePaths).toBeGreaterThan(0);
+  });
+
+  it("accepts 'pool' as an alias with identical results", () => {
+    const aliasResult = runMonteCarloSimulation(fixtureTrades, {
+      ...fixtureParams,
+      worstCaseMode: "pool",
+    });
+    expect(aliasResult.statistics.medianFinalValue).toBe(result.statistics.medianFinalValue);
+    expect(aliasResult.statistics.meanFinalValue).toBe(result.statistics.meanFinalValue);
+  });
+
+  it("is deterministic under a fixed seed", () => {
+    const rerun = runMonteCarloSimulation(fixtureTrades, { ...fixtureParams });
+    expect(rerun.statistics.meanFinalValue).toBe(result.statistics.meanFinalValue);
+    expect(rerun.statistics.zeroBalancePaths).toBe(result.statistics.zeroBalancePaths);
+  });
+
+  it("defaults to probabilistic semantics when no mode is given", () => {
+    const defaulted = runMonteCarloSimulation(fixtureTrades, {
+      ...fixtureParams,
+      worstCaseMode: undefined,
+    });
+    expect(defaulted.statistics.meanFinalValue).toBe(result.statistics.meanFinalValue);
+  });
+});
+
+describe("reference-semantics regression fixture", () => {
+  it("mean final value matches the independently-computed per-slot-replacement expectation", () => {
+    // Independent per-slot replacement makes every step an iid mixture:
+    // with probability (1 - p) a pool value, with probability p the flat
+    // -$90,000 event. The expectation of the final value is therefore exactly
+    //   initialCapital + L * ((1 - p) * mean(pool) - p * 90,000)
+    // and stationary-block resampling preserves it (blocks change joint
+    // structure, never the marginal distribution).
+    //
+    // Tolerance derivation: Var(step) for the mixture is computed below from
+    // the fixture arrays; the variance of a path sum is L * Var(step) for iid
+    // draws, and the fixture pool is shuffled so block resampling adds no
+    // autocorrelation term beyond sampling noise. The standard error of the
+    // mean over numSimulations paths is sqrt(L * Var(step) / numSimulations)
+    // ≈ $16k. We allow 6 standard errors — generous against residual block
+    // effects and LCG imperfection, still an order of magnitude tighter than
+    // the ~$440k median displacement the pool-membership defect produced on
+    // the real log.
+    const result = runMonteCarloSimulation(fixtureTrades, fixtureParams);
+
+    const p = REPLACEMENT_PROBABILITY;
+    const poolMean = fixturePoolPls.reduce((s, v) => s + v, 0) / fixturePoolPls.length;
+    const poolMeanSquare = fixturePoolPls.reduce((s, v) => s + v * v, 0) / fixturePoolPls.length;
+    const stepMean = (1 - p) * poolMean + p * -DOMINANT_MARGIN;
+    const stepMeanSquare = (1 - p) * poolMeanSquare + p * DOMINANT_MARGIN ** 2;
+    const stepVariance = stepMeanSquare - stepMean ** 2;
+
+    const expectedFinal = INITIAL_CAPITAL + SIMULATION_LENGTH * stepMean;
+    const standardError = Math.sqrt((SIMULATION_LENGTH * stepVariance) / NUM_SIMULATIONS);
+
+    expect(Math.abs(result.statistics.meanFinalValue - expectedFinal)).toBeLessThan(
+      6 * standardError,
+    );
+  });
+
+  it("block resampling shows no synthetic clustering: median matches iid injection", () => {
+    // The injection layer is independent of the draw mode, so the median
+    // final value under stationary blocks must sit within tail noise of the
+    // median under iid draws of the same configuration. Under the reverted
+    // pool-membership semantics this fails loudly: blocks walking the
+    // contiguous synthetic region push most paths past the synthetics
+    // entirely while wiping out the rest, displacing the median by ~50% on
+    // the real log (measured $1.30M vs the correct ~$860k).
+    //
+    // Tolerance: the standard error of a sample median is about
+    // 1.2533 * sd(final) / sqrt(numSimulations) ≈ $20k per run; two
+    // independent runs differ by sqrt(2) of that. We allow 6 combined
+    // standard errors (~$170k) — loose against seed luck, tight against the
+    // ~$440k displacement the defect produced.
+    const blocksResult = runMonteCarloSimulation(fixtureTrades, fixtureParams);
+    const iidResult = runMonteCarloSimulation(fixtureTrades, {
+      ...fixtureParams,
+      resampleMode: "iid",
+    });
+
+    const finals = blocksResult.simulations.map((s) => s.finalValue);
+    const mean = finals.reduce((s, v) => s + v, 0) / finals.length;
+    const sd = Math.sqrt(finals.reduce((s, v) => s + (v - mean) ** 2, 0) / (finals.length - 1));
+    const combinedMedianSe = Math.sqrt(2) * 1.2533 * (sd / Math.sqrt(NUM_SIMULATIONS));
+
+    expect(
+      Math.abs(blocksResult.statistics.medianFinalValue - iidResult.statistics.medianFinalValue),
+    ).toBeLessThan(6 * combinedMedianSe);
+  });
+});
+
+describe("guarantee mode: exact count, independent positions", () => {
+  const guaranteeResult = runMonteCarloSimulation(fixtureTrades, {
+    ...fixtureParams,
+    worstCaseMode: "guarantee",
+  });
+  const flags = syntheticFlagsPerPath(guaranteeResult);
+
+  it("every path carries exactly the requested count", () => {
+    for (const path of flags) {
+      expect(path.filter(Boolean).length).toBe(INJECTED_COUNT);
+    }
+  });
+
+  it("synthetic events are never block-contiguous: adjacency matches independent placement", () => {
+    // Placing k events at independent positions in a path of length L yields
+    // roughly k^2 / L adjacent pairs per path (~0.75 here, ~375 across 500
+    // paths). Contiguous placement would yield k - 1 = 14 per path — nearly
+    // twenty times more. A 3x upper bound separates the regimes decisively.
+    const totalPairs = flags.reduce((sum, path) => sum + countAdjacentSyntheticPairs(path), 0);
+    const independentExpectation = (NUM_SIMULATIONS * INJECTED_COUNT ** 2) / SIMULATION_LENGTH;
+    expect(totalPairs).toBeLessThan(3 * independentExpectation);
+  });
+
+  it("is deterministic under a fixed seed", () => {
+    const rerun = runMonteCarloSimulation(fixtureTrades, {
+      ...fixtureParams,
+      worstCaseMode: "guarantee",
+    });
+    expect(rerun.statistics.meanFinalValue).toBe(guaranteeResult.statistics.meanFinalValue);
+  });
+});
+
+describe("absolute sizing is gated out of percentage mode", () => {
+  const percentageParams: MonteCarloParams = {
+    numSimulations: 50,
+    simulationLength: 100,
+    resampleMethod: "percentage",
+    initialCapital: INITIAL_CAPITAL,
+    tradesPerYear: 252,
+    randomSeed: 42,
+    worstCaseEnabled: true,
+    worstCasePercentage: 5,
+    worstCaseMode: "probabilistic",
+  };
+
+  it("throws a validation error naming the coherent alternative", () => {
+    expect(() =>
+      runMonteCarloSimulation(fixtureTrades, {
+        ...percentageParams,
+        worstCaseSizing: "absolute",
+      }),
+    ).toThrow(ABSOLUTE_SIZING_PERCENTAGE_ERROR);
+    expect(ABSOLUTE_SIZING_PERCENTAGE_ERROR).toMatch(/dollar/i);
+    expect(ABSOLUTE_SIZING_PERCENTAGE_ERROR).toMatch(/'trades' or 'daily'/);
+  });
+
+  it("relative sizing still runs under percentage mode", () => {
+    expect(() =>
+      runMonteCarloSimulation(fixtureTrades, {
+        ...percentageParams,
+        worstCaseSizing: "relative",
+      }),
+    ).not.toThrow();
+  });
+
+  it("absolute sizing still runs under dollar sampling methods", () => {
+    expect(() =>
+      runMonteCarloSimulation(fixtureTrades, {
+        ...fixtureParams,
+        numSimulations: 50,
+        worstCaseSizing: "absolute",
+      }),
+    ).not.toThrow();
+  });
+
+  it("does not throw when worst-case injection is disabled", () => {
+    expect(() =>
+      runMonteCarloSimulation(fixtureTrades, {
+        ...percentageParams,
+        worstCaseEnabled: false,
+        worstCaseSizing: "absolute",
+      }),
+    ).not.toThrow();
+  });
+});

--- a/tests/unit/monte-carlo-injection-semantics.test.ts
+++ b/tests/unit/monte-carlo-injection-semantics.test.ts
@@ -3,9 +3,9 @@
  *
  * The sampler draws only real history; injection replaces slots AFTER the
  * draw. "probabilistic" (canonical name for the old "pool" value) replaces
- * each slot independently with probability injectedCount / (poolSize +
- * injectedCount); "guarantee" splices the exact count at independent
- * positions. Neither mode may produce synthetic losses that walk in as
+ * each slot independently with the literal chance the percentage field
+ * promises — worstCasePercentage / 100; "guarantee" splices the exact count
+ * at independent positions. Neither mode may produce synthetic losses that walk in as
  * contiguous blocks — that was the defect: synthetics appended to the pool
  * formed a contiguous region a stationary-block walk could traverse,
  * manufacturing catastrophe clusters no user asked for.
@@ -109,7 +109,9 @@ const WORST_CASE_PERCENTAGE = 5;
 const SIMULATION_LENGTH = 300;
 const NUM_SIMULATIONS = 500;
 const INJECTED_COUNT = worstCaseInjectionCount(SIMULATION_LENGTH, WORST_CASE_PERCENTAGE); // 15
-const REPLACEMENT_PROBABILITY = INJECTED_COUNT / (POOL_SIZE + INJECTED_COUNT);
+// The literal per-slot chance the percentage field promises: 5% means each
+// slot has exactly a 0.05 chance of being replaced.
+const REPLACEMENT_PROBABILITY = WORST_CASE_PERCENTAGE / 100;
 
 const fixtureParams: MonteCarloParams = {
   numSimulations: NUM_SIMULATIONS,
@@ -166,7 +168,7 @@ describe("per-slot replacement injection (probabilistic mode)", () => {
     expect(fixturePoolPls.some(isSyntheticStep)).toBe(false);
   });
 
-  it("replaces slots at the pool-membership-equivalent probability", () => {
+  it("replaces slots at the literal per-slot chance the percentage promises", () => {
     // Each slot is an independent Bernoulli(p) replacement, so across
     // numSimulations * simulationLength slots the observed fraction has
     // standard error sqrt(p * (1 - p) / N) with N = 150,000 — about 0.00055.
@@ -185,7 +187,7 @@ describe("per-slot replacement injection (probabilistic mode)", () => {
   it("synthetic events are never block-contiguous: adjacency matches independent replacement", () => {
     // Independent replacement puts a synthetic pair at consecutive slots with
     // probability p^2, so the expected adjacent-pair count is
-    // numSimulations * (simulationLength - 1) * p^2 ≈ 339. Pool-membership
+    // numSimulations * (simulationLength - 1) * p^2 ≈ 374. Pool-membership
     // injection under stationary blocks (the reverted behavior this test
     // exists to catch) walks through the contiguous synthetic region, giving
     // adjacency at roughly p * (1 - 1/meanBlockLength) per slot — more than

--- a/tests/unit/monte-carlo-injection-semantics.test.ts
+++ b/tests/unit/monte-carlo-injection-semantics.test.ts
@@ -221,6 +221,34 @@ describe("per-slot replacement injection (probabilistic mode)", () => {
     expect(rerun.statistics.zeroBalancePaths).toBe(result.statistics.zeroBalancePaths);
   });
 
+  it("reports the literal per-slot probability, never a pool-derived ratio", () => {
+    // The statistical calibration test above cannot distinguish the literal
+    // 0.05 from the old pool-ratio formula (15 / 315 ≈ 0.0476 — inside its
+    // noise band), so the engine reports the probability it actually used
+    // and this pins it deterministically: exactly worstCasePercentage / 100,
+    // and provably not the ratio a 300-trade pool would have produced.
+    expect(result.effectiveWorstCaseReplacementProbability).toBe(WORST_CASE_PERCENTAGE / 100);
+    expect(result.effectiveWorstCaseReplacementProbability).not.toBe(
+      INJECTED_COUNT / (POOL_SIZE + INJECTED_COUNT),
+    );
+  });
+
+  it("reports no replacement probability when injection is off or guaranteed", () => {
+    const disabled = runMonteCarloSimulation(fixtureTrades, {
+      ...fixtureParams,
+      numSimulations: 20,
+      worstCaseEnabled: false,
+    });
+    expect(disabled.effectiveWorstCaseReplacementProbability).toBeNull();
+
+    const guarantee = runMonteCarloSimulation(fixtureTrades, {
+      ...fixtureParams,
+      numSimulations: 20,
+      worstCaseMode: "guarantee",
+    });
+    expect(guarantee.effectiveWorstCaseReplacementProbability).toBeNull();
+  });
+
   it("defaults to probabilistic semantics when no mode is given", () => {
     const defaulted = runMonteCarloSimulation(fixtureTrades, {
       ...fixtureParams,

--- a/tests/unit/risk-simulator-pool-hint.test.ts
+++ b/tests/unit/risk-simulator-pool-hint.test.ts
@@ -1,14 +1,14 @@
 /**
  * The risk simulator previews the automatic mean block length before a run,
- * from an estimate of the resample pool. Worst-case injection in "pool" mode
- * adds synthetic max-loss trades to that pool, so a preview that ignores them
- * understates the block length the run will actually use. These tests pin the
- * two derivations behind the preview and check them against a real run.
+ * from an estimate of the resample pool. The pool holds only real history —
+ * worst-case injection replaces slots after the draw and never changes the
+ * pool size — so the preview derives from the base pool in every mode. These
+ * tests pin the derivations behind the preview and check them against a real
+ * run.
  */
 
 import {
   defaultMeanBlockLength,
-  effectiveResamplePoolSize,
   runMonteCarloSimulation,
   worstCaseInjectionCount,
   Trade,
@@ -60,26 +60,6 @@ describe("worstCaseInjectionCount", () => {
   });
 });
 
-describe("effectiveResamplePoolSize", () => {
-  it("counts the injected trades in pool mode", () => {
-    expect(effectiveResamplePoolSize(27, { enabled: true, mode: "pool", injectedCount: 37 })).toBe(
-      64,
-    );
-  });
-
-  it("leaves the pool alone in guarantee mode", () => {
-    expect(
-      effectiveResamplePoolSize(27, { enabled: true, mode: "guarantee", injectedCount: 37 }),
-    ).toBe(27);
-  });
-
-  it("leaves the pool alone when worst-case injection is off", () => {
-    expect(effectiveResamplePoolSize(27, { enabled: false, mode: "pool", injectedCount: 37 })).toBe(
-      27,
-    );
-  });
-});
-
 describe("the previewed block length matches the run", () => {
   const trades = Array.from({ length: 27 }, (_, i) => createTrade(i));
   const simulationLength = 37;
@@ -99,50 +79,29 @@ describe("the previewed block length matches the run", () => {
     worstCaseSizing: "relative" as const,
   };
 
-  it("includes the injected trades in pool mode", () => {
+  it("derives the block length from the real pool in probabilistic mode", () => {
     const result = runMonteCarloSimulation(trades, {
       ...baseParams,
-      worstCaseMode: "pool" as const,
+      worstCaseMode: "probabilistic" as const,
     });
 
-    const injectedCount = worstCaseInjectionCount(simulationLength, worstCasePercentage);
-    const previewed = defaultMeanBlockLength(
-      effectiveResamplePoolSize(trades.length, {
-        enabled: true,
-        mode: "pool",
-        injectedCount,
-      }),
-    );
-
     expect(result.actualResamplePoolSize).toBe(trades.length);
-    expect(result.effectiveMeanBlockLength).toBe(previewed);
-    // The whole point: ignoring the injection would have previewed a shorter
-    // block than the run used.
-    expect(defaultMeanBlockLength(trades.length)).toBeLessThan(previewed);
+    expect(result.effectiveMeanBlockLength).toBe(defaultMeanBlockLength(trades.length));
   });
 
-  it("ignores the injected trades in guarantee mode", () => {
+  it("derives the block length from the real pool in guarantee mode", () => {
     const result = runMonteCarloSimulation(trades, {
       ...baseParams,
       worstCaseMode: "guarantee" as const,
     });
 
-    const previewed = defaultMeanBlockLength(
-      effectiveResamplePoolSize(trades.length, {
-        enabled: true,
-        mode: "guarantee",
-        injectedCount: worstCaseInjectionCount(simulationLength, worstCasePercentage),
-      }),
-    );
-
-    expect(result.effectiveMeanBlockLength).toBe(previewed);
-    expect(previewed).toBe(defaultMeanBlockLength(trades.length));
+    expect(result.effectiveMeanBlockLength).toBe(defaultMeanBlockLength(trades.length));
   });
 
   it("hands the run's own block length to the hint once the run finishes", () => {
     const result = runMonteCarloSimulation(trades, {
       ...baseParams,
-      worstCaseMode: "pool" as const,
+      worstCaseMode: "probabilistic" as const,
     });
 
     const hint = selectBlockLengthHint({

--- a/tests/unit/risk-simulator-worst-case-copy.test.ts
+++ b/tests/unit/risk-simulator-worst-case-copy.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Mode-aware worst-case budget captions. Guarantee mode forces an exact count
+ * into every simulation, so it may speak in "exactly"/"force" terms;
+ * probabilistic mode replaces each slot at a literal chance, so its captions
+ * must speak in per-slot-chance and average terms — nothing is forced there.
+ */
+
+import { describeWorstCaseBudget } from "@/app/(platform)/risk-simulator/worst-case-copy";
+
+describe("describeWorstCaseBudget", () => {
+  it("simulation basis, probabilistic: literal chance and an average count", () => {
+    const text = describeWorstCaseBudget({
+      mode: "probabilistic",
+      basedOn: "simulation",
+      percentage: 5,
+      budget: 15,
+    });
+    expect(text).toMatch(/literal 5% chance/);
+    expect(text).toMatch(/15 per simulation on average/);
+    expect(text).not.toMatch(/[Ff]orce/);
+    expect(text).not.toMatch(/[Ee]xactly/);
+  });
+
+  it("simulation basis, guarantee: exact share of the horizon", () => {
+    const text = describeWorstCaseBudget({
+      mode: "guarantee",
+      basedOn: "simulation",
+      percentage: 5,
+      budget: 15,
+    });
+    expect(text).toMatch(/Exactly 5% of the simulation horizon/);
+    expect(text).toMatch(/15 synthetic trades/);
+  });
+
+  it("historical basis, guarantee: keeps the force-promise wording", () => {
+    const text = describeWorstCaseBudget({
+      mode: "guarantee",
+      basedOn: "historical",
+      percentage: 5,
+      budget: 15,
+    });
+    expect(text).toMatch(/historical trade count/);
+    expect(text).toMatch(/"Force 5%" promise/);
+  });
+
+  it("historical basis, probabilistic: average composition, no force promise", () => {
+    const text = describeWorstCaseBudget({
+      mode: "probabilistic",
+      basedOn: "historical",
+      percentage: 5,
+      budget: 15,
+    });
+    expect(text).toMatch(/historical trade count/);
+    expect(text).toMatch(/literal 5% replacement chance/);
+    expect(text).toMatch(/15 per simulation on average/);
+    expect(text).not.toMatch(/[Ff]orce/);
+  });
+});

--- a/tests/unit/statistics-cards-reality-check.test.tsx
+++ b/tests/unit/statistics-cards-reality-check.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * Mode-aware Reality Check: zero-balance paths is structurally dead under
+ * percentage returns (a per-trade return clamps at -100% of current equity,
+ * so capital can never cross zero) — it must never render as a live statistic
+ * there. Percentage mode leads with Probability of Ruin instead, at a default
+ * 50%-decline threshold when the user has not set one. Dollar sampling
+ * methods keep zero-balance as the primary ruin figure.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { StatisticsCards } from "@/components/risk-simulator/statistics-cards";
+import type { MonteCarloResult } from "@tradeblocks/lib";
+
+function buildResult(overrides: {
+  resampleMethod: "trades" | "daily" | "percentage";
+  ruinThresholdPct?: number;
+  probabilityOfRuin?: number;
+  zeroBalancePaths?: number;
+}): MonteCarloResult {
+  const simulation = {
+    equityCurve: [0.01, 0.02],
+    finalValue: 102000,
+    totalReturn: 0.02,
+    annualizedReturn: 0.05,
+    maxDrawdown: 0.1,
+    sharpeRatio: 1.2,
+    touchedZero: false,
+    ruined: false,
+  };
+
+  return {
+    simulations: [simulation],
+    percentiles: {
+      steps: [1, 2],
+      p5: [0, 0.01],
+      p25: [0, 0.015],
+      p50: [0.01, 0.02],
+      p75: [0.015, 0.03],
+      p95: [0.02, 0.04],
+    },
+    statistics: {
+      meanFinalValue: 102000,
+      medianFinalValue: 102000,
+      stdFinalValue: 1000,
+      meanTotalReturn: 0.02,
+      medianTotalReturn: 0.02,
+      meanAnnualizedReturn: 0.05,
+      medianAnnualizedReturn: 0.05,
+      meanMaxDrawdown: 0.1,
+      medianMaxDrawdown: 0.1,
+      meanSharpeRatio: 1.2,
+      probabilityOfProfit: 0.8,
+      valueAtRisk: { p5: -0.05, p10: -0.03, p25: -0.01 },
+      zeroBalancePaths: overrides.zeroBalancePaths ?? 0,
+      ...(overrides.probabilityOfRuin !== undefined
+        ? { probabilityOfRuin: overrides.probabilityOfRuin }
+        : {}),
+    },
+    parameters: {
+      numSimulations: 100,
+      simulationLength: 2,
+      resampleMethod: overrides.resampleMethod,
+      initialCapital: 100000,
+      tradesPerYear: 252,
+      ...(overrides.ruinThresholdPct !== undefined
+        ? { ruinThresholdPct: overrides.ruinThresholdPct }
+        : {}),
+    },
+    timestamp: new Date("2026-01-01"),
+    actualResamplePoolSize: 50,
+    effectiveMeanBlockLength: 4,
+  };
+}
+
+describe("Reality Check under percentage returns", () => {
+  it("does not render zero-balance as a live statistic", () => {
+    render(
+      <StatisticsCards
+        result={buildResult({
+          resampleMethod: "percentage",
+          ruinThresholdPct: 0.5,
+          probabilityOfRuin: 0.12,
+          zeroBalancePaths: 0,
+        })}
+        ruinThresholdDefaulted
+      />,
+    );
+
+    expect(screen.queryByTestId("zero-balance-value")).not.toBeInTheDocument();
+    expect(screen.getByTestId("zero-balance-unavailable")).toBeInTheDocument();
+  });
+
+  it("leads with Probability of Ruin and names the default threshold", () => {
+    render(
+      <StatisticsCards
+        result={buildResult({
+          resampleMethod: "percentage",
+          ruinThresholdPct: 0.5,
+          probabilityOfRuin: 0.12,
+        })}
+        ruinThresholdDefaulted
+      />,
+    );
+
+    expect(screen.getByText("Probability of Ruin")).toBeInTheDocument();
+    expect(screen.getByTestId("ruin-value")).toHaveTextContent("12.0%");
+    expect(screen.getByTestId("ruin-caption").textContent).toMatch(/default/i);
+    expect(screen.getByTestId("ruin-caption").textContent).toMatch(/50%/);
+  });
+
+  it("does not call a user-set threshold a default", () => {
+    render(
+      <StatisticsCards
+        result={buildResult({
+          resampleMethod: "percentage",
+          ruinThresholdPct: 0.3,
+          probabilityOfRuin: 0.2,
+        })}
+        ruinThresholdDefaulted={false}
+      />,
+    );
+
+    expect(screen.getByTestId("ruin-value")).toHaveTextContent("20.0%");
+    expect(screen.getByTestId("ruin-caption").textContent).toMatch(/30%/);
+    expect(screen.getByTestId("ruin-caption").textContent).not.toMatch(/default/i);
+  });
+});
+
+describe("Reality Check under dollar sampling methods", () => {
+  it("keeps zero-balance as the live primary statistic", () => {
+    render(
+      <StatisticsCards
+        result={buildResult({ resampleMethod: "trades", zeroBalancePaths: 0.23 })}
+      />,
+    );
+
+    expect(screen.getByTestId("zero-balance-value")).toHaveTextContent("23.0%");
+    expect(screen.queryByTestId("zero-balance-unavailable")).not.toBeInTheDocument();
+  });
+
+  it("shows ruin only when a threshold was supplied", () => {
+    render(<StatisticsCards result={buildResult({ resampleMethod: "trades" })} />);
+    expect(screen.queryByText("Probability of Ruin")).not.toBeInTheDocument();
+
+    render(
+      <StatisticsCards
+        result={buildResult({
+          resampleMethod: "daily",
+          ruinThresholdPct: 0.4,
+          probabilityOfRuin: 0.05,
+        })}
+      />,
+    );
+    expect(screen.getByText("Probability of Ruin")).toBeInTheDocument();
+    expect(screen.getByTestId("ruin-value")).toHaveTextContent("5.0%");
+  });
+});

--- a/tests/unit/statistics-cards-reality-check.test.tsx
+++ b/tests/unit/statistics-cards-reality-check.test.tsx
@@ -69,6 +69,7 @@ function buildResult(overrides: {
     timestamp: new Date("2026-01-01"),
     actualResamplePoolSize: 50,
     effectiveMeanBlockLength: 4,
+    effectiveWorstCaseReplacementProbability: null,
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes three defects in the Monte Carlo worst-case injection and ruin-reporting layer, found by validating our stressed results against Option Omega's Monte Carlo on a real 670-trade log, and adds the injection mode needed for full parity. Ships as **tradeblocks-mcp 3.9.0**.

The un-stressed arithmetic was already correct (resimulating the log over its own length: median $4.006M vs actual $4.014M). The defects were all in the stress layer.

## Defects fixed

1. **Pool injection clustered catastrophes under block resampling.** `worstCaseMode: "pool"` appended synthetic max-loss trades contiguously to the resample pool, so a stationary-block walk entering that region stepped through consecutive maximum losses — a catastrophe streak nobody asked for. Measured on the real log (5% injection, $89k events): median $1.30M with 47.7% zero-balance where correct semantics give ~$860k / ~23%. Injection is now a **per-slot replacement layer applied after the sampler draws** — the pool never contains synthetics, so blocks cannot cluster them. The canonical mode is `"probabilistic"` (each simulated step has the literal N% chance of being replaced by a max-loss event); `"pool"` is kept as a parsing alias mapped to the same semantics.
2. **"Use historical dollars" in percentage mode was incoherent.** It baked the dollar loss into a ratio of starting capital and compounded it — neither fixed dollars nor an account fraction. No application rule can make fixed-dollar events coherent in a scale-free return stream (applying them against live capital yields ~98% ruin, because percentage paths lack the grown-account dollar wins that offset fixed shocks in dollar resampling). The combination is now **rejected**: lib validation error, MCP schema rejection with the same message, and the UI option disabled under Percentage Returns with one plain sentence steering dollar stress tests to Individual Trades.
3. **Zero-Balance Paths was structurally dead in percentage mode** — returns clamp at −100% of current equity, so capital can never cross zero, and the recommended default mode showed a permanent 0.0%. The Reality Check is now mode-aware: percentage runs surface **Probability of Ruin** (default threshold: down 50%, overridable) as the primary ruin stat, with zero-balance shown as unavailable with an honest sentence; dollar modes keep zero-balance live.

## Parity validation (real 670-trade log, $1M start, 5% injection, $89,040 events)

| | P5 | P50 | P95 | Zero-balance |
|---|---|---|---|---|
| Option Omega | −$423,164 | $860,264 | $2,153,239 | 22.8% |
| This branch (dollar + probabilistic + historical dollars) | −$377,698 | $887,925 | $2,182,756 | 22.1% |

The reference semantics (flat max-posted-margin loss replacing the drawn trade at a literal per-slot chance, over block-resampled dollar P&L) was fitted against all five reported numbers before implementation; the add-on-top and pool-ratio variants were rejected by the same fit.

## Consumers

`run_monte_carlo` gains `probabilistic` as the documented default mode (`pool` legacy alias); percentage+absolute rejected up front. `portfolio_health_check`'s stress leg moves to probabilistic. **Prior pool-mode stress results were overstated under block resampling and will not reproduce** — the release notes lead with that re-baselining call.

## Verification

- Root suite 1445 green; MCP suite 1823 green; typecheck/lint/format and Next build green; packed-provenance runtime check OK; version lockstep verified across both manifests and both lockfile entries; release notes present.
- New 16-test regression suite: analytic per-slot expectation (tolerance derived from mixture variance, documented), block-vs-iid median agreement (fails loudly on pool-membership reversion, which displaced the median ~50%), synthetic-adjacency distribution matching independent placement in both modes, seeded determinism, alias identity.
- End-to-end parity table above run against the real log through this branch's library.

Tier: 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
