### PR TITLE
feat(risk-simulator): one-press Match OO stress test preset + divergence copy

### DIFF
--- a/app/(platform)/risk-simulator/oo-stress-preset.ts
+++ b/app/(platform)/risk-simulator/oo-stress-preset.ts
@@ -1,0 +1,69 @@
+/**
+ * "Match OO stress test" preset for the Worst-Case Scenario Testing panel.
+ *
+ * With matching configurations the simulator reproduces Option Omega's
+ * fixed-count stress results (validated side by side on a reference log:
+ * P95 within 0.06%, median within 1.3%). That configuration is Individual
+ * Trades sampling + guarantee-mode injection + historical-dollar loss sizing.
+ * The preset is a shortcut to those three settings, not a mode: it never
+ * touches the injection percentage, basis, horizon, simulation count, or
+ * seed, and every control stays editable after pressing it.
+ *
+ * Percentage-mode injection answers a different question — it stresses the
+ * worst RELATIVE exposure (each loss sized as a share of the account at the
+ * time), while OO stresses a fixed dollar amount. On a log whose account
+ * grew substantially the two read very differently, which is why the
+ * percentage-mode divergence notice below names this preset as the
+ * OO-comparable path.
+ */
+
+export interface OoStressPresetSettings {
+  resampleMethod: "trades" | "daily" | "percentage";
+  worstCaseMode: "probabilistic" | "guarantee";
+  worstCaseSizing: "absolute" | "relative";
+}
+
+export const OO_STRESS_PRESET: OoStressPresetSettings = {
+  resampleMethod: "trades",
+  worstCaseMode: "guarantee",
+  worstCaseSizing: "absolute",
+};
+
+export function matchesOoStressPreset(settings: OoStressPresetSettings): boolean {
+  return (
+    settings.resampleMethod === OO_STRESS_PRESET.resampleMethod &&
+    settings.worstCaseMode === OO_STRESS_PRESET.worstCaseMode &&
+    settings.worstCaseSizing === OO_STRESS_PRESET.worstCaseSizing
+  );
+}
+
+/**
+ * Returns a copy of the settings with exactly the three preset fields set to
+ * their OO-validated values and every other field untouched.
+ */
+export function applyOoStressPreset<T extends OoStressPresetSettings>(settings: T): T {
+  return { ...settings, ...OO_STRESS_PRESET };
+}
+
+export interface PercentageStressDivergenceInput {
+  worstCaseEnabled: boolean;
+  resampleMethod: "trades" | "daily" | "percentage";
+}
+
+/**
+ * Honest divergence notice for percentage-mode injection, shown only when
+ * injection is enabled with Percentage Returns sampling. Null everywhere else.
+ */
+export function describePercentageStressDivergence(
+  input: PercentageStressDivergenceInput,
+): string | null {
+  if (!input.worstCaseEnabled || input.resampleMethod !== "percentage") {
+    return null;
+  }
+  return (
+    "With Percentage Returns, each injected loss is sized as a share of the account at the " +
+    "time it lands — this stresses your worst relative exposure, so on an account that grew " +
+    "a lot it will read milder than Option Omega's fixed-dollar stress. For the " +
+    "OO-comparable result, use the “Match OO stress test” preset."
+  );
+}

--- a/app/(platform)/risk-simulator/page.tsx
+++ b/app/(platform)/risk-simulator/page.tsx
@@ -63,8 +63,13 @@ import {
   selectBlockLengthHint,
 } from "./block-length-hint";
 import { describeSimulationHorizon } from "./horizon-notice";
+import {
+  applyOoStressPreset,
+  describePercentageStressDivergence,
+  matchesOoStressPreset,
+} from "./oo-stress-preset";
 import { describeWorstCaseBudget } from "./worst-case-copy";
-import { Download, HelpCircle, Loader2, Play, RotateCcw } from "lucide-react";
+import { Check, Download, HelpCircle, Loader2, Play, RotateCcw } from "lucide-react";
 import { useTheme } from "next-themes";
 import dynamic from "next/dynamic";
 import type { Data } from "plotly.js";
@@ -343,6 +348,24 @@ export default function RiskSimulatorPage() {
     worstCaseBasedOn === "historical" &&
     historicalWorstCaseRequest > worstCaseSimulationBudget &&
     worstCaseSimulationBudget > 0;
+
+  const ooStressPresetMatched = matchesOoStressPreset({
+    resampleMethod,
+    worstCaseMode,
+    worstCaseSizing: effectiveWorstCaseSizing,
+  });
+
+  const percentageStressDivergence = describePercentageStressDivergence({
+    worstCaseEnabled,
+    resampleMethod,
+  });
+
+  const handleApplyOoStressPreset = () => {
+    const next = applyOoStressPreset({ resampleMethod, worstCaseMode, worstCaseSizing });
+    setResampleMethod(next.resampleMethod);
+    setWorstCaseMode(next.worstCaseMode);
+    setWorstCaseSizing(next.worstCaseSizing);
+  };
 
   const runSimulation = async () => {
     if (!activeBlockId || trades.length === 0) {
@@ -1249,6 +1272,70 @@ export default function RiskSimulatorPage() {
 
                 {worstCaseEnabled && (
                   <div className="space-y-4 pl-6 border-l-2 border-primary/20">
+                    {/* Match OO stress test preset */}
+                    <div className="space-y-2">
+                      <div className="flex items-center gap-2">
+                        <Label className="text-sm font-medium">Option Omega comparison</Label>
+                        <HoverCard>
+                          <HoverCardTrigger asChild>
+                            <HelpCircle className="h-3.5 w-3.5 text-muted-foreground/60 cursor-help" />
+                          </HoverCardTrigger>
+                          <HoverCardContent className="w-80 p-0 overflow-hidden">
+                            <div className="space-y-3">
+                              <div className="bg-primary/5 border-b px-4 py-3">
+                                <h4 className="text-sm font-semibold text-primary">
+                                  Match OO Stress Test
+                                </h4>
+                              </div>
+                              <div className="px-4 pb-4 space-y-3">
+                                <p className="text-sm font-medium text-foreground leading-relaxed">
+                                  One press sets the configuration validated against Option
+                                  Omega&apos;s Monte Carlo: Individual Trades sampling (actual
+                                  sizing), the loss count forced into every simulation, and
+                                  historical-dollar loss events.
+                                </p>
+                                <p className="text-xs text-muted-foreground leading-relaxed">
+                                  Percentage Returns sizes each injected loss relative to the
+                                  account at the time instead of in fixed dollars, so its stress
+                                  reads differently from OO&apos;s. The preset leaves the
+                                  percentage, basis, and everything else untouched, and every
+                                  control stays editable afterwards.
+                                </p>
+                              </div>
+                            </div>
+                          </HoverCardContent>
+                        </HoverCard>
+                      </div>
+                      {ooStressPresetMatched ? (
+                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                          <Check className="h-4 w-4 text-primary" aria-hidden="true" />
+                          <span>
+                            Current settings match the configuration validated against Option
+                            Omega&apos;s stress test.
+                          </span>
+                        </div>
+                      ) : (
+                        <>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={handleApplyOoStressPreset}
+                          >
+                            Match OO stress test
+                          </Button>
+                          <p className="text-xs text-muted-foreground">
+                            Sets Individual Trades sampling, forces the loss count into every
+                            simulation, and uses historical dollars — the injection percentage and
+                            basis stay put.
+                          </p>
+                        </>
+                      )}
+                      {percentageStressDivergence && (
+                        <p className="text-xs text-amber-600">{percentageStressDivergence}</p>
+                      )}
+                    </div>
+
                     {/* Percentage Slider */}
                     <div className="space-y-2">
                       <div className="flex items-center gap-2">

--- a/app/(platform)/risk-simulator/page.tsx
+++ b/app/(platform)/risk-simulator/page.tsx
@@ -1332,7 +1332,9 @@ export default function RiskSimulatorPage() {
                         </>
                       )}
                       {percentageStressDivergence && (
-                        <p className="text-xs text-amber-600">{percentageStressDivergence}</p>
+                        <p className="text-xs text-amber-600 dark:text-amber-500">
+                          {percentageStressDivergence}
+                        </p>
                       )}
                     </div>
 

--- a/tests/unit/risk-simulator-oo-stress-preset.test.ts
+++ b/tests/unit/risk-simulator-oo-stress-preset.test.ts
@@ -1,0 +1,129 @@
+/**
+ * "Match OO stress test" preset derivation and the percentage-mode divergence
+ * notice. The preset must land on exactly the three OO-validated settings
+ * (Individual Trades sampling, guarantee injection, historical-dollar sizing)
+ * from ANY starting configuration and touch nothing else; the divergence
+ * notice must appear only for enabled injection under Percentage Returns.
+ */
+
+import {
+  applyOoStressPreset,
+  describePercentageStressDivergence,
+  matchesOoStressPreset,
+  OO_STRESS_PRESET,
+  type OoStressPresetSettings,
+} from "@/app/(platform)/risk-simulator/oo-stress-preset";
+
+const RESAMPLE_METHODS = ["trades", "daily", "percentage"] as const;
+const INJECTION_MODES = ["probabilistic", "guarantee"] as const;
+const LOSS_SIZINGS = ["absolute", "relative"] as const;
+
+function allConfigurations(): OoStressPresetSettings[] {
+  const configs: OoStressPresetSettings[] = [];
+  for (const resampleMethod of RESAMPLE_METHODS) {
+    for (const worstCaseMode of INJECTION_MODES) {
+      for (const worstCaseSizing of LOSS_SIZINGS) {
+        configs.push({ resampleMethod, worstCaseMode, worstCaseSizing });
+      }
+    }
+  }
+  return configs;
+}
+
+describe("applyOoStressPreset", () => {
+  it("lands on the three target settings from every starting configuration", () => {
+    for (const config of allConfigurations()) {
+      expect(applyOoStressPreset(config)).toEqual({
+        resampleMethod: "trades",
+        worstCaseMode: "guarantee",
+        worstCaseSizing: "absolute",
+      });
+    }
+  });
+
+  it("touches nothing beyond the three preset fields", () => {
+    const config = {
+      resampleMethod: "percentage" as const,
+      worstCaseMode: "probabilistic" as const,
+      worstCaseSizing: "relative" as const,
+      worstCasePercentage: 7,
+      worstCaseBasedOn: "historical",
+      numSimulations: 2500,
+      simulationLength: 670,
+      seed: 42,
+    };
+    const next = applyOoStressPreset(config);
+    expect(next.worstCasePercentage).toBe(7);
+    expect(next.worstCaseBasedOn).toBe("historical");
+    expect(next.numSimulations).toBe(2500);
+    expect(next.simulationLength).toBe(670);
+    expect(next.seed).toBe(42);
+    expect(Object.keys(next).sort()).toEqual(Object.keys(config).sort());
+  });
+
+  it("does not mutate the input", () => {
+    const config: OoStressPresetSettings = {
+      resampleMethod: "percentage",
+      worstCaseMode: "probabilistic",
+      worstCaseSizing: "relative",
+    };
+    applyOoStressPreset(config);
+    expect(config).toEqual({
+      resampleMethod: "percentage",
+      worstCaseMode: "probabilistic",
+      worstCaseSizing: "relative",
+    });
+  });
+
+  it("is idempotent: an already-matching configuration is returned unchanged", () => {
+    expect(applyOoStressPreset({ ...OO_STRESS_PRESET })).toEqual(OO_STRESS_PRESET);
+  });
+});
+
+describe("matchesOoStressPreset", () => {
+  it("is true exactly when all three settings hold the preset values", () => {
+    for (const config of allConfigurations()) {
+      const expected =
+        config.resampleMethod === "trades" &&
+        config.worstCaseMode === "guarantee" &&
+        config.worstCaseSizing === "absolute";
+      expect(matchesOoStressPreset(config)).toBe(expected);
+    }
+  });
+
+  it("is true after applying the preset from every starting configuration", () => {
+    for (const config of allConfigurations()) {
+      expect(matchesOoStressPreset(applyOoStressPreset(config))).toBe(true);
+    }
+  });
+});
+
+describe("describePercentageStressDivergence", () => {
+  it("names relative exposure, the milder read, and the preset for enabled percentage mode", () => {
+    const text = describePercentageStressDivergence({
+      worstCaseEnabled: true,
+      resampleMethod: "percentage",
+    });
+    expect(text).toMatch(/relative exposure/);
+    expect(text).toMatch(/share of the account at the time/);
+    expect(text).toMatch(/milder than Option Omega/);
+    expect(text).toMatch(/Match OO stress test/);
+  });
+
+  it("is null when injection is disabled", () => {
+    expect(
+      describePercentageStressDivergence({
+        worstCaseEnabled: false,
+        resampleMethod: "percentage",
+      }),
+    ).toBeNull();
+  });
+
+  it("is null for the dollar sampling methods", () => {
+    for (const resampleMethod of ["trades", "daily"] as const) {
+      expect(
+        describePercentageStressDivergence({ worstCaseEnabled: true, resampleMethod }),
+      ).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

One press to run the stress test the way Option Omega does, and an honest sentence where the two definitions diverge.

With matching configurations the engine already reproduces OO's stressed results (validated on a real 670-trade log: dollar sampling + fixed-count injection + historical dollars vs OO fixed-count — P95 within 0.06%, median $831,682 vs $820,887, zero-balance 17.6% vs 18.1%). But percentage-mode injection stresses your worst *relative* exposure (max margin-to-equity ratio — 2.50% per event on that log) while OO stresses a fixed dollar amount (max posted margin, $89,040, from when the account was ~4x larger). On strongly compounding logs the percentage-mode stress therefore reads much milder, and nothing on the page said so — users comparing against OO reasonably concluded the math was wrong.

## Changes (UI only — no engine, no MCP, no version bump)

- **"Match OO stress test"** control in the Worst-Case panel: sets Sampling Method = Individual Trades, Injection = Fixed count, Loss sizing = Use historical dollars, and touches nothing else (percentage, basis, sims, horizon, seed all preserved). Renders as a confirmed state when the configuration already matches, judged against the effective sizing so the percentage-method coercion is respected. Hover copy names this as the configuration validated against Option Omega and explains the divergence in one sentence.
- **Divergence notice** under percentage-mode stress: plain-English sentence that this stresses relative exposure and reads milder than OO's fixed-dollar stress on accounts that grew substantially, naming the preset as the OO-comparable path. Copy states live in a pure tested helper per the page's established pattern.

## Verification

- New 9-test suite: exhaustive preset derivation over all 12 starting configurations, key-set equality (provably touches nothing else), non-mutation, idempotence, match predicate, all copy states.
- Full root suite 1460 green; verify (typecheck/lint/prettier) and Next build green.
- `git diff --stat origin/master`: exactly three files, zero `packages/**` paths — the Release workflow does not fire.

Tier: 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
